### PR TITLE
$password_hash not being encrypted when sent to postgresql::database_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ There are many ways to set up a postgres database using the `postgresql::db` cla
 To manage users, roles and permissions:
 
     postgresql::database_user{'marmot':
-      password_hash => 'foo',
+      password_hash => postgresql_password('marmot', 'foo'),
     }
 
     postgresql::database_grant { 'test1':

--- a/manifests/database_user.pp
+++ b/manifests/database_user.pp
@@ -22,7 +22,7 @@
 #
 # Parameters:
 #   [*user*]             - username to create.
-#   [*password_hash*]    - user's password; this may be clear text, or an md5 hash as returned by the
+#   [*password_hash*]    - user's password; this must be an md5 hash as returned by the
 #                           "postgresql_password" function in this module.
 #
 # Actions:

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -12,8 +12,7 @@
 # Parameters:
 #   [*title*]       - postgresql database name.
 #   [*user*]        - username to create and grant access.
-#   [*password*]    - user's password.  may be md5-encoded, in the format returned by the "postgresql_password"
-#                            function in this module
+#   [*password*]    - user's password.  must be plain text
 #   [*charset*]     - database charset. defaults to 'utf8'
 #   [*grant*]       - privilege to grant user. defaults to 'all'.
 #   [*tablespace*]  - database tablespace. default to use the template database's tablespace.
@@ -59,7 +58,7 @@ define postgresql::db (
     postgresql::database_user { $user:
       # TODO: ensure is not yet supported
       #ensure         => present,
-      password_hash   => $password,
+      password_hash   => postgresql_password($user, $password),
       #provider       => 'postgresql',
       require         => Postgresql::Database[$name],
     }


### PR DESCRIPTION
Fixes #216 where $password_hash was not being encrypted which caused an ALTER ROLE to be run every time the puppet agent runs. Also Fixes puppetlabs/puppetlabs-puppetdb#72 downstream.

Because of this fix, the postgresql::db::password parameter MUST be passed in plain text. This may be undesirable for some/most. Perhaps there should be an option to either send the password as a hash as well as plain text, OR change the postgresql::db::password to postgresql::db::password_hash and require it to be sent as a hash.
