### PR TITLE
add a $pg_hba_conf_template parameter to the class postgresql::config to...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,7 @@
 #   [*ipv6acls*]                     - list of strings for access control for connection method, users, databases, IPv6
 #                                       addresses; see postgresql documentation about pg_hba.conf for information
 #   [*pg_hba_conf_path*]             - path to pg_hba.conf file
+#   [*pg_hba_conf_template*]         - template to use for pg_hba.conf; defaults to 'postgresql/pg_hba.conf.erb'
 #   [*postgresql_conf_path*]         - path to postgresql.conf file
 #   [*manage_redhat_firewall*]       - boolean indicating whether or not the module should open a port in the firewall on
 #                                       redhat-based systems; this parameter is likely to change in future versions.  Possible
@@ -40,6 +41,7 @@ class postgresql::config(
   $ipv4acls                     = $postgresql::params::ipv4acls,
   $ipv6acls                     = $postgresql::params::ipv6acls,
   $pg_hba_conf_path             = $postgresql::params::pg_hba_conf_path,
+  $pg_hba_conf_template         = $postgresql::params::pg_hba_conf_template,
   $postgresql_conf_path         = $postgresql::params::postgresql_conf_path,
   $manage_redhat_firewall       = $postgresql::params::manage_redhat_firewall
 ) inherits postgresql::params {
@@ -55,6 +57,7 @@ class postgresql::config(
     ipv4acls                      => $ipv4acls,
     ipv6acls                      => $ipv6acls,
     pg_hba_conf_path              => $pg_hba_conf_path,
+    pg_hba_conf_template          => $pg_hba_conf_template,
     postgresql_conf_path          => $postgresql_conf_path,
     manage_redhat_firewall        => $manage_redhat_firewall,
   }

--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -13,6 +13,7 @@
 #   [*ipv6acls*]                - list of strings for access control for connection method, users, databases, IPv6
 #                                    addresses; see postgresql documentation about pg_hba.conf for information
 #   [*pg_hba_conf_path*]        - path to pg_hba.conf file
+#   [*pg_hba_conf_template*]    - template to use for pg_hba.conf; defaults to 'postgresql/pg_hba.conf.erb'
 #   [*postgresql_conf_path*]    - path to postgresql.conf file
 #   [*manage_redhat_firewall*]  - boolean indicating whether or not the module should open a port in the firewall on
 #                                    redhat-based systems; this parameter is likely to change in future versions.  Possible
@@ -35,6 +36,7 @@
 #
 class postgresql::config::beforeservice(
   $pg_hba_conf_path,
+  $pg_hba_conf_template         = $postgresql::params::pg_hba_conf_template,
   $postgresql_conf_path,
   $ip_mask_deny_postgres_user   = $postgresql::params::ip_mask_deny_postgres_user,
   $ip_mask_allow_all_users      = $postgresql::params::ip_mask_allow_all_users,
@@ -56,7 +58,7 @@ class postgresql::config::beforeservice(
   file { 'pg_hba.conf':
     ensure      => file,
     path        => $pg_hba_conf_path,
-    content     => template('postgresql/pg_hba.conf.erb'),
+    content     => template($pg_hba_conf_template),
     notify      => Exec['reload_postgresql'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class postgresql::params(
   $ipv6acls                     = []
   # TODO: figure out a way to make this not platform-specific
   $manage_redhat_firewall       = false
+  $pg_hba_conf_template         = 'postgresql/pg_hba.conf.erb'
 
 
   if ($manage_package_repo) {


### PR DESCRIPTION
... allow the default pg_hba.conf template to be overrideen

example usage:

  class { 'postgresql::server':
    config_hash => {
      'pg_hba_conf_template'       => 'mymodule/pg_hba.conf.erb',
    },
  }

Per discussion in https://github.com/puppetlabs/puppet-postgresql/pull/72
