### PR TITLE
Fix versions for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,30 @@ script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
   - ruby-head
 env:
-  - PUPPET_GEM_VERSION="~> 2.6"
-  - PUPPET_GEM_VERSION="~> 2.7"
-  - PUPPET_GEM_VERSION="~> 3.0"
+  - PUPPET_GEM_VERSION="~> 2.6.0"
+  - PUPPET_GEM_VERSION="~> 2.7.0"
+  - PUPPET_GEM_VERSION="~> 3.0.0"
+  - PUPPET_GEM_VERSION="~> 3.1.0"
 matrix:
   allow_failures:
+    - rvm: 2.0.0
     - rvm: ruby-head
+    - env: PUPPET_GEM_VERSION="~> 2.6.0"
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7"
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.7"
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.6"
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
     - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.6"
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class postgresql::params(
   $custom_service_name        = undef,
   $custom_user                = undef,
   $custom_group               = undef,
-  $run_initdb                 = undef,
+  $run_initdb                 = undef
 ) {
   $user                         = pick($custom_user, 'postgres')
   $group                        = pick($custom_group, 'postgres')

--- a/manifests/pg_hba_rule.pp
+++ b/manifests/pg_hba_rule.pp
@@ -13,7 +13,7 @@ define postgresql::pg_hba_rule(
 ) {
   include postgresql::params
 
-  validate_re($type, ['^local$', '^host$', '^hostssl$', '^hostnossl$'],
+  validate_re($type, '^(local|host|hostssl|hostnossl)$',
     "The type you specified [${type}] must be one of: local, host, hostssl, hostnosssl")
   validate_re($auth_method, '^(trust|reject|md5|crypt|password|gss|sspi|krb5|ident|peer|ldap|radius|cert|pam)$',
     "The auth_method you specified [${auth_method}] must be one of: trust, reject, md5, crypt, password, krb5, ident, ldap, pam")


### PR DESCRIPTION
This fixes some mistakes in the .travis.yml file:
- Corrects matches so the minor gem revisions get rounded, this means 2.6.0
  for example is used.
- Adds Ruby 2.0.0 tests
- Allows 2.6.0 to fail for now, as it doesn't have create_resources.
- Removes trailing commas and arrays in functions for 2.6.0.

Signed-off-by: Ken Barber ken@bob.sh
