### PR TITLE
Add default PostgreSQL version for Ubuntu 13.04

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -23,7 +23,7 @@ end
 
 def get_ubuntu_postgres_version
   case Facter.value('operatingsystemrelease')
-    when "11.10", "12.04", "12.10"
+    when "11.10", "12.04", "12.10", "13.04"
       "9.1"
     when "10.04", "10.10", "11.04"
       "8.4"


### PR DESCRIPTION
Module release before 25th April (Ubuntu 13.04 release date) is advisable.
