### PR TITLE
Give the persist-firewall Exec a more explicit name

### DIFF
--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -67,13 +67,13 @@ class postgresql::config::beforeservice(
   #        an out-of-the-box firewall configuration that seems trickier to manage
   # TODO: get rid of hard-coded port
   if ($manage_redhat_firewall and $firewall_supported) {
-      exec { "persist-firewall":
+      exec { "postgresql-persist-firewall":
         command => $persist_firewall_command,
         refreshonly => true,
       }
 
       Firewall {
-        notify => Exec["persist-firewall"]
+        notify => Exec["postgresql-persist-firewall"]
       }
 
       firewall { '5432 accept - postgres':


### PR DESCRIPTION
The title I'd used for the persist-firewall resource
was too generic, and fairly likely to collide with
resources in other modules.  This commit simply
renames it to be a bit more explicit about belonging
to this module, to reduce the likelihood of a title
collision.
