### PR TITLE
add search_path attribute to postgresql_psql resource

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -51,6 +51,10 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
   end
 
   def run_sql_command(sql)
+    if resource[:search_path]
+      sql = "set search_path to #{Array(resource[:search_path]).join(',')}; #{sql}"
+    end
+
     command = [resource[:psql_path]]
     command.push("-d", resource[:db]) if resource[:db]
     command.push("-t", "-c", sql)

--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -49,6 +49,10 @@ Puppet::Type.newtype(:postgresql_psql) do
     desc "The name of the database to execute the SQL command against."
   end
 
+  newparam(:search_path) do
+    desc "The schema search path to use when executing the SQL command"
+  end
+
   newparam(:psql_path) do
     desc "The path to psql executable."
     defaultto("psql")

--- a/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
@@ -40,6 +40,35 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
         provider.run_sql_command("SELECT something")
       end
     end
+    describe "with search_path string" do
+      let(:attributes) do {
+        :search_path => "schema1"
+      } end
+
+      it "executes with the given search_path" do
+        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
+          ['psql', '-t', '-c', 'set search_path to schema1; SELECT something'],
+          'postgres',
+          'postgres'
+        )
+        provider.run_sql_command("SELECT something")
+      end
+    end
+    describe "with search_path array" do
+      let(:attributes) do {
+        :search_path => ['schema1','schema2'],
+      } end
+
+      it "executes with the given search_path" do
+        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
+          ['psql', '-t', '-c', 'set search_path to schema1,schema2; SELECT something'],
+          'postgres',
+          'postgres'
+        )
+        provider.run_sql_command("SELECT something")
+      end
+    end
+
   end
 
   context("#command") do

--- a/spec/unit/puppet/type/postgresql_psql_spec.rb
+++ b/spec/unit/puppet/type/postgresql_psql_spec.rb
@@ -30,6 +30,7 @@ describe Puppet::Type.type(:postgresql_psql), :unless => Puppet.features.microso
       :psql_group  => "postgres",
       :cwd         => "/var/lib",
       :refreshonly => :true,
+      :search_path => [ "schema1", "schema2"]
     }.each do |attr, value|
       context attr do
         let(:attributes) do { attr => value } end


### PR DESCRIPTION
This allows you to set a schema search_path on postgresql_psql
resources, in case you have multiple schemas in your database and the
SQL you are trying to run requires a different path
