### PR TITLE
Fix service status check on Ubuntu and Debian.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,7 @@ class postgresql::params {
       $pg_hba_conf_path         = "/etc/postgresql/${::postgres_default_version}/main/pg_hba.conf"
       $postgresql_conf_path     = "/etc/postgresql/${::postgres_default_version}/main/postgresql.conf"
       $firewall_supported       = false
-      $service_status           = "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+'"
+      $service_status           = "service ${service_name} status"
       # TODO: not exactly sure yet what the right thing to do for Debian/Ubuntu is.
       #$persist_firewall_command = '/sbin/iptables-save > /etc/iptables/rules.v4'
 


### PR DESCRIPTION
The check for service status fails on both Ubuntu-12.04 and Debian-6.0,
triggering an unneeded service start on every update. Using the standard
command "service postgresql status" fixes it.
