### PR TITLE
Reload postgresql after changes to pg_hba.conf

### DIFF
--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -56,7 +56,7 @@ class postgresql::config::beforeservice(
     ensure      => file,
     path        => $pg_hba_conf_path,
     content     => template('postgresql/pg_hba.conf.erb'),
-    notify      => Service['postgresqld'],
+    notify      => Exec['reload_postgresql'],
   }
 
   # We must set a "listen_addresses" line in the postgresql.conf if we

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,5 +49,8 @@ class postgresql::server (
     status   => $service_status,
   }
 
-
+  exec {'reload_postgresql':
+    refreshonly => true,
+    command => "/usr/bin/service ${postgresql::params::service_name} reload",
+  }
 }


### PR DESCRIPTION
This is a very simple fix for issue #31. A new exec resource "reload_postgresql" is defined and the "pg_hba.conf" resource notifies it after changes to pg_hba.conf. This avoids unnecessary restarts of the whole cluster for changes that only need a reload (such as those in pg_hba.conf).

I believe this works on both Debian an Redhat OS families, but I have no instance of the latter available for testing.
