### PR TITLE
Allow SQL commands to be run against a specific DB

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
   end
 
   def run_sql_command(sql)
-    command = 'psql -t -c "' << sql.gsub('"', '\"') << '"'
+    command = %{psql #{"-d #{resource[:db]}" if resource[:db]} -t -c "#{sql.gsub('"', '\"')}"}
     if resource[:cwd]
       Dir.chdir resource[:cwd] do
         Puppet::Util::SUIDManager.run_and_capture(command, resource[:psql_user], resource[:psql_group])


### PR DESCRIPTION
If resource[:db] is set, then it is sent to psql. 

Otherwise, argument is omitted and should not introduce any regression.
