### PR TITLE
Fix inherits issue with validate_db_connection

### DIFF
--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -13,9 +13,6 @@
 #   [*database_password*]   - the postgres user's password
 #   [*database_name*]       - the database name that the connection should be
 #                             established against
-#   [*client_package_name*] - (optional) the name of the postgres client package
-#                             that provides the psql tool, if you aren't using
-#                             the default system package.
 #
 # NOTE: to some degree this type assumes that you've created the corresponding
 # postgres database instance that you are validating by using the
@@ -49,17 +46,9 @@ define postgresql::validate_db_connection(
     $database_name,
     $database_password,
     $database_username,
-    $client_package_name = $postgresql::params::client_package_name,
     $database_port       = 5432
-) inherits postgresql::params {
-
-    # Make sure the postgres client package is installed; we need it for
-    # `psql`.
-    package { 'postgresql-client':
-        ensure => present,
-        name   => $client_package_name,
-        tag    => 'postgresql',
-    }
+) {
+    require postgresql
 
     # TODO: port to ruby
     $psql = "${postgresql::params::psql_path} --tuples-only --quiet -h ${database_host} -U ${database_username} -p ${database_port} --dbname ${database_name}"

--- a/spec/support/shared_examples/system_default_postgres.rb
+++ b/spec/support/shared_examples/system_default_postgres.rb
@@ -117,4 +117,21 @@ shared_examples :system_default_postgres do
     end
   end
 
+  describe 'postgresql::validate_db_connections' do
+    it 'should run puppet with no changes declared if database connectivity works' do
+      # Setup
+      setup_class = 'class {"postgresql_tests::system_default::test_db": db => "foo" }'
+      sudo_and_log(vm, "puppet apply --detailed-exitcodes -e '#{setup_class}'; [ $? == 2 ]")
+
+      # Run test
+      test_pp = "postgresql::validate_db_connection {'foo': database_host => 'localhost', database_name => 'foo', database_username => 'foo', database_password => 'foo' }"
+      sudo_and_log(vm, "puppet apply --detailed-exitcodes -e '#{test_pp}'")
+    end
+
+    it 'should fail catalogue if database connectivity fails' do
+      # Run test
+      test_pp = "postgresql::validate_db_connection {'foo': database_host => 'localhost', database_name => 'foo', database_username => 'foo', database_password => 'foo' }"
+      sudo_and_log(vm, "puppet apply --detailed-exitcodes -e '#{test_pp}'; [ $? == 4 ]")
+    end
+  end
 end


### PR DESCRIPTION
Previously the validate_db_connection defined type was trying to use inherits
like a class. This of course would fail.

After analyzing its usage, I've removed the need for the top-level params
inherit by just including the 'postgresql' module which pulls in the client
package and the params class as well. It also avoids resource duplication
for the client package as well.

To ensure we don't get regression on this I've added system tests that test
this defined type in a success and failure state.

Signed-off-by: Ken Barber ken@bob.sh
