### PR TITLE
Use db in postgresql_psql provider

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -52,6 +52,11 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
 
   def run_sql_command(sql)
     command = 'psql -t -c "' << sql.gsub('"', '\"') << '"'
+
+    if resource[:db]
+      command << ' -d "' << resource[:db].gsub('"', '\"') << '"'
+    end
+
     if resource[:cwd]
       Dir.chdir resource[:cwd] do
         Puppet::Util::SUIDManager.run_and_capture(command, resource[:psql_user], resource[:psql_group])


### PR DESCRIPTION
The database flag isn't being used like in [postgresql::psql](https://github.com/puppetlabs/puppet-postgresql/blob/236ce4783a8e03cf4901be0c34a68fa0750a660d/manifests/psql.pp#L37).
