### PR TITLE
Rework `postgres_default_version` fact

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -1,30 +1,61 @@
-def get_debian_postgres_version
-  depends = Facter::Util::Resolution.exec('apt-cache show postgresql |grep "^Depends" |head -n 1')
-  if match = /^Depends: postgresql-(.*)$/.match(depends)
-    match[1]
-  else
-    nil
+def get_debianfamily_postgres_version
+  case Facter.value('operatingsystem')
+    when "Debian"
+      get_debian_postgres_version()
+    when "Ubuntu"
+      get_ubuntu_postgres_version()
+    else
+      nil
   end
 end
 
-def get_redhat_postgres_version
-  version = Facter::Util::Resolution.exec('yum info postgresql-server |grep "^Version"')
-  if match = /^Version\s*:\s*(\d+\.\d+).*$/.match(version)
-    match[1]
-  else
-    nil
+def get_debian_postgres_version
+  case Facter.value('operatingsystemrelease')
+    # TODO: add more debian versions or better logic here
+    when /^6\./
+      "8.4"
+    else
+      nil
+  end
+end
+
+def get_ubuntu_postgres_version
+  case Facter.value('operatingsystemrelease')
+    # TODO: add more ubuntu versions or better logic here
+    when "12.04"
+      "9.1"
+    when "10.04"
+      "8.4"
+    else
+      nil
+  end
+end
+
+def get_redhatfamily_postgres_version
+  case Facter.value('operatingsystemrelease')
+    when /^6\./
+      "8.4"
+    when /^5\./
+      "8.1"
+    else
+      nil
   end
 end
 
 Facter.add("postgres_default_version") do
   setcode do
-    case Facter.value('osfamily')
-      when 'RedHat'
-        get_redhat_postgres_version()
-      when 'Debian'
-        get_debian_postgres_version()
-      else
-        nil
+    result =
+      case Facter.value('osfamily')
+        when 'RedHat'
+          get_redhatfamily_postgres_version()
+        when 'Debian'
+          get_debianfamily_postgres_version()
+        else
+          nil
+      end
+    if result == nil
+      result = "Unsupported OS!  Please check `postgres_default_version` fact."
     end
+    result
   end
 end

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -25,7 +25,7 @@ define postgresql::database(
 {
   include postgresql::params
 
-  if ($::postgres_default_version != '8.1') {
+  if ($postgresql::params::version != '8.1') {
     $locale_option = '--locale=C'
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,6 @@
 # Sample Usage:
 #
 class postgresql (
-  $version        = $::postgres_default_version,
   $package_name   = $postgresql::params::client_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {

--- a/manifests/psql.pp
+++ b/manifests/psql.pp
@@ -30,7 +30,7 @@ define postgresql::psql(
   # things but not nested escaping.  Need a lexer, preferably a ruby SQL parser
   # to catch errors at catalog time.  Possibly https://github.com/omghax/sql ?
 
-  if ($::postgres_default_version != '8.1') {
+  if ($postgresql::params::version != '8.1') {
     $no_password_option = '--no-password'
   }
 

--- a/templates/pg_hba.conf.erb
+++ b/templates/pg_hba.conf.erb
@@ -74,12 +74,12 @@
 # (custom daily cronjobs, replication, and similar tasks).
 #
 # Database administrative login by UNIX sockets
-local   all         postgres                          ident  <%= "sameuser" if @postgres_default_version == "8.1" %>
+local   all         postgres                          ident  <%= "sameuser" if scope.lookupvar('postgresql::params::version') == "8.1" %>
 
 # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
 
 # "local" is for Unix domain socket connections only
-local   all         all                               ident <%= "sameuser" if @postgres_default_version == "8.1" %>
+local   all         all                               ident <%= "sameuser" if scope.lookupvar('postgresql::params::version') == "8.1" %>
 # IPv4 local connections:
 host    all         postgres    <%= @ip_mask_deny_postgres_user + "\t" %>      reject
 host    all         all         <%= @ip_mask_allow_all_users + "\t" %>      md5


### PR DESCRIPTION
This commit fixes up the `postgres_default_version` fact so that
it doesn't use apt/yum (slow), and instead just has a hard-coded
list of default postgres versions for various OS versions.  We
will need to add new OS versions to this fact over time, but that
seems preferable to the previous implementation which was causing
slower puppet runs on all nodes (regardless of whether they were
actually using postgres or not).
