### PR TITLE
improve pg_hba.conf template flexibility and consistency

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,12 +3,10 @@
 # Parameters:
 #
 #   [*postgres_password*]            - postgres db user password.
-#   [*ip_mask_deny_postgres_user*]   - ip mask for denying remote access for postgres user; defaults to '0.0.0.0/0',
-#                                       meaning that all TCP access for postgres user is denied.
-#   [*ip_mask_allow_all_users*]      - ip mask for allowing remote access for other users (besides postgres);
-#                                       defaults to '127.0.0.1/32', meaning only allow connections from localhost
 #   [*listen_addresses*]             - what IP address(es) to listen on; comma-separated list of addresses; defaults to
 #                                       'localhost', '*' = all
+#   [*unixacls*]                     - list of strings for access control for connection method, users, databases, UNIX
+#                                       addresses; see postgresql documentation about pg_hba.conf for information
 #   [*ipv4acls*]                     - list of strings for access control for connection method, users, databases, IPv4
 #                                       addresses; see postgresql documentation about pg_hba.conf for information
 #   [*ipv6acls*]                     - list of strings for access control for connection method, users, databases, IPv6
@@ -34,9 +32,8 @@
 #
 class postgresql::config(
   $postgres_password            = undef,
-  $ip_mask_deny_postgres_user   = $postgresql::params::ip_mask_deny_postgres_user,
-  $ip_mask_allow_all_users      = $postgresql::params::ip_mask_allow_all_users,
   $listen_addresses             = $postgresql::params::listen_addresses,
+  $unixacls                     = $postgresql::params::unixacls,
   $ipv4acls                     = $postgresql::params::ipv4acls,
   $ipv6acls                     = $postgresql::params::ipv6acls,
   $pg_hba_conf_path             = $postgresql::params::pg_hba_conf_path,
@@ -49,9 +46,8 @@ class postgresql::config(
   #  the proper ordering.
 
   class { 'postgresql::config::beforeservice':
-    ip_mask_deny_postgres_user    => $ip_mask_deny_postgres_user,
-    ip_mask_allow_all_users       => $ip_mask_allow_all_users,
     listen_addresses              => $listen_addresses,
+    unixacls                      => $unixacls,
     ipv4acls                      => $ipv4acls,
     ipv6acls                      => $ipv6acls,
     pg_hba_conf_path              => $pg_hba_conf_path,

--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -2,12 +2,10 @@
 #
 # Parameters:
 #
-#   [*ip_mask_deny_postgres_user*]   - ip mask for denying remote access for postgres user; defaults to '0.0.0.0/0',
-#                                       meaning that all TCP access for postgres user is denied.
-#   [*ip_mask_allow_all_users*]      - ip mask for allowing remote access for other users (besides postgres);
-#                                       defaults to '127.0.0.1/32', meaning only allow connections from localhost
 #   [*listen_addresses*]        - what IP address(es) to listen on; comma-separated list of addresses; defaults to
 #                                    'localhost', '*' = all
+#   [*unixacls*]                - list of strings for access control for connection method, users, databases, UNIX 
+#                                    addresses; see postgresql documentation about pg_hba.conf for information
 #   [*ipv4acls*]                - list of strings for access control for connection method, users, databases, IPv4
 #                                    addresses; see postgresql documentation about pg_hba.conf for information
 #   [*ipv6acls*]                - list of strings for access control for connection method, users, databases, IPv6
@@ -36,9 +34,8 @@
 class postgresql::config::beforeservice(
   $pg_hba_conf_path,
   $postgresql_conf_path,
-  $ip_mask_deny_postgres_user   = $postgresql::params::ip_mask_deny_postgres_user,
-  $ip_mask_allow_all_users      = $postgresql::params::ip_mask_allow_all_users,
   $listen_addresses             = $postgresql::params::listen_addresses,
+  $unixacls                     = $postgresql::params::unixacls,
   $ipv4acls                     = $postgresql::params::ipv4acls,
   $ipv6acls                     = $postgresql::params::ipv6acls,
   $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,11 +34,13 @@ class postgresql::params(
 ) {
   $user                         = 'postgres'
   $group                        = 'postgres'
-  $ip_mask_deny_postgres_user   = '0.0.0.0/0'
-  $ip_mask_allow_all_users      = '127.0.0.1/32'
   $listen_addresses             = 'localhost'
-  $ipv4acls                     = []
-  $ipv6acls                     = []
+  $unixacls                     = [ 'local all all ident' ]
+  $ipv4acls                     = [
+                                   'host all postgres 0.0.0.0/0 reject',
+                                   'host all all 127.0.0.1/32 md5',
+                                  ]
+  $ipv6acls                     = [ 'host all all ::1/128 md5' ]
   # TODO: figure out a way to make this not platform-specific
   $manage_redhat_firewall       = false
 

--- a/templates/pg_hba.conf.erb
+++ b/templates/pg_hba.conf.erb
@@ -74,21 +74,21 @@
 # (custom daily cronjobs, replication, and similar tasks).
 #
 # Database administrative login by UNIX sockets
+<% format = '%-8s%-12s%-12s%-22s%s' -%>
 local   all         postgres                          ident  <%= "sameuser" if scope.lookupvar('postgresql::params::version') == "8.1" %>
 
 # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
 
 # "local" is for Unix domain socket connections only
-local   all         all                               ident <%= "sameuser" if scope.lookupvar('postgresql::params::version') == "8.1" %>
-# IPv4 local connections:
-host    all         postgres    <%= @ip_mask_deny_postgres_user + "\t" %>      reject
-<% @ipv4acls.each do |acl|; parts = acl.split -%>
-<%= parts[0] + "\t" + parts[1] + "\t" + parts[2] + "\t\t" + parts[3] + "\t\t" + parts[4] + "\t" + parts.last(parts.length - 5).join(" ") %>
+<% @unixacls.each do |acl|; parts = acl.split -%>
+<%= sprintf(format, parts[0], parts[1], parts[2], '', parts[3]) %>
 <% end -%>
-host    all         all         <%= @ip_mask_allow_all_users + "\t" %>      md5
+# IPv4 local connections:
+<% @ipv4acls.each do |acl|; parts = acl.split -%>
+<%= sprintf(format, parts[0], parts[1], parts[2], parts[3], parts[4]) %>
+<% end -%>
 # IPv6 local connections:
-host    all         all         ::1/128               md5
 <% @ipv6acls.each do |acl|; parts = acl.split -%>
-<%= parts[0] + "\t" + parts[1] + "\t" + parts[2] + "\t\t" + parts[3] + "\t\t" + parts[4] + "\t" + parts.last(parts.length - 5).join(" ") %>
+<%= sprintf(format, parts[0], parts[1], parts[2], parts[3], parts[4]) %>
 <% end -%>
 


### PR DESCRIPTION
We need the ability to set UNIX domain socket (local) acls in the pg_hba.conf.
The usage of two string variables (ip_mask_deny_postgres_user &
ip_mask_allow_all_users) to set special acl rules along with with lists
(ipv4acls, ipv6avls) was highly non-orthogonal.

This patch removes from postgresql::{params, config, config::beforeservice}

$ip_mask_deny_postgres_user
$ip_mask_allow_all_users

And moves the ACLs created by those two vars into
$postgresql::params::ipv4acls.  It adds a new variable
$postgresql::params::unixacls which replaces one of the hard coded unix domain
socket rules in pg_hba.conf.erb.  In addition, it removes the usage of
tabstops in pg_hba.conf.erb and makes the indentation more consistent.  One of
the major motivations of this patch is to get the use the ability to remove
almost all of the ACLs.
