### PR TITLE
Fix NOREPLICATION option for Postgres 9.1

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -56,8 +56,14 @@ define postgresql::server::role(
   }
 
   if(versioncmp($version, '9.1') >= 0) {
-    postgresql_psql {"ALTER ROLE \"${username}\" ${replication_sql}":
-      unless => "SELECT rolname FROM pg_roles WHERE rolname='${username}' and rolreplication=${replication}",
+    if $replication_sql == '' {
+      postgresql_psql {"ALTER ROLE \"${username}\" NOREPLICATION":
+        unless => "SELECT rolname FROM pg_roles WHERE rolname='${username}' and rolreplication=${replication}",
+      }
+    } else {
+      postgresql_psql {"ALTER ROLE \"${username}\" ${replication_sql}":
+        unless => "SELECT rolname FROM pg_roles WHERE rolname='${username}' and rolreplication=${replication}",
+      }
     }
   }
 


### PR DESCRIPTION
Fixing a bug when using this module with Postgresql 9.1 that causes alter role statements to execute during every apply.

If replication is disabled, the module is supposed to alter the role to set `NOREPLICATION`, however, `$replication_sql` is set to an empty string by default to avoid breaking on pre 9.1 installs. 
