### PR TITLE
Prevent float of defined resource.

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -13,6 +13,8 @@ class postgresql::server::service {
     default => $ensure
   }
 
+  anchor { 'postgresql::server::service::begin': }
+
   service { 'postgresqld':
     ensure    => $service_ensure,
     name      => $service_name,
@@ -35,6 +37,9 @@ class postgresql::server::service {
       tries           => 60,
       create_db_first => false,
       require         => Service['postgresqld'],
+      before          => Anchor['postgresql::server::service::end']
     }
   }
+
+  anchor { 'postgresql::server::service::end': }
 }


### PR DESCRIPTION
ensure puppet::server::validate_db_connection doesn't float out of postgresql::server
