### PR TITLE
Add management of user name maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Resources:
 * [postgresql::server::database](#resource-postgresqlserverdatabase)
 * [postgresql::server::database_grant](#resource-postgresqlserverdatabasegrant)
 * [postgresql::server::pg_hba_rule](#resource-postgresqlserverpghbarule)
+* [postgresql::server::pg_ident_map](#resource-postgresqlserverpgidentmap)
 * [postgresql::server::role](#resource-postgresqlserverrole)
 * [postgresql::server::table_grant](#resource-postgresqlservertablegrant)
 * [postgresql::server::tablespace](#resource-postgresqlservertablespace)
@@ -325,6 +326,9 @@ Path to the `psql` command.
 
 ####`pg_hba_conf_path`
 Path to your `pg\_hba.conf` file.
+
+####`pg_ident_conf_path`
+Path to your `pg\_ident.conf` file.
 
 ####`postgresql_conf_path`
 Path to your `postgresql.conf` file.
@@ -434,6 +438,9 @@ Path to the `psql` command.
 ####`pg_hba_conf_path`
 Path to your `pg\_hba.conf` file.
 
+####`pg_ident_conf_path`
+Path to your `pg\_ident.conf` file.
+
 ####`postgresql_conf_path`
 Path to your `postgresql.conf` file.
 
@@ -467,6 +474,9 @@ This value defaults to `false`. Many distros ship with a fairly restrictive fire
 
 ####`manage_pg_hba_conf`
 This value defaults to `true`. Whether or not manage the pg_hba.conf. If set to `true`, puppet will overwrite this file. If set to `false`, puppet will not modify the file.
+
+####`manage_pg_ident_conf`
+This value defaults to `true`. Whether or not manage the pg_ident.conf. If set to `true`, puppet will overwrite this file. If set to `false`, puppet will not modify the file.
 
 
 ###Class: postgresql::client
@@ -693,6 +703,58 @@ For certain `auth_method` settings there are extra options that can be passed. C
 
 ####`order`
 An order for placing the rule in `pg_hba.conf`. Defaults to `150`.
+
+####`target`
+This provides the target for the rule, and is generally an internal only property. Use with caution.
+
+
+###Resource: postgresql::server::pg\_ident\_map
+This defined type allows you to create a user map for `pg_ident.conf`. For more details see the [PostgreSQL documentation](http://www.postgresql.org/docs/8.4/static/auth-username-maps.html).
+
+For example:
+
+    postgresql::server::pg_ident_map {'map_robert_to_bob':
+      map_name          => 'omicron',
+      system_username   => 'robert',
+      database_username => 'bob',
+      description       => 'Map robert to bob'
+    }
+
+This would create a user map in `pg_ident.conf` similar to:
+
+    # Map Name: omicron
+    # Description: Map robert to bob
+    # Order: 150
+    omicron robert bob
+
+To refer to this example map in the `pg_hba.conf`, use `map=omicron`. An example `pg_hba_rule` would look similar to this:
+
+    postgresql::server::pg_hba_rule { 'allow bob to connect all databases with mapping':
+      description => 'allow any user to connect with user mapping enabled',
+      type        => 'local',
+      database    => 'all',
+      user        => 'bob',
+      auth_method => 'ident',
+      auth_option => 'map=omicron',
+    }
+
+####`namevar`
+A unique identifier or short description for this user map. The namevar doesn't provide any functional usage, but it is stored in the comments of the produced `pg_ident.conf` so the originating resource can be identified.
+
+####`description`
+A longer description for this user map if required. Defaults to `none`. This description is placed in the comments above the map in `pg_ident.conf`.
+
+####`map_name`
+Name of the user map, that is used to refer to this mapping in `pg_hba.conf`.
+
+####`system_username`
+Operating system user name, the user name used to connect to the database.
+
+####`database_username`
+Database user name, the user name of the the database user. The `system_username` will be mapped to this user name
+
+####`order`
+An order for placing the mapping in pg_ident.conf. Defaults to 150.
 
 ####`target`
 This provides the target for the rule, and is generally an internal only property. Use with caution.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -20,6 +20,7 @@ class postgresql::globals (
   $createdb_path        = undef,
   $psql_path            = undef,
   $pg_hba_conf_path     = undef,
+  $pg_ident_conf_path   = undef,
   $postgresql_conf_path = undef,
 
   $pg_hba_conf_defaults = undef,
@@ -42,6 +43,7 @@ class postgresql::globals (
 
   $manage_firewall      = undef,
   $manage_pg_hba_conf   = undef,
+  $manage_pg_ident_conf = undef,
   $firewall_supported   = undef,
 
   $manage_package_repo  = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class postgresql::params inherits postgresql::globals {
   $service_provider           = $service_provider
   $manage_firewall            = $manage_firewall
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
+  $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
   $package_ensure             = 'present'
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
@@ -200,4 +201,5 @@ class postgresql::params inherits postgresql::globals {
   $pg_hba_conf_defaults = pick($pg_hba_conf_defaults, true)
   $postgresql_conf_path = pick($postgresql_conf_path, "${confdir}/postgresql.conf")
   $default_database     = pick($default_database, 'postgres')
+  $pg_ident_conf_path   = pick($pg_ident_conf_path, "${confdir}/pg_ident.conf")
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,6 +26,7 @@ class postgresql::server (
   $createdb_path              = $postgresql::params::createdb_path,
   $psql_path                  = $postgresql::params::psql_path,
   $pg_hba_conf_path           = $postgresql::params::pg_hba_conf_path,
+  $pg_ident_conf_path         = $postgresql::params::pg_ident_conf_path,
   $postgresql_conf_path       = $postgresql::params::postgresql_conf_path,
 
   $datadir                    = $postgresql::params::datadir,
@@ -43,6 +44,7 @@ class postgresql::server (
 
   $manage_firewall            = $postgresql::params::manage_firewall,
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
+  $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $firewall_supported         = $postgresql::params::firewall_supported,
 
   #Deprecated

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -7,12 +7,14 @@ class postgresql::server::config {
   $ipv4acls                   = $postgresql::server::ipv4acls
   $ipv6acls                   = $postgresql::server::ipv6acls
   $pg_hba_conf_path           = $postgresql::server::pg_hba_conf_path
+  $pg_ident_conf_path         = $postgresql::server::pg_ident_conf_path
   $postgresql_conf_path       = $postgresql::server::postgresql_conf_path
   $pg_hba_conf_defaults       = $postgresql::server::pg_hba_conf_defaults
   $user                       = $postgresql::server::user
   $group                      = $postgresql::server::group
   $version                    = $postgresql::server::version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
+  $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -105,6 +107,18 @@ class postgresql::server::config {
     file { '/etc/sysconfig/pgsql/postgresql':
       ensure  => present,
       replace => false,
+    }
+  }
+
+  if ($manage_pg_ident_conf == true) {
+    # Prepare the main pg_ident file
+    concat { $pg_ident_conf_path:
+      owner  => $user,
+      group  => $group,
+      mode   => '0640',
+      warn   => true,
+      force  => true,
+      notify => Class['postgresql::server::reload'],
     }
   }
 }

--- a/manifests/server/pg_ident_map.pp
+++ b/manifests/server/pg_ident_map.pp
@@ -1,0 +1,26 @@
+# This resource manages an individual user name map that applies to the file
+# defined in $target. See README.md for more details.
+define postgresql::server::pg_ident_map(
+  $map_name,
+  $system_username,
+  $database_username,
+  $description = 'none',
+  $order       = '150',
+
+  # Needed for testing primarily, support for multiple files is not really
+  # working.
+  $target      = $postgresql::server::pg_ident_conf_path
+) {
+
+  if $postgresql::server::manage_pg_ident_conf == false {
+      fail('postgresql::server::manage_pg_ident_conf has been disabled, so this resource is now unused and redundant, either enable that option or remove this resource from your manifests')
+  }
+
+  # Create a mapping fragment
+  $fragname = "pg_ident_map_${name}"
+  concat::fragment { $fragname:
+    target  => $target,
+    content => template('postgresql/pg_ident_map.conf'),
+    order   => $order,
+  }
+}

--- a/spec/unit/defines/server/pg_ident_map_spec.rb
+++ b/spec/unit/defines/server/pg_ident_map_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'postgresql::server::pg_ident_map', :type => :define do
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :concat_basedir => tmpfilename('pg_ident'),
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let :title do
+    'test'
+  end
+  let :target do
+    tmpfilename('pg_ident_map')
+  end
+
+  context 'test user map' do
+    let :pre_condition do
+      <<-EOS
+        class { 'postgresql::server': }
+      EOS
+    end
+
+    let :params do
+      {
+        :map_name => 'omicron',
+        :system_username => 'robert',
+        :database_username => 'bob',
+        :target => target,
+      }
+    end
+    it do
+      is_expected.to contain_concat__fragment('pg_ident_map_test').with({
+        :content => /omicron\s+robert\s+bob/
+      })
+    end
+  end
+end

--- a/templates/pg_ident_map.conf
+++ b/templates/pg_ident_map.conf
@@ -1,0 +1,5 @@
+
+# Map Name: <%=@name%>
+# Description: <%=@description%>
+# Order: <%=@order%>
+<%=@map_name%> <%=@system_username%> <%=@database_username%>


### PR DESCRIPTION
This PR adds the capability to manage [user name maps](http://www.postgresql.org/docs/8.4/static/auth-username-maps.html) in pg_ident.conf. If the system user is not the same as the database user, you can create a mapping. Most of the time, you need this for external authentication.

I have added a new type _pg_ident_map_, which manages a single map entry in pg_ident.conf.
Most of the work is based on the pg_hba_rule type as they have quite much in common.
It is still possible to manage the file in a different way by setting _postgresql::globals::manage_pg_ident_conf_ to false.

This is also of use for #287, because it allows to map X.509 certificate subjects to database users.
