### PR TITLE
Add support for updating database charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ Grant permissions during creation. Defaults to `ALL`.
 ####`istemplate`
 Define database as a template. Defaults to `false`.
 
+####`update_charset`
+Update database charset if set to `true`. Defaults to `false`.
+
 ###Resource: postgresql::database
 This defined type can be used to create a database with no users and no permissions, which is a rare use case.
 
@@ -348,6 +351,9 @@ Override the locale during creation of the database. Defaults to the default def
 
 ####`istemplate`
 Define database as a template. Defaults to `false`.
+
+####`update_charset`
+Update database charset if set to `true`. Defaults to `false`.
 
 ###Resource: postgresql::database\_grant
 This defined type manages grant based access privileges for users. Consult the PostgreSQL documentation for `grant` for more information.

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -36,23 +36,25 @@
 define postgresql::db (
   $user,
   $password,
-  $charset    = $postgresql::params::charset,
-  $locale     = $postgresql::params::locale,
-  $grant      = 'ALL',
-  $tablespace = undef,
-  $istemplate = false
+  $charset        = $postgresql::params::charset,
+  $locale         = $postgresql::params::locale,
+  $grant          = 'ALL',
+  $tablespace     = undef,
+  $istemplate     = false,
+  $update_charset = false
 ) {
   include postgresql::params
 
   postgresql::database { $name:
     # TODO: ensure is not yet supported
-    #ensure    => present,
-    charset    => $charset,
-    tablespace => $tablespace,
-    #provider  => 'postgresql',
-    require    => Class['postgresql::server'],
-    locale     => $locale,
-    istemplate => $istemplate,
+    #ensure        => present,
+    charset        => $charset,
+    tablespace     => $tablespace,
+    #provider      => 'postgresql',
+    require        => Class['postgresql::server'],
+    locale         => $locale,
+    istemplate     => $istemplate,
+    update_charset => $update_charset,
   }
 
   if ! defined(Postgresql::Database_user[$user]) {


### PR DESCRIPTION
When you install postgresql package via puppet on Debian, it uses 'C' as locales and thus creates templates databases with SQL_ASCII instead of UTF8. We could ensure that templates charset is really set to default with:

``` puppet
postgresql::database { ['template0', 'template1', 'postgres']:
  update_charset => true,
  istemplate => true
}
```
