### PR TITLE
Remove trailing commas for Puppet 2.7.1 compatibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,7 +35,7 @@ class postgresql::config(
   $listen_addresses             = $postgresql::params::listen_addresses,
   $pg_hba_conf_path             = $postgresql::params::pg_hba_conf_path,
   $postgresql_conf_path         = $postgresql::params::postgresql_conf_path,
-  $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall,
+  $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall
 ) inherits postgresql::params {
 
     # Basically, all this class needs to handle is passing parameters on

--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -35,7 +35,7 @@ class postgresql::config::beforeservice(
   $listen_addresses             = $postgresql::params::listen_addresses,
   $pg_hba_conf_path             = $postgresql::params::pg_hba_conf_path,
   $postgresql_conf_path         = $postgresql::params::postgresql_conf_path,
-  $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall,
+  $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall
 ) inherits postgresql::params {
 
   File {

--- a/manifests/database_grant.pp
+++ b/manifests/database_grant.pp
@@ -31,7 +31,7 @@ define postgresql::database_grant(
     $db,
     $role,
     $psql_db = 'postgres',
-    $psql_user='postgres',
+    $psql_user='postgres'
 ) {
 
   # TODO: FIXME: only works on databases, due to using has_database_privilege


### PR DESCRIPTION
Thanks for creating this module!

I had to remove a few trailing commas to make things run on 2.7.1 (which is the default in Ubuntu 11.10).
