### PR TITLE
Support apt.postgresql.org version specific packages.

### DIFF
--- a/manifests/package_source/apt_postgresql_org.pp
+++ b/manifests/package_source/apt_postgresql_org.pp
@@ -1,4 +1,6 @@
-class postgresql::package_source::apt_postgresql_org {
+class postgresql::package_source::apt_postgresql_org (
+  $version
+) {
   # Here we have tried to replicate the instructions on the PostgreSQL site:
   #
   # http://www.postgresql.org/download/linux/debian/
@@ -10,7 +12,7 @@ class postgresql::package_source::apt_postgresql_org {
   apt::source { 'apt.postgresql.org':
     location          => 'http://apt.postgresql.org/pub/repos/apt/',
     release           => "${::lsbdistcodename}-pgdg",
-    repos             => 'main',
+    repos             => "main ${version}",
     required_packages => 'pgdg-keyring',
     key               => 'ACCC4CF8',
     key_source        => 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,9 @@ class postgresql::params(
       }
 
       'Debian': {
-        class { 'postgresql::package_source::apt_postgresql_org': }
+        class { 'postgresql::package_source::apt_postgresql_org':
+          version => $version
+        }
       }
 
       default: {


### PR DESCRIPTION
To use packages of postgresql-9.3 in apt.postgresql.org (while it is still in beta or release candidate state), you need to add the 9.3 component to your /etc/apt/sources.list.d/pgdg.list entry, so the 9.3 version of libpq5 will be available for installation.

For stable version this change will make available the libpq package for that specific version (that will not hurts)
