### PR TITLE
Add sample usage for postgresql::server class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,40 @@ And the fallback, analogous to exec resources, only for SQL statements:
 Basic usage
 -----------
 
-    postgresql::user{'marmot':
-        password => 'foo',
-    }
+Manage a PostgreSQL server with sane defaults (login via `sudo -u postgres psql`):
 
-    postgresql::grant{'grant select to marmot':
-       grantee   => 'marmot',
-       on_object => 'my_table',
-       perm      => 'select',
-       require   => Postgresql::User['marmot'],
-    }
+```Puppet
+include postgresql::server
+```
+
+...or a custom configuration:
+
+```Puppet
+class { 'postgresql::server':
+    config_hash => {
+        'ip_mask_deny_postgres_user' => '0.0.0.0/32',
+        'ip_mask_allow_all_users'    => '0.0.0.0/0',
+        'listen_addresses'           => '*',
+        'manage_redhat_firewall'     => true,
+        'postgres_password'          => 'TPSrep0rt!',
+    },
+}
+```
+
+Manage users / roles and permissions:
+
+```Puppet
+postgresql::user{'marmot':
+    password => 'foo',
+}
+
+postgresql::grant{'grant select to marmot':
+   grantee   => 'marmot',
+   on_object => 'my_table',
+   perm      => 'select',
+   require   => Postgresql::User['marmot'],
+}
+```
 
 etc, etc.
 


### PR DESCRIPTION
I had some issues trying to connect to the server, managed with
defaults:

```
vagrant@precise32:~$ psql
psql: FATAL:  role "vagrant" does not exist
vagrant@precise32:~$ psql -U postgres
psql: FATAL:  Peer authentication failed for user "postgres"
vagrant@precise32:~$ psql -U postgres -h 127.0.0.1
psql: FATAL:  pg_hba.conf rejects connection for host "127.0.0.1", user
"postgres", database "postgres", SSL on
FATAL:  pg_hba.conf rejects connection for host "127.0.0.1", user
"postgres", database "postgres", SSL off
vagrant@precise32:~$ psql -U postgres -h /var/run/postgresql
psql: FATAL:  Peer authentication failed for user "postgres"
```

After some trial and error I found out that the reason for this was a
restrictive permission on the unix socket (which isn't bad at all):

```
vagrant@precise32:~$ ls -l /var/run/postgresql/
total 4
-rw------- 1 postgres postgres 5 Oct 16 20:16 9.1-main.pid
```

So I though I send some usage examples to help noops like myself to a
quicker start with your module :-)
