### PR TITLE
Add manage_postgresql_conf flag to avoid config customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ This value defaults to `localhost`, meaning the postgres server will only accept
 ####`manage_redhat_firewall`
 This value defaults to `false`. Many RedHat-based distros ship with a fairly restrictive firewall configuration which will block the port that postgres tries to listen on. If you’d like for the puppet module to open this port for you (using the [puppetlabs-firewall](http://forge.puppetlabs.com/puppetlabs/firewall) module), change this value to true. *[This parameter is likely to change in future versions.  Possible changes include support for non-RedHat systems and finer-grained control over the firewall rule (currently, it simply opens up the postgres port to all TCP connections).]*
 
+####`manage_postgresql_conf`
+This value defaults to `true`. Whether or not manage the postgresql.conf. If set to `true`, puppet will add lines to this file and create the `postgresql_puppet_extras.conf` file in the same directory. If set to `false`, puppet will not modify the file.
+
 ####`manage_pg_hba_conf`
 This value defaults to `true`. Whether or not manage the pg_hba.conf. If set to `true`, puppet will overwrite this file. If set to `false`, puppet will not modify the file.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,8 @@
 #                                       redhat-based systems; this parameter is likely to change in future versions.  Possible
 #                                       changes include support for non-RedHat systems and finer-grained control over the
 #                                       firewall rule (currently, it simply opens up the postgres port to all TCP connections).
-#   [*manage_pg_hba_conf*]      - boolean indicating whether or not the module manages pg_hba.conf file.
+#   [*manage_postgresql_conf*]       - boolean indicating whether or not the module manages postgresql.conf file.
+#   [*manage_pg_hba_conf*]           - boolean indicating whether or not the module manages pg_hba.conf file.
 #
 #
 # Actions:
@@ -43,6 +44,7 @@ class postgresql::config(
   $pg_hba_conf_path           = $postgresql::params::pg_hba_conf_path,
   $postgresql_conf_path       = $postgresql::params::postgresql_conf_path,
   $manage_redhat_firewall     = $postgresql::params::manage_redhat_firewall,
+  $manage_postgresql_conf     = $postgresql::params::manage_postgresql_conf,
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf
 ) inherits postgresql::params {
 
@@ -59,6 +61,7 @@ class postgresql::config(
     pg_hba_conf_path           => $pg_hba_conf_path,
     postgresql_conf_path       => $postgresql_conf_path,
     manage_redhat_firewall     => $manage_redhat_firewall,
+    manage_postgresql_conf     => $manage_postgresql_conf,
     manage_pg_hba_conf         => $manage_pg_hba_conf,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,14 @@
 #    the postgresql service is started. If not specified, the
 #    module will decide whether to call initdb or not depending
 #    on your OS distro.
+# [*manage_postgresql_conf*]
+#    This determines whether or not the module should
+#    attempt to manage the postgres.conf file.
+#    Defaults to `true`.
+# [*manage_pg_hba_conf*]
+#    This determines whether or not the module should
+#    attempt to manage the pg_hba.conf file.
+#    Defaults to `true`.
 #
 # === Examples
 #
@@ -104,23 +112,25 @@
 #
 #
 class postgresql (
-  $version              = $::postgres_default_version,
-  $manage_package_repo  = false,
-  $package_source       = undef,
-  $locale               = undef,
-  $charset              = 'UTF8',
-  $datadir              = undef,
-  $confdir              = undef,
-  $bindir               = undef,
-  $client_package_name  = undef,
-  $server_package_name  = undef,
-  $contrib_package_name = undef,
-  $devel_package_name   = undef,
-  $java_package_name    = undef,
-  $service_name         = undef,
-  $user                 = undef,
-  $group                = undef,
-  $run_initdb           = undef
+  $version                = $::postgres_default_version,
+  $manage_package_repo    = false,
+  $package_source         = undef,
+  $locale                 = undef,
+  $charset                = 'UTF8',
+  $datadir                = undef,
+  $confdir                = undef,
+  $bindir                 = undef,
+  $client_package_name    = undef,
+  $server_package_name    = undef,
+  $contrib_package_name   = undef,
+  $devel_package_name     = undef,
+  $java_package_name      = undef,
+  $service_name           = undef,
+  $user                   = undef,
+  $group                  = undef,
+  $run_initdb             = undef,
+  $manage_postgresql_conf = true,
+  $manage_pg_hba_conf     = true
 ) {
 
   class { 'postgresql::params':
@@ -141,5 +151,7 @@ class postgresql (
     custom_user                 => $user,
     custom_group                => $group,
     run_initdb                  => $run_initdb,
+    manage_postgresql_conf      => $manage_postgresql_conf,
+    manage_pg_hba_conf          => $manage_pg_hba_conf,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,9 @@ class postgresql::params(
   $custom_service_name         = undef,
   $custom_user                 = undef,
   $custom_group                = undef,
-  $run_initdb                  = undef
+  $run_initdb                  = undef,
+  $manage_postgresql_conf      = true,
+  $manage_pg_hba_conf          = true
 ) {
   $user                         = pick($custom_user, 'postgres')
   $group                        = pick($custom_group, 'postgres')
@@ -54,7 +56,6 @@ class postgresql::params(
   $listen_addresses             = 'localhost'
   $ipv4acls                     = []
   $ipv6acls                     = []
-  $manage_pg_hba_conf           = true
   # TODO: figure out a way to make this not platform-specific
   $manage_redhat_firewall       = false
 


### PR DESCRIPTION
This patch adds support for disabling management of postgresql.conf by the module, through the parameter `manage_postgresql_conf`.
