### PR TITLE
Update status for postgres service on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,7 @@ class postgresql::params {
       $pg_hba_conf_path         = "/etc/postgresql/${::postgres_default_version}/main/pg_hba.conf"
       $postgresql_conf_path     = "/etc/postgresql/${::postgres_default_version}/main/postgresql.conf"
       $firewall_supported       = false
+      $service_status           = "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+'"
       # TODO: not exactly sure yet what the right thing to do for Debian/Ubuntu is.
       #$persist_firewall_command = '/sbin/iptables-save > /etc/iptables/rules.v4'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,7 @@ class postgresql::server (
   $package_ensure   = 'present',
   $service_name     = $postgresql::params::service_name,
   $service_provider = $postgresql::params::service_provider,
+  $service_status   = $postgresql::params::service_status,
   $config_hash      = {}
 ) inherits postgresql::params {
 
@@ -45,6 +46,7 @@ class postgresql::server (
     enable   => true,
     require  => Package['postgresql-server'],
     provider => $service_provider,
+    status   => $service_status,
   }
 
 


### PR DESCRIPTION
The postgresql init script on debian/ubuntu returns 0 no matter whether postgresql is started or stopped, so puppet has no way of knowing whether to start postgresql when the service is set to 'ensure => running'. This commit adds a param to the params class called $service_status which is set to the status piped to an egrep on debian/ubuntu, which reliably returns 0 if there are clusters running and 1 if there are none. The output before and after this patch can be seen below. If the init script is fixed at some point, the logic would need to be revisited.

Before patch postgresql remains stopped after puppet run.

```
$ # service postgresql stop
$ #   * Stopping PostgreSQL 9.1 database server
$ # puppet apply -e "class {'postgresql::server':}"
$ #   notice: Finished catalog run in 0.15 seconds
$ # service postgresql status
$ #   Running clusters:
```

After patch postgresql is started after puppet run.

```
$ # service postgresql stop
$ #   * Stopping PostgreSQL 9.1 database server
$ # puppet apply -e "class {'postgresql::server':}"
$ #   notice: /Stage[main]/Postgresql::Server/Service[postgresqld]/ensure: ensure changed 'stopped' to 'running'
$ #   notice: Finished catalog run in 2.26 seconds
$ # service postgresql status
$ #   Running clusters: 9.1/main
```
