### PR TITLE
type and provider for postgresql role/user

### DIFF
--- a/lib/puppet/provider/pg_user/debian_postgresql.rb
+++ b/lib/puppet/provider/pg_user/debian_postgresql.rb
@@ -1,0 +1,165 @@
+require 'digest/md5'
+
+Puppet::Type.type(:pg_user).provide(:debian_postgresql) do
+
+  desc "Manage users for a postgres database cluster"
+
+  defaultfor :operatingsystem => [:debian, :ubuntu]
+
+  commands :psql => 'psql'
+  commands :su => 'su'
+
+  # generate getters for properties
+  mk_resource_methods
+
+  def initialize(value={})
+      super(value)
+
+      @flush_query = []
+
+      @pg_param_hash = {
+          :superuser  => {:true => "SUPERUSER", :false=>"NOSUPERUSER"},
+          :createdb   => {:true => "CREATEDB", :false=>"NOCREATEDB"},
+          :createrole => {:true => "CREATEROLE", :false=>"NOCREATEROLE"},
+          :inherit    => {:true => "INHERIT", :false=>"NOINHERIT"},
+          :canlogin   => {:true => "LOGIN", :false=>"NOLOGIN"},
+          :connlimit  => "CONNECTION LIMIT",
+          :password   => "ENCRYPTED PASSWORD",
+          :validuntil => "VALID UNTIL"
+      }
+  end
+
+
+  def run_psql(query)
+      su("-", "postgres", "-c", "psql --quiet -A -t -c \"%s\"" % query)
+  end
+
+  def self.instances
+      instances = []
+      roles = su("-", "postgres", "-c", "psql --quiet -A -t -c \"select rolname, rolsuper, rolcreatedb, rolcreaterole, rolinherit, rolcanlogin, rolconnlimit, rolpassword, rolvaliduntil from pg_authid;\"")
+
+      roles.each_line do |line|
+          data = line.split('|')
+          instances << new( :name      => data[0],
+                           :ensure     => :present,
+                           :superuser  => data[1] == 't' ? :true : :false,
+                           :createdb   => data[2] == 't' ? :true : :false,
+                           :createrole => data[3] == 't' ? :true : :false,
+                           :inherit    => data[4] == 't' ? :true : :false,
+                           :canlogin   => data[5] == 't' ? :true : :false,
+                           :connlimit  => data[6],
+                           :password   => data[7],
+                           :validuntil => data[8]
+          )
+      end
+
+      return instances
+  end
+
+  def self.prefetch(resources)
+      resources.keys.each do |name|
+        if provider = instances.find{ |role| role.name == name }
+            resources[name].provider = provider
+        end
+      end
+  end
+
+
+  def create
+
+    stm = "CREATE ROLE %s WITH" % @resource.value(:name)
+
+    stm << (@resource.value(:superuser).nil? ? '' : " " << @pg_param_hash[:superuser][@resource.value(:superuser)])
+    stm << (@resource.value(:createdb).nil? ? '' : " " << @pg_param_hash[:createdb][@resource.value(:createdb)])
+    stm << (@resource.value(:createrole).nil? ? '' : " " << @pg_param_hash[:createrole][@resource.value(:createrole)])
+    stm << (@resource.value(:inherit).nil? ? '' : " " << @pg_param_hash[:inherit][@resource.value(:inherit)])
+    stm << (@resource.value(:canlogin).nil? ? '' : " " << @pg_param_hash[:canlogin][@resource.value(:canlogin)])
+    stm << (@resource.value(:connlimit).nil? ? '' : " " << @pg_param_hash[:connlimit] << " %s" % @resource.value(:connlimit))
+
+    if @resource.value(:password)
+        password = 'md5' + Digest::MD5.hexdigest(@resource.value(:password) + @resource.value(:name))
+        stm << " " << @pg_param_hash[:password] << " '%s'" % password
+    end
+
+    stm << (@resource.value(:validuntil).nil? ? '' : " " << @pg_param_hash[:validuntil] << " '%s'" % @resource.value(:validuntil))
+
+    run_psql(stm)
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    su("-", "postgres", "-c", "dropuser %s" % [ @resource.value(:name) ])
+    @property_hash.clear
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def flush
+      return unless not @property_hash.empty?
+
+      stm = "ALTER ROLE %s WITH" % resource[:name]
+
+      @flush_query.each do |value|
+          stm << " " << value
+      end
+
+      run_psql(stm)
+
+      @property_hash = resource.to_hash
+  end
+
+
+  # Getters/setters for properties
+
+  def superuser=(value)
+    @flush_query << @pg_param_hash[:superuser][value]
+  end
+
+  def createdb=(value)
+    @flush_query << @pg_param_hash[:createdb][value]
+  end
+
+  def createrole=(value)
+    @flush_query << @pg_param_hash[:createrole][value]
+  end
+
+  def inherit=(value)
+    @flush_query << @pg_param_hash[:inherit][value]
+  end
+
+  def canlogin=(value)
+    @flush_query << @pg_param_hash[:canlogin][value]
+  end
+
+  def connlimit=(value)
+    @flush_query << (@pg_param_hash[:connlimit] << " %s" % value)
+  end
+
+  def password
+      # if we are requesting via `puppet resource pg_user` - just return property_hash value
+      if not @resource.value(:password)
+          return @property_hash[:password]
+      end
+
+      password_hash = 'md5' + Digest::MD5.hexdigest(@resource.value(:password) + @resource.value(:name))
+
+    # compare resource password or calculated hash from resource password with db value
+    if @resource.value(:password) == @property_hash[:password] or password_hash == @property_hash[:password]
+        return @resource.value(:password)
+    end
+
+    # no luck - password is different
+    return @property_hash[:password]
+  end
+
+  def password=(value)
+    @flush_query << (@pg_param_hash[:password] << " '%s'" % value)
+  end
+
+  def validuntil=(value)
+    @flush_query << (@pg_param_hash[:validuntil] << " '%s'" % value)
+  end
+
+end

--- a/lib/puppet/provider/pg_user/default.rb
+++ b/lib/puppet/provider/pg_user/default.rb
@@ -1,0 +1,21 @@
+Puppet::Type.type(:pg_user).provide(:default) do
+
+  desc "A default pg_user provider which just fails."
+
+  def self.instances
+      []
+  end
+
+  def create
+    return false
+  end
+
+  def destroy
+    return false
+  end
+
+  def exists?
+    fail('This is just the default provider for pg_user, all it does is fail')
+  end
+
+end

--- a/lib/puppet/type/pg_user.rb
+++ b/lib/puppet/type/pg_user.rb
@@ -1,0 +1,60 @@
+# This has to be a separate type to enable collecting
+Puppet::Type.newtype(:pg_user) do
+  @doc = "Manage a Postgresql database user/role."
+
+  ensurable
+
+  newparam(:name, :namevar=>true) do
+    desc "The name of the user/role"
+  end
+
+  newproperty(:superuser, :boolean => true) do
+    desc "Role has superuser privileges"
+    newvalues(:true, :false)
+  end
+
+  newproperty(:createdb, :boolean => true) do
+    desc "Role may create databases"
+    newvalues(:true, :false)
+  end
+
+  newproperty(:createrole, :boolean => true) do
+    desc "Role may create more roles"
+    newvalues(:true, :false)
+  end
+
+  newproperty(:inherit, :boolean => true) do
+    desc "Role automatically inherits privileges of roles it is a member of"
+    newvalues(:true, :false)
+  end
+
+  newproperty(:canlogin, :boolean => true) do
+    desc "Role may log in, that is, this role can be given as the initial session authorization identifier."
+    newvalues(:true, :false)
+  end
+
+  newproperty(:connlimit) do
+    desc "If role can log in, this specifies how many concurrent connections the role can make. -1 (the default) means no limit."
+  end
+
+  newproperty(:password) do
+    desc "Role's password"
+  end
+
+  newproperty(:validuntil) do
+    desc "Sets a date and time after which the role's password is no longer valid"
+  end
+
+#  newproperty(:inrole) do
+#    desc "Lists one or more existing roles to which the new role will be immediately added as a new member"
+#  end
+#
+#  newproperty(:role) do
+#    desc "Lists one or more existing roles which are automatically added as members of the new role. (This in effect makes the new role a 'group'.)"
+#  end
+#
+#  newproperty(:admin) do
+#    desc "Like ROLE, but the named roles are added to the new role WITH ADMIN OPTION, giving them the right to grant membership in this role to others"
+#  end
+
+end


### PR DESCRIPTION
Hello again.

I've separated commits. Now here is code only for managing user/role via puppet type and provider.
Usage example:

``` ruby
pg_user { 'new_user':
        ensure => present,
        password => '12345',
        superuser => true,
        connlimit => 13,
        createdb => true,
    }
```

Every parameter is automatically cheked each time agent runs, so role is up to date with manifest descriptor. 
Also I would like to mention, that my code was originally based on code from @akumria https://github.com/akumria/puppet-postgresql. But is significantly improved.

It's not 100% tested, all tests were made manually. So, it's possible there could be mistakes :(
Hope it helps.
