### PR TITLE
Remove deprecated and unused parameters to concat::fragment

### DIFF
--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -47,8 +47,6 @@ define postgresql::server::pg_hba_rule(
       target  => $target,
       content => template('postgresql/pg_hba_rule.conf'),
       order   => $order,
-      owner   => $::id,
-      mode    => '0600',
     }
   }
 }


### PR DESCRIPTION
The warnings are as follows:

Warning: Scope(Concat::Fragment[pg_hba_rule_deny access to postgresql user]): The $mode parameter to concat::fragment is deprecated and has no effect
Warning: Scope(Concat::Fragment[pg_hba_rule_deny access to postgresql user]): The $owner parameter to concat::fragment is deprecated and has no effect

Found during testing the catalog with cucumber.
