### PR TITLE
Set sensible path in exec to reload postgres

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,8 +49,9 @@ class postgresql::server (
     status   => $service_status,
   }
 
-  exec {'reload_postgresql':
+  exec { 'reload_postgresql':
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+    command     => "service ${postgresql::params::service_name} reload",
     refreshonly => true,
-    command => "/usr/bin/service ${postgresql::params::service_name} reload",
   }
 }


### PR DESCRIPTION
In the exec resource to reload postgres add path parameter and set it to
"/usr/bin:/usr/sbin:/bin:/sbin", so that the service command can be
called correctly on different platforms.
