### PR TITLE
Add unit tests and travis-ci support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,7 @@
+fixtures:
+  repositories:
+    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    firewall: "git://github.com/puppetlabs/puppetlabs-firewall.git"
+  symlinks:
+    postgresql: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vagrant
 /postgresql/pkg
+# This is a library, so don't pin
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - ruby-head
+env:
+  - PUPPET_GEM_VERSION="~> 2.6"
+  - PUPPET_GEM_VERSION="~> 2.7"
+  - PUPPET_GEM_VERSION="~> 3.0"
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7"
+    - rvm: ruby-head
+      env: PUPPET_GEM_VERSION="~> 2.7"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.6"
+    - rvm: ruby-head
+      env: PUPPET_GEM_VERSION="~> 2.6"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source :rubygems
+
+group :development, :test do
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'vagrant', '~> 1.0.5'
+  gem 'sahara', '~> 0.0.13'
+  gem 'puppet-lint', '~> 0.3.2'
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-#require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.send("disable_80chars")

--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -63,11 +63,9 @@ Facter.add("postgres_default_version") do
     # TODO: not sure if this is really a great idea, but elsewhere in the code
     # it is useful to be able to distinguish between the case where the fact
     # does not exist at all (e.g., if pluginsync is not enabled), and the case
-    # where the fact is not known for the OS in question.  It might be better
-    # to use a shorter sentinel value here and then check for it elsewhere,
-    # e.g. in the same place we're checking for nil and warning about pluginsync.
+    # where the fact is not known for the OS in question.
     if result == nil
-      result = "Unsupported OS!  Please check `postgres_default_version` fact."
+      result = 'unknown'
     end
     result
   end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql::client', :type => :class do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  it { should include_class("postgresql::client") }
+end

--- a/spec/classes/devel_spec.rb
+++ b/spec/classes/devel_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql::devel', :type => :class do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  it { should include_class("postgresql::devel") }
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql', :type => :class do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  it { should include_class("postgresql") }
+end

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql::params', :type => :class do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql::server', :type => :class do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  it { should include_class("postgresql::server") }
+end

--- a/spec/defines/database_grant_spec.rb
+++ b/spec/defines/database_grant_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'postgresql::database_grant', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :privilege => 'ALL',
+      :db => 'test',
+      :role => 'test',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/database_spec.rb
+++ b/spec/defines/database_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'postgresql::database', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/database_user_spec.rb
+++ b/spec/defines/database_user_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'postgresql::database_user', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :password_hash => 'test',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'postgresql::db', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :user => 'test',
+      :password => 'test',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/psql_spec.rb
+++ b/spec/defines/psql_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'postgresql::psql', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :db => 'test',
+      :unless => 'test',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/role_spec.pp
+++ b/spec/defines/role_spec.pp
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'postgresql::role', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/tablespace_spec.pp
+++ b/spec/defines/tablespace_spec.pp
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'postgresql::tablespace', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/defines/validate_db_connection_spec.rb
+++ b/spec/defines/validate_db_connection_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'postgresql::validate_db_connection', :type => :define do
+  let :facts do
+    {
+      :postgres_default_version => '8.4',
+      :osfamily => 'Debian',
+    }
+  end
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :database_host => 'test',
+      :database_name => 'test',
+      :database_password => 'test',
+      :database_username => 'test',
+    }
+  end
+  it { should include_class("postgresql::params") }
+end

--- a/spec/facts/postgres_default_version_spec.rb
+++ b/spec/facts/postgres_default_version_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'postgres_default_version', :type => :fact do
+  before :each do
+    Facter.flush
+  end
+
+  it 'should handle redhat 6.0' do
+    Facter.fact(:osfamily).stubs(:value).returns 'RedHat'
+    Facter.fact(:operatingsystemrelease).stubs(:value).returns '6.0'
+    Facter.fact(:postgres_default_version).value.should == '8.4'
+  end
+
+  it 'should return unknown if osfamily is unknown' do
+    Facter.fact(:osfamily).stubs(:value).returns 'test'
+    Facter.fact(:postgres_default_version).value.should eq 'unknown'
+  end
+end

--- a/spec/functions/postgresql_password_spec.rb
+++ b/spec/functions/postgresql_password_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'postgresql_password', :type => :puppet_function do
+  it { should run.with_params('foo', 'bar').
+    and_return('md596948aad3fcae80c08a35c9b5958cd89') }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
This patch includes some very basic and initial unit testing using rspec-puppet
and for the case of facts, just normal rspec.

I've taken a very light approach here as rspec-puppet can be quite combinatorial
when one gets carried away. For now I've just added basic compile failure
detection effectively for classes and defined resources. As we continue to work
on the code and find regressions this work can be expanded.

For facts and functions I've also taken a basic approach for now.

One little thing I did change, was the strange string that the fact returns
when the default version is undefined. Instead of an error message I've just
returned the string 'unknown' which is more in line with other facts I've seen
in the wild, and to be quite honest 'unknown' is fairly self-explantory. Since
a fact isn't an error reporting message this seemed more appropriate, and looked
nicer in the rspec test.

As far as travis-ci support, I've added the same configuration that @jmmcune
came up with for stdlib which is pretty light and reasonable standard now we
propogated that to 4 or so other modules in the puppetlabs/ namespace. It should
work out of the box.

Signed-off-by: Ken Barber ken@bob.sh
