### PR TITLE
Fixups for travis configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - PUPPET_GEM_VERSION="~> 2.6.0"
   - PUPPET_GEM_VERSION="~> 2.7.0"
   - PUPPET_GEM_VERSION="~> 3.0.0"
+  - PUPPET_GEM_VERSION="~> 3.1.0"
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This adds 3.1.x testing, and constrains the versions more correctly.
