### PR TITLE
Add support to custom xlogdir parameter to postgresql::initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ This will set the default charset for all databases created with this module. On
 ####`datadir`
 This setting can be used to override the default postgresql data directory for the target platform. If not specified, the module will use whatever directory is the default for your OS distro.
 
+####`xlogdir`
+This setting can be used to override the default postgresql xlog directory location. If not specified, the module will use the pg_xlog directory in data directory.
+
 ####`confdir`
 This setting can be used to override the default postgresql configuration directory for the target platform. If not specified, the module will use whatever directory is the default for your OS distro.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,10 @@
 #    data directory for the target platform. If not specified, the
 #    module will use whatever directory is the default for your
 #    OS distro.
+# [*xlogdir*]
+#    This setting can be used to override the default postgresql
+#    xlog directory location. If not specified, the
+#    module will use the pg_xlog directory in data directory.
 # [*confdir*]
 #    This setting can be used to override the default postgresql
 #    configuration directory for the target platform. If not
@@ -110,6 +114,7 @@ class postgresql (
   $locale               = undef,
   $charset              = 'UTF8',
   $datadir              = undef,
+  $xlogdir              = undef,
   $confdir              = undef,
   $bindir               = undef,
   $client_package_name  = undef,
@@ -130,6 +135,7 @@ class postgresql (
     locale                      => $locale,
     charset                     => $charset,
     custom_datadir              => $datadir,
+    xlogdir                     => $xlogdir,
     custom_confdir              => $confdir,
     custom_bindir               => $bindir,
     custom_client_package_name  => $client_package_name,

--- a/manifests/initdb.pp
+++ b/manifests/initdb.pp
@@ -25,12 +25,16 @@ class postgresql::initdb(
 ) inherits postgresql::params {
   # Build up the initdb command.
   #
+  $xlogdir_param = $postgresql::params::xlogdir ? {
+    undef   => '',
+    default => "--xlogdir '${postgresql::params::xlogdir}'"
+  }
   # We optionally add the locale switch if specified. Older versions of the
   # initdb command don't accept this switch. So if the user didn't pass the
   # parameter, lets not pass the switch at all.
   $initdb_command = $postgresql::params::locale ? {
-    undef   => "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'",
-    default => "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}' --locale '${postgresql::params::locale}'"
+    undef   => "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}' ${xlogdir_param}",
+    default => "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}' ${xlogdir_param} --locale '${postgresql::params::locale}'"
   }
 
   # This runs the initdb command, we use the existance of the PG_VERSION file to

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class postgresql::params(
   $locale                      = undef,
   $charset                     = 'UTF8',
   $custom_datadir              = undef,
+  $xlogdir                     = undef,
   $custom_confdir              = undef,
   $custom_bindir               = undef,
   $custom_client_package_name  = undef,


### PR DESCRIPTION
Having a custom xlogdir location is desiderable for performances in many production environments
