### PR TITLE
Reverted some of the coding style fixes

### DIFF
--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -73,7 +73,7 @@ class postgresql::config::beforeservice(
   # managing their own settings in a second conf file.
   file_line { 'postgresql.conf#include':
     path        => $postgresql_conf_path,
-    line        => 'include \'postgresql_puppet_extras.conf\'',
+    line        => "include 'postgresql_puppet_extras.conf'",
     notify      => Service['postgresqld'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,6 @@ class postgresql (
   $charset             = 'UTF8'
 ) {
   class { 'postgresql::params':
-
     version             => $version,
     manage_package_repo => $manage_package_repo,
     package_source      => $package_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,7 +81,7 @@ class postgresql::params(
   # that pluginsync might not be enabled.  Ideally this would be handled directly
   # in puppet.
   if ($::postgres_default_version == undef) {
-    fail 'No value for postgres_default_version facter fact; it\'s possible that you don\'t have pluginsync enabled.'
+    fail "No value for postgres_default_version facter fact; it's possible that you don't have pluginsync enabled."
   }
 
   case $::operatingsystem {


### PR DESCRIPTION
Strings containing single quotes may be easier to read if enclosed in double quotes although it generates puppet lint warning.
