### PR TITLE
(GH-216) Alter role call not idempotent with cleartext passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'rake'
   gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-system-puppet', '~>1.0'
-  gem 'rspec-system', '>=1.2.1'
+  gem 'rspec-system-puppet', '~>2.0'
   gem 'puppet-lint', '~> 0.3.2'
 end
 

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -17,15 +17,15 @@
 # limitations under the License.
 
 define postgresql::role(
-    $password_hash    = false,
-    $createdb         = false,
-    $createrole       = false,
-    $db               = 'postgres',
-    $login            = false,
-    $superuser        = false,
-    $replication      = false,
-    $connection_limit = '-1',
-    $username         = $title
+  $password_hash    = false,
+  $createdb         = false,
+  $createrole       = false,
+  $db               = 'postgres',
+  $login            = false,
+  $superuser        = false,
+  $replication      = false,
+  $connection_limit = '-1',
+  $username         = $title
 ) {
   include postgresql::params
 
@@ -80,8 +80,14 @@ define postgresql::role(
   }
 
   if $password_hash {
+    if($password_hash =~ /^md5.+/) {
+      $pwd_hash_sql = $password_hash
+    } else {
+      $pwd_md5 = md5("${password_hash}${username}")
+      $pwd_hash_sql = "md5${pwd_md5}"
+    }
     postgresql_psql {"ALTER ROLE \"${username}\" ${password_sql}":
-      unless => "SELECT usename FROM pg_shadow WHERE usename='${username}' and passwd='${password_hash}'",
+      unless => "SELECT usename FROM pg_shadow WHERE usename='${username}' and passwd='${pwd_hash_sql}'",
     }
   }
 }

--- a/spec/system/non_defaults_spec.rb
+++ b/spec/system/non_defaults_spec.rb
@@ -56,9 +56,9 @@ describe 'non defaults:' do
         # Currently puppetlabs/apt shows deprecated messages
         #r.stderr.should be_empty
         [2,6].should include(r.exit_code)
-      end
 
-      puppet_apply(pp) do |r|
+        r.refresh
+
         # Currently puppetlabs/apt shows deprecated messages
         #r.stderr.should be_empty
         # It also returns a 4
@@ -90,9 +90,9 @@ describe 'non defaults:' do
         #r.stderr.should be_empty
         # It also returns a 6
         [2,6].should include(r.exit_code)
-      end
 
-      puppet_apply(pp) do |r|
+        r.refresh
+
         # Currently puppetlabs/apt shows deprecated messages
         #r.stderr.should be_empty
         # It also returns a 2


### PR DESCRIPTION
The postgresql::role defined type was not idempotent when passed cleartext
passwords. This is because we were comparing it with its md5 equivalent in
the db.

This patch converts any cleartext passwords to md5 before comparison, but
only if they are cleartext (ie. not starting with md5).

I also bumped the version of rspec-system-puppet to get use of the refresh
method, plus did some cleanup because the old tests were a bit dusty, again
taking advantage of refresh plus changing some matchers for clarity.

Signed-off-by: Ken Barber ken@bob.sh
