### PR TITLE
README.md postgresql::globals class parameter description fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,13 @@ This setting can be used to override the default postgresql PL/perl package name
 This setting can be used to override the default postgresql Python package name. If not specified, the module will use whatever package name is the default for your OS distro.
 
 ####`service_name`
-This setting can be used to override the default postgresql service provider. If not specified, the module will use whatever service name is the default for your OS distro.
+This setting can be used to override the default postgresql service name. If not specified, the module will use whatever service name is the default for your OS distro.
+
+####`service_provider`
+This setting can be used to override the default postgresql service provider. If not specified, the module will use whatever service provider is the default for your OS distro.
 
 ####`service_status`
-This setting can be used to override the default status check command for your PostgreSQL service. If not specified, the module will use whatever service name is the default for your OS distro.
+This setting can be used to override the default status check command for your PostgreSQL service. If not specified, the module will use whatever service status is the default for your OS distro.
 
 ####`default_database`
 This setting is used to specify the name of the default database to connect with. On most systems this will be "postgres".


### PR DESCRIPTION
Missing service_provider description and wrong service_name description for postgresql::globals class
