### PR TITLE
define validate db connection should be a class.

### DIFF
--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -44,7 +44,7 @@
 #  }
 #
 
-define postgresql::validate_db_connection(
+class postgresql::validate_db_connection(
     $database_host,
     $database_name,
     $database_password,


### PR DESCRIPTION
when I tried to use the puppetdb, module, I saw the following
error:

Syntax error at 'inherits' at manifests/validate_db_connection.pp:54

This manfiest contains a define, even though it should really be a class.
