### PR TITLE
Turn the exec in validate_db_connection.pp around

### DIFF
--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -66,7 +66,8 @@ define postgresql::validate_db_connection(
 
     $exec_name = "validate postgres connection for ${database_host}/${database_name}"
     exec { $exec_name:
-      command     => "/bin/echo \"SELECT 1\" | ${psql}",
+      command     => '/bin/false',
+      unless      => "/bin/echo \"SELECT 1\" | ${psql}",
       cwd         => '/tmp',
       environment => "PGPASSWORD=${database_password}",
       logoutput   => 'on_failure',


### PR DESCRIPTION
The Exec "validate postgres connection for ${database_host}/${database_name}" is always executed and returns a notice every time it is executed successfully. A node which uses this, will never turn ' green' in puppet-dashboard.

I do not like that, so i changed the exec. It does the validation now in within the 'unless' statement . If that returns something else then 0 (zero), the command '/bin/false' is executed. /bin/false returns a 1 (one), what will cause the Exec to fail.

Effectively the check does exact the same as before, but now nothing is logged, except when it fails. 
