### PR TITLE
(FM-486) Fix deprecated Puppet::Util::SUIDManager.run_and_capture

### DIFF
--- a/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
@@ -13,11 +13,10 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       let(:attributes) do { :db => 'spec_db' } end
 
       it "executes with the given psql_path on the given DB" do
-        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
-          ['psql', '-d', attributes[:db], '-t', '-c', 'SELECT something'],
-          'postgres',
-          'postgres'
-        )
+        expect(provider).to receive(:run_command).with(['psql', '-d',
+          attributes[:db], '-t', '-c', 'SELECT something'], 'postgres',
+          'postgres')
+
         provider.run_sql_command("SELECT something")
       end
     end
@@ -32,11 +31,10 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
 
       it "executes with the given psql_path on the given DB" do
         expect(Dir).to receive(:chdir).with(attributes[:cwd]).and_yield
-        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
-          [attributes[:psql_path], '-d', attributes[:db], '-t', '-c', 'SELECT something'],
-          attributes[:psql_user],
-          attributes[:psql_group]
-        )
+        expect(provider).to receive(:run_command).with([attributes[:psql_path],
+          '-d', attributes[:db], '-t', '-c', 'SELECT something'],
+          attributes[:psql_user], attributes[:psql_group])
+
         provider.run_sql_command("SELECT something")
       end
     end
@@ -46,11 +44,10 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       } end
 
       it "executes with the given search_path" do
-        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
-          ['psql', '-t', '-c', 'set search_path to schema1; SELECT something'],
-          'postgres',
-          'postgres'
-        )
+        expect(provider).to receive(:run_command).with(['psql', '-t', '-c',
+          'set search_path to schema1; SELECT something'],
+          'postgres', 'postgres')
+
         provider.run_sql_command("SELECT something")
       end
     end
@@ -60,11 +57,12 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       } end
 
       it "executes with the given search_path" do
-        expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).with(
-          ['psql', '-t', '-c', 'set search_path to schema1,schema2; SELECT something'],
+        expect(provider).to receive(:run_command).with(['psql', '-t', '-c',
+          'set search_path to schema1,schema2; SELECT something'],
           'postgres',
           'postgres'
         )
+
         provider.run_sql_command("SELECT something")
       end
     end


### PR DESCRIPTION
Puppet::Util::SUIDManager.run_and_capture recently changed to
Execution.execute, switch before it blows up and stops working.
