### PR TITLE
change auth method validation error message to a maintainable one

### DIFF
--- a/manifests/pg_hba_rule.pp
+++ b/manifests/pg_hba_rule.pp
@@ -16,7 +16,7 @@ define postgresql::pg_hba_rule(
   validate_re($type, '^(local|host|hostssl|hostnossl)$',
     "The type you specified [${type}] must be one of: local, host, hostssl, hostnosssl")
   validate_re($auth_method, '^(trust|reject|md5|crypt|password|gss|sspi|krb5|ident|peer|ldap|radius|cert|pam)$',
-    "The auth_method you specified [${auth_method}] must be one of: trust, reject, md5, crypt, password, krb5, ident, ldap, pam")
+    "The auth_method you specified [${auth_method}] must be a valid client authentication method")
 
   if($type =~ /^host/ and $address == undef) {
     fail('You must specify an address property when type is host based')

--- a/spec/unit/defines/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/pg_hba_rule_spec.rb
@@ -97,7 +97,7 @@ describe 'postgresql::pg_hba_rule', :type => :define do
       end
       it 'should fail parsing when auth_method is not valid' do
         expect {subject}.to raise_error(Puppet::Error,
-          /The auth_method you specified \[invalid\] must be one of/)
+          /The auth_method you specified \[invalid\] must be a valid client authentication method/)
       end
     end
   end


### PR DESCRIPTION
Maintainable auth method validation error message that also doesn't list improper authentication methods for some PostgreSQL versions
