### PR TITLE
Properly quote database name when using postgresql::psql

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -38,7 +38,7 @@ define postgresql::database(
 
   # This will prevent users from connecting to the database unless they've been
   #  granted privileges.
-  postgresql::psql {"REVOKE CONNECT ON DATABASE ${dbname} FROM public":
+  postgresql::psql {"REVOKE CONNECT ON DATABASE \"${dbname}\" FROM public":
     db          => 'postgres',
     user        => 'postgres',
     unless      => 'SELECT 1 where 1 = 0',

--- a/manifests/database_grant.pp
+++ b/manifests/database_grant.pp
@@ -49,7 +49,7 @@ define postgresql::database_grant(
     default => $privilege,
   }
 
-  postgresql::psql { "GRANT ${privilege} ON database ${db} TO \"${role}\"":
+  postgresql::psql { "GRANT ${privilege} ON database \"${db}\" TO \"${role}\"":
     db      => $psql_db,
     user    => $psql_user,
     unless  => "SELECT 1 WHERE has_database_privilege('${role}', '${db}', '${unless_privilege}')",


### PR DESCRIPTION
In database.pp and database_grant.pp the database name needs to be put in quotation marks when using postgresql::psql, otherwise Postgres throws syntax errors when the database name start with, for example, a number.
