### PR TITLE
Set /tmp as default CWD for postgresql_psql

### DIFF
--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -66,6 +66,7 @@ Puppet::Type.newtype(:postgresql_psql) do
 
   newparam(:cwd, :parent => Puppet::Parameter::Path) do
     desc "The working directory under which the psql command should be executed."
+    defaultto("/tmp")
   end
 
   newparam(:refreshonly) do


### PR DESCRIPTION
This has been discussed in issue #148. The postgresql_psql type doesn't
change the CWD to something safe when running psql as the postgres user.
During a regular puppet run the CWD remains "/root", to which the
postgres user usually does not have access, resulting in failed psql
calls and failed puppet runs. This simple change makes "/tmp" the
default CWD for postgresql_psql.
