### PR TITLE
set LANG=C in environment

### DIFF
--- a/manifests/initdb.pp
+++ b/manifests/initdb.pp
@@ -36,11 +36,12 @@ class postgresql::initdb(
   # This runs the initdb command, we use the existance of the PG_VERSION file to
   # ensure we don't keep running this command.
   exec { 'postgresql_initdb':
-    command   => $initdb_command,
-    creates   => "${datadir}/PG_VERSION",
-    user      => $user,
-    group     => $group,
-    logoutput => on_failure,
+    command     => $initdb_command,
+    creates     => "${datadir}/PG_VERSION",
+    user        => $user,
+    group       => $group,
+    environment => 'LANG=C',
+    logoutput   => on_failure,
   }
 
   # If we manage the package (which is user configurable) make sure the


### PR DESCRIPTION
Without this patch, initdb would not work for me.

<pre>
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) initdb: encoding mismatch
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) The encoding you selected (UTF8) and the encoding that the
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) selected locale uses (LATIN1) do not match.  This would lead to
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) misbehavior in various character string processing functions.
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) Rerun initdb and either do not specify an encoding explicitly,
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) or choose a matching combination.
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) The files belonging to this database system will be owned by user "postgres".
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) This user must also own the server process.
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) The database cluster will be initialized with locales
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   COLLATE:  C
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   CTYPE:    en_US
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   MESSAGES: C
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   MONETARY: en_US
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   NUMERIC:  en_US
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns)   TIME:     C
/usr/bin/initdb --encoding 'UTF8' --pgdata '/var/lib/pgsql/data' returned 1 instead of one of [0]
(/Stage[main]/Postgresql::Initdb/Exec[postgresql_initdb]/returns) change from notrun to 0 failed: /usr/bin/initdb --encoding 'UTF8' --pgdata '/var/lib/pgsql/data' returned 1 instead of one of [0]
</pre>
