### PR TITLE
Add support for ubuntu 12.10 status

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -146,14 +146,7 @@ class postgresql::params(
       $bindir              = "/usr/lib/postgresql/${version}/bin"
       $datadir             = "/var/lib/postgresql/${version}/main"
       $confdir             = "/etc/postgresql/${version}/main"
-      if($manage_package_repo) {
-        # The postgresql packages (official not distro) return a different
-        # string when checking status.
-        $service_status      = "/etc/init.d/${service_name} status | /bin/egrep -q 'online'"
-      } else {
-        # And this is what the Debian/Ubuntu packages return.
-        $service_status      = "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+'"
-      }
+      $service_status      = "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+|online'"
     }
 
     default: {


### PR DESCRIPTION
In the latest ubuntu, even with the distro package the string is `9.1/main (port 5432): online`.
