### PR TITLE
Exec['postgresql_initdb'] needs to be done after $datadir exists

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -38,7 +38,7 @@ class postgresql::server::initdb {
         user      => $user,
         group     => $group,
         logoutput => on_failure,
-        after    => File[$datadir],
+        require   => File[$datadir],
       }
     }
   } else {


### PR DESCRIPTION
Fixes an order issue where initdb fails.
