### PR TITLE
enable setting the postgres user's password without resetting the password on every puppet run

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -56,12 +56,19 @@ class postgresql::server::config {
           auth_option => $local_auth_option,
           order       => '002',
         }
+        postgresql::server::pg_hba_rule { 'allow localhost TCP access to postgresql user':
+          type        => 'host',
+          user        => $user,
+          address     => '127.0.0.1/32',
+          auth_method => 'md5',
+          order       => '003',
+        }
         postgresql::server::pg_hba_rule { 'deny access to postgresql user':
           type        => 'host',
           user        => $user,
           address     => $ip_mask_deny_postgres_user,
           auth_method => 'reject',
-          order       => '003',
+          order       => '004',
         }
 
         # ipv4acls are passed as an array of rule strings, here we transform


### PR DESCRIPTION
this update is based on @mattyindustries idea from issue #92 https://github.com/puppetlabs/puppetlabs-postgresql/issues/92)

the underlying issue is that the default pg_hba.conf configuration doesn't allow TCP-based connections from the postgres user; unf. these are exactly the connections used by the password-testing functionality in postgresql::server::passwd

This worked fine on Puppet 3.1.1 on Ubuntu 12.04 LTS
