### PR TITLE
Update postgres_default_version to 9.1 for debian 7.0

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -14,7 +14,7 @@ def get_debian_postgres_version
     # TODO: add more debian versions or better logic here
     when /^6\./
       "8.4"
-    when /^wheezy/
+    when /^wheezy/, /^7\./
       "9.1"
     else
       nil


### PR DESCRIPTION
/etc/debian_version on Wheezy was updated to 7.0 with the release of the
base-files package on 2012-12-12, which means that wheezy could be
either 7.0 or wheezy depending on what version of base-files is
installed. To handle both cases we treat 'wheezy' and '7.*' as
synonymous.
