### PR TITLE
Fix path for `/bin/cat`

### DIFF
--- a/manifests/config/afterservice.pp
+++ b/manifests/config/afterservice.pp
@@ -38,7 +38,7 @@ class postgresql::config::afterservice(
         #  the password is correct (current), this command will exit with an exit code of 0,
         #  which will prevent the main command from running.
         unless      => "env PGPASSWORD=\"$postgres_password\" psql -h localhost -c 'select 1' > /dev/null",
-        path        => '/usr/bin:/usr/local/bin',
+        path        => '/usr/bin:/usr/local/bin:/bin',
     }
   }
 }


### PR DESCRIPTION
This should fix this error:

```
notice: /Stage[main]/Postgresql::Config::Afterservice/Exec[set_postgres_postgrespw]/returns: /usr/bin/ldd: line 118: cat: command not found
notice: /Stage[main]/Postgresql::Config::Afterservice/Exec[set_postgres_postgrespw]/returns: Use of uninitialized value $lib_path in concatenation (.) or string at /usr/bin/psql line 116.
```
