### PR TITLE
Fix error message in default version fact

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -48,15 +48,27 @@ end
 
 Facter.add("postgres_default_version") do
   setcode do
-    case Facter.value('osfamily')
-      when 'RedHat'
-        get_redhatfamily_postgres_version()
-      when 'Linux'
-        get_redhatfamily_postgres_version()
-      when 'Debian'
-        get_debianfamily_postgres_version()
-      else
-        "Unsupported OS!  Please check `postgres_default_version` fact."
+    result =
+      case Facter.value('osfamily')
+        when 'RedHat'
+          get_redhatfamily_postgres_version()
+        when 'Linux'
+          get_redhatfamily_postgres_version()
+        when 'Debian'
+          get_debianfamily_postgres_version()
+        else
+          nil
+      end
+
+    # TODO: not sure if this is really a great idea, but elsewhere in the code
+    # it is useful to be able to distinguish between the case where the fact
+    # does not exist at all (e.g., if pluginsync is not enabled), and the case
+    # where the fact is not known for the OS in question.  It might be better
+    # to use a shorter sentinel value here and then check for it elsewhere,
+    # e.g. in the same place we're checking for nil and warning about pluginsync.
+    if result == nil
+      result = "Unsupported OS!  Please check `postgres_default_version` fact."
     end
+    result
   end
 end


### PR DESCRIPTION
A commit that I merged yesterday broke the default version fact
such that it would sometimes return nil and sometimes an error message
if your distro wasn't supported.  This commit makes it consistent again.
