### PR TITLE
initial suse/opensuse support for postgresql

### DIFF
--- a/lib/facter/postgres_default_version.rb
+++ b/lib/facter/postgres_default_version.rb
@@ -43,6 +43,26 @@ def get_redhatfamily_postgres_version
   end
 end
 
+def get_susefamily_postgres_version
+  case Facter.value('operatingsystem')
+  when "OpenSuSE" 
+    case Facter.value('operatingsystemrelease')
+    when "12.3"
+      "9.2"
+    else
+      nil
+    end
+  when "SLES"
+    case Facter.value('operatingsystemrelease')
+    when /^11\./
+      "8.3"
+    else
+      nil
+    end
+  end
+end
+
+
 Facter.add("postgres_default_version") do
   setcode do
     result =
@@ -53,6 +73,8 @@ Facter.add("postgres_default_version") do
           get_redhatfamily_postgres_version()
         when 'Debian'
           get_debianfamily_postgres_version()
+        when 'Suse'
+          get_susefamily_postgres_version()
         else
           nil
       end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -139,7 +139,49 @@ class postgresql::params(
       $service_status = undef
       $python_package_name="python-psycopg2"
     }
+    'Suse': {
+      $needs_initdb = pick($run_initdb, true)
+      $firewall_supported = false
 
+      if $version == $::postgres_default_version {
+        $client_package_name = pick($custom_client_package_name, 'postgresql')
+        $server_package_name = pick($custom_server_package_name, 'postgresql-server'
+        )
+        $contrib_package_name = pick($custom_contrib_package_name, 'postgresql-contrib'
+        )
+        $devel_package_name = pick($custom_devel_package_name, 'postgresql-devel'
+        )
+        $java_package_name = pick($custom_java_package_name, 'postgresql-jdbc')
+        $plperl_package_name = pick($custom_plperl_package_name, 'postgresql-plperl'
+        )
+        $service_name = pick($custom_service_name, 'postgresql')
+        $bindir = pick($custom_bindir, '/usr/bin')
+        $datadir = pick($custom_datadir, '/var/lib/pgsql/data')
+        $confdir = pick($custom_confdir, $datadir)
+      } else {
+        $version_parts = split($version, '[.]')
+        $package_version = "${version_parts[0]}${version_parts[1]}"
+        $client_package_name = pick($custom_client_package_name, "postgresql${package_version}"
+        )
+        $server_package_name = pick($custom_server_package_name, "postgresql${package_version}-server"
+        )
+        $contrib_package_name = pick($custom_contrib_package_name, "postgresql${package_version}-contrib"
+        )
+        $devel_package_name = pick($custom_devel_package_name, "postgresql${package_version}-devel"
+        )
+        $java_package_name = pick($custom_java_package_name, "postgresql${package_version}-jdbc"
+        )
+        $plperl_package_name = pick($custom_plperl_package_name, "postgresql${package_version}-plperl"
+        )
+        $service_name = pick($custom_service_name, "postgresql")
+        $bindir = pick($custom_bindir, "/usr/pgsql/bin")
+        $datadir = pick($custom_datadir, "/var/lib/pgsql/data")
+        $confdir = pick($custom_confdir, $datadir)
+      }
+
+      $service_status = undef
+      $python_package_name = "python-psycopg2"
+    }
     'Debian': {
       $firewall_supported       = false
       # TODO: not exactly sure yet what the right thing to do for Debian/Ubuntu is.


### PR DESCRIPTION
This will give postgresql module initial opensuse/suse support

postgres_default_version.rb needs more versions to be really usefull for opensuse/suse
but it should be fairly easy to add more versions.

tested against:
- opensuse 12.3
- Suse Linux Enterprise 11 SP2
