### PR TITLE
Optionally manage postgresqld service

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,7 +26,8 @@ class postgresql::server (
   $service_name     = $postgresql::params::service_name,
   $service_provider = $postgresql::params::service_provider,
   $service_status   = $postgresql::params::service_status,
-  $config_hash      = {}
+  $config_hash      = {},
+  $manage_service   = true
 ) inherits postgresql::params {
 
   package { 'postgresql-server':
@@ -41,14 +42,15 @@ class postgresql::server (
 
   create_resources( 'class', $config_class )
 
-
-  service { 'postgresqld':
-    ensure   => running,
-    name     => $service_name,
-    enable   => true,
-    require  => Package['postgresql-server'],
-    provider => $service_provider,
-    status   => $service_status,
+  if $manage_service {
+    service { 'postgresqld':
+      ensure   => running,
+      name     => $service_name,
+      enable   => true,
+      require  => Package['postgresql-server'],
+      provider => $service_provider,
+      status   => $service_status,
+    }
   }
 
   if ($postgresql::params::needs_initdb) {


### PR DESCRIPTION
When using a cluster resource manager (CRM) such as Pacemaker to manage
a Postgres failover/HA cluster, the CRM should have authority over
starting and stopping the service, not Puppet. The new parameter
'manage_service' allows for that. This is implemented exactly like in
the puppetlabs-mysql module.
