### PR TITLE
Remove trailing comma which breaks 2.6 compat

### DIFF
--- a/manifests/config/beforeservice.pp
+++ b/manifests/config/beforeservice.pp
@@ -47,7 +47,7 @@ class postgresql::config::beforeservice(
   $ipv6acls                   = $postgresql::params::ipv6acls,
   $manage_redhat_firewall     = $postgresql::params::manage_redhat_firewall,
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
-  $persist_firewall_command   = $postgresql::params::persist_firewall_command,
+  $persist_firewall_command   = $postgresql::params::persist_firewall_command
 ) inherits postgresql::params {
 
 


### PR DESCRIPTION
I saw you dropped 2.6 from the test matrix, so I figured you'd want a heads up on this :)
