### PR TITLE
Handle refreshonly correctly

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
 
   def command()
     if ((! resource[:unless]) or (resource[:unless].empty?))
-      if (resource[:refreshonly] && resource[:refreshonly] != :false)
+      if (resource[:refreshonly])
         # So, if there's no 'unless', and we're in "refreshonly" mode,
         # we need to return the target command here.  If we don't,
         # then Puppet will generate an event indicating that this

--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:postgresql_psql) do
       # method, and then inside of the body of 'sync' we can tell
       # whether or not we're refreshing.
 
-      if (!@resource[:refreshonly] || (@resource[:refreshonly] == :false) || refreshing)
+      if (!@resource[:refreshonly] || refreshing)
         # If we're not in 'refreshonly' mode, or we're not currently
         # refreshing, then we just call the parent method.
         super()
@@ -71,7 +71,7 @@ Puppet::Type.newtype(:postgresql_psql) do
   newparam(:refreshonly) do
     desc "If 'true', then the SQL will only be executed via a notify/subscribe event."
 
-    defaultto(:false)
+    defaultto(false)
   end
 
   def refresh()


### PR DESCRIPTION
When not explicitely set to `false`, `refreshonly` was always interpreted as `true`.
