### PR TITLE
Fixes for validate_db_connection and adds support for locale

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
   end
 
   def run_sql_command(sql)
-    command = 'psql -t -c "' << sql.gsub('"', '\"') << '"'
+    command = resource[:psql_cmd] << ' -t -c "' << sql.gsub('"', '\"') << '"'
     if resource[:cwd]
       Dir.chdir resource[:cwd] do
         Puppet::Util::SUIDManager.run_and_capture(command, resource[:psql_user], resource[:psql_group])

--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -37,6 +37,10 @@ Puppet::Type.newtype(:postgresql_psql) do
       end
     end
   end
+  
+  newparam(:psql_cmd) do
+    desc "The path of the psql command."
+  end
 
   newparam(:unless) do
     desc "An optional SQL command to execute prior to the main :command; " +

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -21,12 +21,13 @@
 
 define postgresql::database(
   $dbname  = $title,
-  $charset = 'UTF8')
+  $charset = 'UTF8',
+  $locale  = 'C')
 {
   include postgresql::params
 
   if ($postgresql::params::version != '8.1') {
-    $locale_option = '--locale=C'
+    $locale_option = "--locale=${locale}"
   }
 
   $createdb_command = "${postgresql::params::createdb_path} --template=template0 --encoding '${charset}' ${locale_option} '${dbname}'"
@@ -35,6 +36,7 @@ define postgresql::database(
     command => "SELECT 1",
     unless  => "SELECT datname FROM pg_database WHERE datname='$dbname'",
     cwd     => $postgresql::params::datadir,
+	 psql_cmd => $postgresql::params::psql_path,
   } ~>
 
   exec { $createdb_command :
@@ -49,6 +51,7 @@ define postgresql::database(
     db          => 'postgres',
     refreshonly => true,
     cwd         => $postgresql::params::datadir,
+	 psql_cmd => $postgresql::params::psql_path,
   }
 
 }

--- a/manifests/database_grant.pp
+++ b/manifests/database_grant.pp
@@ -55,6 +55,7 @@ define postgresql::database_grant(
     psql_user    => $psql_user,
     unless       => "SELECT 1 WHERE has_database_privilege('$role', '$db', '$unless_privilege')",
     cwd          => $postgresql::params::datadir,
+	 psql_cmd => $postgresql::params::psql_path,
   }
 }
 

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -35,13 +35,15 @@ define postgresql::db (
   $user,
   $password,
   $charset     = 'utf8',
-  $grant       = 'ALL'
+  $grant       = 'ALL',
+  $locale      = undef
 ) {
 
   postgresql::database { $name:
     # TODO: ensure is not yet supported
     #ensure     => present,
     charset     => $charset,
+	 locale      => $locale,
     #provider   => 'postgresql',
     require     => Class['postgresql::server'],
   }

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -38,5 +38,7 @@ define postgresql::role(
     psql_user    => 'postgres',
     unless       => "SELECT rolname FROM pg_roles WHERE rolname='$username'",
     cwd          => $postgresql::params::datadir,
+	 psql_cmd => $postgresql::params::psql_path,
+
   }
 }

--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -51,26 +51,21 @@ define postgresql::validate_db_connection(
     $database_username,
     $client_package_name = $postgresql::params::client_package_name,
     $database_port       = 5432
-) inherits postgresql::params {
+) {
 
-    # Make sure the postgres client package is installed; we need it for
-    # `psql`.
-    package { 'postgresql-client':
-        ensure => present,
-        name   => $client_package_name,
-        tag    => 'postgresql',
-    }
+	include postgresql::params
 
     # TODO: port to ruby
+ 
     $psql = "${postgresql::params::psql_path} --tuples-only --quiet -h ${database_host} -U ${database_username} -p ${database_port} --dbname ${database_name}"
-
-    $exec_name = "validate postgres connection for ${database_host}/${database_name}"
+ 
+	 $exec_name = "validate postgres connection for ${database_host}/${database_name}"
     exec { $exec_name:
       command     => "/bin/echo \"SELECT 1\" | ${psql}",
       cwd         => '/tmp',
       environment => "PGPASSWORD=${database_password}",
       logoutput   => 'on_failure',
-      require     => Package['postgresql-client'],
+      require     => Package['postgresql-client']
     }
 
     # This is a little bit of puppet magic.  What we want to do here is make


### PR DESCRIPTION
I have fixed the validate_db_connection such that it does not give syntax-error any more. 
It is still a "define", but I include postgresql::params instead of inheriting.

I also added support for a parameter locale which lets the user override the locale used.
