### PR TITLE
Adding the ability to create users without a password.

### DIFF
--- a/manifests/database_user.pp
+++ b/manifests/database_user.pp
@@ -38,7 +38,7 @@
 #
 
 define postgresql::database_user(
-  $password_hash,
+  $password_hash    = false,
   $createdb         = false,
   $createrole       = false,
   $db               = $postgresql::params::user,

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 define postgresql::role(
-    $password_hash,
+    $password_hash    = false,
     $createdb         = false,
     $createrole       = false,
     $db               = 'postgres',
@@ -40,9 +40,14 @@ define postgresql::role(
   $createdb_sql    = $createdb    ? { true => 'CREATEDB'    , default => 'NOCREATEDB' }
   $superuser_sql   = $superuser   ? { true => 'SUPERUSER'   , default => 'NOSUPERUSER' }
   $replication_sql = $replication ? { true => 'REPLICATION' , default => '' }
+  if ($password_hash != false) {
+    $password_sql = "ENCRYPTED PASSWORD '${password_hash}'"
+  } else {
+    $password_sql = ""
+  }
 
   # TODO: FIXME: Will not correct the superuser / createdb / createrole / login / replication status nor the connection limit of a role that already exists
-  postgresql_psql {"CREATE ROLE \"${username}\" ENCRYPTED PASSWORD '${password_hash}' ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}":
+  postgresql_psql {"CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}":
     db        => $db,
     psql_user => $postgresql::params::user,
     unless    => "SELECT rolname FROM pg_roles WHERE rolname='${username}'",


### PR DESCRIPTION
Users created with the `createuser` don't have a password by default (unless `-P` is used). When `ident` authentication is used, setting a password is indeed unnecessary.

This patch adds the ability not to need a password hash when creating a new user. Not setting a password is also the default (consistent with `createuser`).
