### PR TITLE
Create dependent directory for sudoers so tests work on Centos 5

### DIFF
--- a/spec/system/base.pp
+++ b/spec/system/base.pp
@@ -25,6 +25,13 @@ user {'puppet':
   gid    => 'puppet',
 }
 
+file { '/etc/sudoers.d':
+  ensure => directory,
+  mode   => '0750',
+  owner   => root,
+  group   => root,
+}
+
 file {'/etc/sudoers.d/puppet_postgresql_tests':
   ensure  => file,
   content => 'vagrant ALL=(ALL) ALL',


### PR DESCRIPTION
Signed-off-by: Ken Barber ken@bob.sh
