### PR TITLE
Syntax error in params.pp file

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@
 class postgresql::params(
     $version             = $::postgres_default_version,
     $manage_package_repo = false,
-    $package_source      = undef,
+    $package_source      = undef
 ) {
   $user                         = 'postgres'
   $group                        = 'postgres'


### PR DESCRIPTION
err: Could not parse for environment production: Syntax error at ')' at /etc/puppet/modules/common/postgresql/manifests/params.pp:34
