### PR TITLE
Adds correct user permissions for postgresql_puppet_extras.conf

### DIFF
--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -126,8 +126,12 @@ class postgresql::config::beforeservice(
   if(versioncmp($postgresql::params::version, '8.2') >= 0) {
     # Since we're adding an "include" for this extras config file, we need
     # to make sure it exists.
+    # This is created by an exec rather than a file resource so that users can
+    # manage this seperately with a file resource and not have a duplicate 
+    # definition failure.
     exec { "create_postgresql_conf_path":
       command => "touch `dirname ${postgresql_conf_path}`/postgresql_puppet_extras.conf",
+      user    => $postgresql::params::user,
       path    => '/usr/bin:/bin',
       unless  => "[ -f `dirname ${postgresql_conf_path}`/postgresql_puppet_extras.conf ]"
     }


### PR DESCRIPTION
This fixes issue #181 where servers with restrictive umask entries create
the postgresql_puppet_extras.conf file owned by root with 600 permissions.

This file will now be created and owned by postgres user.

I've also added in extra documentation around why an exec is used rather than
a file resource and the only reason I can think of is that if someone attempted
to manage this file with a personal manifest they would then encounter duplicate
file definitions.
