### PR TITLE
Add explicit call to concat::setup when creating concat file

### DIFF
--- a/manifests/pg_hba.pp
+++ b/manifests/pg_hba.pp
@@ -6,6 +6,7 @@ define postgresql::pg_hba(
   $group = $postgresql::params::group
 ) {
   include postgresql::params
+  include concat::setup
 
   # Collect file from fragments
   concat { $target:


### PR DESCRIPTION
Puppet 2.6 seemed unable to resolve the concat define without it, so make sure setup is called where concat's used.
