### PR TITLE
Fix the non-defaults test failing to use UTF8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 metadata.json
 spec/fixtures
 pkg/
+.rspec_system/


### PR DESCRIPTION
The non-default tests try to set UTF8 when UTF8 is not installed on the en_US
machine. These are non-default settings anyway, but one should presume the
correct locale should be set before this is attempted, this patch includes
that step.

In an ideal world we would use a locale module to do this.

This patch also fixes an Ubuntu 10.04 issue where you need to be absolute about
the locale and encoding as well.

Signed-off-by: Ken Barber ken@bob.sh
