### PR TITLE
Increase stdlib dependency to include 5.x

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,7 +7,7 @@ summary 'PostgreSQL defined resource types'
 license 'Apache'
 project_page 'https://github.com/puppetlabs/puppet-postgresql'
 
-dependency 'puppetlabs/stdlib', '>=3.2.0 <4.0.0'
+dependency 'puppetlabs/stdlib', '>=3.2.0 <5.0.0'
 dependency 'puppetlabs/firewall', '>= 0.0.4'
 dependency 'puppetlabs/apt', '>=1.1.0 <2.0.0'
 dependency 'ripienaar/concat', '>= 0.2.0'


### PR DESCRIPTION
Without this patch, librarian-puppet will do strange things like roll back
the version of puppetdb to version 1.0.1 to satisfy all constraints.

Signed-off-by: Ken Barber ken@bob.sh
