### PR TITLE
Restore support for Puppet 2.6.

### DIFF
--- a/manifests/pg_hba_rule.pp
+++ b/manifests/pg_hba_rule.pp
@@ -9,7 +9,7 @@ define postgresql::pg_hba_rule(
   $description = 'none',
   $auth_option = undef,
   $target = $postgresql::params::pg_hba_conf_path,
-  $order = '150',
+  $order = '150'
 ) {
   include postgresql::params
 


### PR DESCRIPTION
Drop the trailing comma in the class parameters of pg_hba_rule.pp in order to restore support for Puppet 2.6.
