### PR TITLE
Tag the postgresql-contrib package as postgresql

### DIFF
--- a/manifests/contrib.pp
+++ b/manifests/contrib.pp
@@ -24,5 +24,6 @@ class postgresql::contrib (
   package { 'postgresql-contrib':
     ensure => $package_ensure,
     name   => $package_name,
+    tag    => 'postgresql',
   }
 }


### PR DESCRIPTION
Correctly tag the postgresql-contrib. 

Due to the missing tag the installation can fail the first time on precise if PGDG repository is used.
