### PR TITLE
Fixes #93: Ensure PGDATA env var for the init script

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class postgresql::params inherits postgresql::globals {
           default  => pick($datadir, '/var/lib/pgsql/data'),
         }
         $confdir              = pick($confdir, $datadir)
+        $sysconfig_filename   = '/etc/sysconfig/postgresql'
       } else {
         $version_parts        = split($version, '[.]')
         $package_version      = "${version_parts[0]}${version_parts[1]}"
@@ -51,6 +52,7 @@ class postgresql::params inherits postgresql::globals {
           default  => pick($datadir, "/var/lib/pgsql/${version}/data"),
         }
         $confdir              = pick($confdir, $datadir)
+        $sysconfig_filename   = "/etc/sysconfig/postgresql-${version}"
       }
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
@@ -81,6 +83,7 @@ class postgresql::params inherits postgresql::globals {
       $datadir              = pick($datadir, '/var/lib/postgres/data')
       $confdir              = pick($confdir, $datadir)
       $psql_path            = pick($psql_path, "${bindir}/psql")
+      $sysconfig_filename   = false
 
       $service_status      = $service_status
       $python_package_name = pick($python_package_name, 'python-psycopg2')
@@ -116,6 +119,7 @@ class postgresql::params inherits postgresql::globals {
       $confdir              = pick($confdir, "/etc/postgresql/${version}/main")
       $service_status       = pick($service_status, "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+|online'")
       $psql_path            = pick($psql_path, "/usr/bin/psql")
+      $sysconfig_filename   = false
 
       $firewall_supported   = pick($firewall_supported, true)
     }
@@ -138,6 +142,7 @@ class postgresql::params inherits postgresql::globals {
       if ($bindir == undef) { fail("${err_prefix}bindir") }
       if ($datadir == undef) { fail("${err_prefix}datadir") }
       if ($confdir == undef) { fail("${err_prefix}confdir") }
+      $sysconfig_filename = false
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,6 +29,7 @@ class postgresql::server (
   $postgresql_conf_path       = $postgresql::params::postgresql_conf_path,
 
   $datadir                    = $postgresql::params::datadir,
+  $sysconfig_filename         = $postgresql::params::sysconfig_filename,
 
   $pg_hba_conf_defaults       = $postgresql::params::pg_hba_conf_defaults,
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -102,12 +102,29 @@ class postgresql::server::config {
     postgresql::server::config_entry { 'listen_addresses':
       value => $listen_addresses,
     }
+
+    # Ensure the service starts with the correct datadir on RedHat and Amazon (Linux)
+    if $postgresql::sysconfig_filename {
+      file { '/etc/sysconfig/pgsql':
+        ensure => directory,
+      }
+
+      file { $postgresql::server::sysconfig_filename:
+        content => "PGDATA=${postgresql::server::datadir}\n",
+      }
+    }
   } else {
     file { $pg_hba_conf_path:
       ensure => absent,
     }
     file { $postgresql_conf_path:
       ensure => absent,
+    }
+
+    if $postgresql::server::sysconfig_filename {
+      file { $postgresql::server::sysconfig_filename:
+        ensure => absent,
+      }
     }
   }
 }


### PR DESCRIPTION
RedHat-based distros look in /etc/sysconfig/pgsql/postgresql or /etc/sysconfig/pgsql/postgresql-${version} for the PGDATA environment variable. This is passed on to the init script.

I should note that this is untested, but hopefully gets the ball rolling.
