### PR TITLE
Support apt.postgresql.org version specific packages.

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -12,7 +12,7 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
     apt::source { 'apt.postgresql.org':
       location          => 'http://apt.postgresql.org/pub/repos/apt/',
       release           => "${::lsbdistcodename}-pgdg",
-      repos             => 'main',
+      repos             => "main ${version}",
       key               => 'ACCC4CF8',
       key_source        => 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc',
       include_src       => false,


### PR DESCRIPTION
This change will allow to test beta and release candidate version of
postgres from apt.postgresql.org.

For stable version this change will make available the libpq package
for that specific version (that will not hurts).
