### PR TITLE
Support special characters in database role name

### DIFF
--- a/manifests/database_grant.pp
+++ b/manifests/database_grant.pp
@@ -49,7 +49,7 @@ define postgresql::database_grant(
     default => $privilege,
   }
 
-  postgresql::psql {"GRANT $privilege ON database $db TO $role":
+  postgresql::psql {"GRANT $privilege ON database $db TO \"$role\"":
     db      => $psql_db,
     user    => $psql_user,
     unless  => "SELECT 1 WHERE has_database_privilege('$role', '$db', '$unless_privilege')",

--- a/manifests/psql.pp
+++ b/manifests/psql.pp
@@ -35,8 +35,8 @@ define postgresql::psql(
   }
 
   $psql = "${postgresql::params::psql_path} $no_password_option --tuples-only --quiet --dbname $db"
-  $quoted_command = regsubst($command, '"', '\\"')
-  $quoted_unless  = regsubst($unless,  '"', '\\"')
+  $quoted_command = regsubst($command, '"', '\\"', 'G')
+  $quoted_unless  = regsubst($unless,  '"', '\\"', 'G')
 
   exec {"/bin/echo \"$quoted_command\" | $psql |egrep -v -q '^$'":
     cwd         => '/tmp',

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -32,7 +32,7 @@ define postgresql::role(
   $superuser_sql  = $superuser  ? { true => 'SUPERUSER' , default => 'NOSUPERUSER' }
 
   # TODO: FIXME: Will not correct the superuser / createdb / createrole / login status of a role that already exists
-  postgresql::psql {"CREATE ROLE ${username} ENCRYPTED PASSWORD '${password_hash}' $login_sql $createrole_sql $createdb_sql $superuser_sql":
+  postgresql::psql {"CREATE ROLE \"${username}\" ENCRYPTED PASSWORD '${password_hash}' $login_sql $createrole_sql $createdb_sql $superuser_sql":
     db      => $db,
     user    => 'postgres',
     unless  => "SELECT rolname FROM pg_roles WHERE rolname='$username'",


### PR DESCRIPTION
This will allow characters such as '-' in database role names. Additionally, escaping of '"' characters now applies to all '"' characters, not just the first in a sql command.
