### PR TITLE
Add support for other operating systems besides Redhat/Debian

### DIFF
--- a/manifests/contrib.pp
+++ b/manifests/contrib.pp
@@ -19,6 +19,8 @@ class postgresql::contrib (
   $package_ensure = 'present'
 ) inherits postgresql::params {
 
+  validate_string($package_name)
+
   package { 'postgresql-contrib':
     ensure => $package_ensure,
     name   => $package_name,

--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -17,6 +17,8 @@ class postgresql::devel(
   $package_ensure = 'present'
 ) inherits postgresql::params {
 
+  validate_string($package_name)
+
   package { 'postgresql-devel':
     ensure => $package_ensure,
     name   => $package_name,

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -19,6 +19,8 @@ class postgresql::java (
   $package_ensure = 'present'
 ) inherits postgresql::params {
 
+  validate_string($package_name)
+
   package { 'postgresql-jdbc':
     ensure => $package_ensure,
     name   => $package_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,6 @@ class postgresql::params(
   # TODO: figure out a way to make this not platform-specific
   $manage_redhat_firewall       = false
 
-
   if ($manage_package_repo) {
     case $::osfamily {
       'RedHat': {
@@ -175,7 +174,59 @@ class postgresql::params(
     }
 
     default: {
-      fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports osfamily RedHat and Debian")
+
+      $err_msg_prefix = "Module ${module_name} does not provide defaults for osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}; please specify a value for ${module_name}::params::"
+
+      if ($run_initdb != undef) {
+        $needs_initdb = $run_initdb
+      } else {
+        fail("${err_msg_prefix}run_initdb")
+      }
+
+      $firewall_supported = false
+
+      if ($custom_service_name) {
+        $service_name = $custom_service_name
+      } else {
+        fail("${err_msg_prefix}custom_service_name")
+      }
+
+      if ($custom_client_package_name) {
+        $client_package_name = $custom_client_package_name
+      } else {
+        fail("${err_msg_prefix}custom_client_package_name")
+      }
+
+      if ($custom_server_package_name) {
+        $server_package_name = $custom_server_package_name
+      } else {
+        fail("${err_msg_prefix}custom_server_package_name")
+      }
+
+
+      $contrib_package_name = $custom_contrib_package_name
+      $devel_package_name = $custom_devel_package_name
+      $java_package_name = $custom_java_package_name
+
+      if ($custom_bindir) {
+        $bindir = $custom_bindir
+      } else {
+        fail("${err_msg_prefix}custom_bindir")
+      }
+
+      if ($custom_datadir) {
+        $datadir = $custom_datadir
+      } else {
+        fail("${err_msg_prefix}custom_datadir")
+      }
+
+      if ($custom_confdir) {
+        $confdir = $custom_confdir
+      } else {
+        fail("${err_msg_prefix}custom_confdir")
+      }
+
+      $service_status = undef
     }
   }
 

--- a/spec/unit/classes/postgresql_java_spec.rb
+++ b/spec/unit/classes/postgresql_java_spec.rb
@@ -35,16 +35,4 @@ describe 'postgresql::java', :type => :class do
     end
   end
 
-  describe 'on any other os' do
-    let :facts do {
-      :osfamily                 => 'foo',
-      :postgres_default_version => 'foo',
-    }
-    end
-
-    it 'should fail' do
-      expect { subject }.to raise_error(/Unsupported osfamily: foo/)
-    end
-  end
-
 end

--- a/spec/unit/classes/postgresql_python_spec.rb
+++ b/spec/unit/classes/postgresql_python_spec.rb
@@ -26,16 +26,4 @@ describe 'postgresql::python', :type => :class do
     )}
   end
 
-  describe 'on any other os' do
-    let :facts do {
-      :osfamily                 => 'foo',
-      :postgres_default_version => 'foo',
-    }
-    end
-
-    it 'should fail' do
-      expect { subject }.to raise_error(/Unsupported osfamily: foo/)
-    end
-  end
-
 end


### PR DESCRIPTION
Prior to this commit, if you attempted to use the module to
manage postgres on any OS other than Redhat/Debian, there
was an explicit check for that, and a call to `fail`.

In reality, the OS family is only used to build up defaults
for various path and package names, which are all exposed
as parameters.  If the user is willing to explicitly pass
in all of those parameters, there's no reason we should
fail based on OS family.

This commit adds checks to the 'default' osfamily case
such that we now only fail if they're on a non-Redhat-or-Debian
system _and_ they haven't explicitly passed in values for
all of the required parameters.
