### PR TITLE
$password_hash was not being encrypted

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -81,7 +81,7 @@ define postgresql::role(
 
   if $password_hash {
     postgresql_psql {"ALTER ROLE \"${username}\" ${password_sql}":
-      unless => "SELECT usename FROM pg_shadow WHERE usename='${username}' and passwd='${password_hash}'",
+      unless => "SELECT usename FROM pg_shadow WHERE usename='${username}' and passwd = 'md5' || md5('${password_hash}' || '${username}')"
     }
   }
 }


### PR DESCRIPTION
Fixes puppetlabs/puppetlabs-postgresql#216 where $password_hash was not being encrypted which caused an ALTER ROLE to be run every time the puppet agent runs. Also Fixes puppetlabs/puppetlabs-puppetdb#72 downstream.
