### PR TITLE
pgdg-keyring package requires pgpg repository

### DIFF
--- a/manifests/package_source/apt_postgresql_org.pp
+++ b/manifests/package_source/apt_postgresql_org.pp
@@ -11,10 +11,14 @@ class postgresql::package_source::apt_postgresql_org {
     location          => 'http://apt.postgresql.org/pub/repos/apt/',
     release           => "${::lsbdistcodename}-pgdg",
     repos             => 'main',
-    required_packages => 'pgdg-keyring',
     key               => 'ACCC4CF8',
     key_source        => 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc',
     include_src       => false,
+  }
+
+  package { 'pgdg-keyring':
+    ensure => latest,
+    tag    => 'postgresql',
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>


### PR DESCRIPTION
Putting pgdg-keyring in required_packages parameter is a kind of circular dependency as the apt::source resource will try to install it before to add the apt source line.

However the pgpd-keyring package is not really required for the very first run, because of key and key_source parameters.

Moving it to a separate package resource will avoid the error.
