### PR TITLE
Add Debian wheezy support for default version fact

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -14,6 +14,8 @@ def get_debian_postgres_version
     # TODO: add more debian versions or better logic here
     when /^6\./
       "8.4"
+    when /^wheezy/
+      "9.1"
     else
       nil
   end


### PR DESCRIPTION
Debian Wheezy has a default version of 9.1, but doesn't currently have
an operatingsystemrelease value beyond 'wheezy'. This command searches
for wheezy in the operatingsystemrelease fact and sets the fact value
accordingly.
