### PR TITLE
Provide version for ubuntu 12.10

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -24,6 +24,8 @@ end
 def get_ubuntu_postgres_version
   case Facter.value('operatingsystemrelease')
     # TODO: add more ubuntu versions or better logic here
+    when "12.10"
+      "9.1"
     when "12.04"
       "9.1"
     when "10.04"


### PR DESCRIPTION
Might be doable for debian & ubuntu by running `apt-cache show postgresql | grep Version` and then parsing that, but I am not sure how much overhead that would add and what is considered good practice in the facter world. My ruby skills are also quite insufficient to do it without checking things anyway ;)

Fixes #68
