### PR TITLE
Remove $service_provider setting for ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,9 +20,6 @@ class postgresql::params {
   $manage_redhat_firewall       = false
 
   case $::operatingsystem {
-    "Ubuntu": {
-      $service_provider = upstart
-    }
     default: {
       $service_provider = undef
     }


### PR DESCRIPTION
Ubuntu's precise ships with init scripts, not with upstart service definitions. Declaring the provider to be upstart will cause service management on postgres to fail. Leaving it undefined will allow puppet to select the correct (init) provider.
