### PR TITLE
Moved remote access for other users to end of IPv4 section

### DIFF
--- a/templates/pg_hba.conf.erb
+++ b/templates/pg_hba.conf.erb
@@ -82,10 +82,10 @@ local   all         postgres                          ident  <%= "sameuser" if @
 local   all         all                               ident <%= "sameuser" if @postgres_default_version == "8.1" %>
 # IPv4 local connections:
 host    all         postgres    <%= @ip_mask_deny_postgres_user + "\t" %>      reject
-host    all         all         <%= @ip_mask_allow_all_users + "\t" %>      md5
 <% @ipv4acls.each do |acl|; parts = acl.split -%>
 <%= parts[0] + "\t" + parts[1] + "\t" + parts[2] + "\t\t" + parts[3] + "\t\t" + parts[4] + "\t" + parts.last(parts.length - 5).join(" ") %>
 <% end -%>
+host    all         all         <%= @ip_mask_allow_all_users + "\t" %>      md5
 # IPv6 local connections:
 host    all         all         ::1/128               md5
 <% @ipv6acls.each do |acl|; parts = acl.split -%>


### PR DESCRIPTION
Moved the ip mask for allowing remote access for other users to the end of the IPv4 section
so that it doesn't block access to the DB via local loopback for other forms of authentication (such as LDAP).
