### PR TITLE
Defined $default_version for Fedora 17

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -48,6 +48,7 @@ class postgresql::globals (
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
         /^(18|19|20)$/ => '9.2',
+        /^(17)$/ => '9.1',
         default => undef,
       },
       default => $::operatingsystemrelease ? {


### PR DESCRIPTION
I have not actually tested this.  I based it off
of http://distrowatch.org/table.php?distribution=fedora

Closes #90
