### PR TITLE
fix for concat error

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -14,11 +14,6 @@ class postgresql::server::config {
   $version                    = $postgresql::server::version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
 
-  File {
-    owner => $user,
-    group => $group,
-  }
-
   if ($ensure == 'present' or $ensure == true) {
 
     if ($manage_pg_hba_conf == true) {


### PR DESCRIPTION
This fixes a - in my opinion - critical bug which leads to a puppet run abort.

using a fairly new concat and postgresql module, this happens:
- postgresql is the first module which uses concat which gets realized by puppet
- concat was not yet initialized, so it does its initialization (create `/var/lib/puppet/concat` ...)
- puppet aborts with a `user postgres not found` error

What happens is that on first run, without being initialized, the concat module wants to create its helper directories. But postgresql defines a standard user for all File{} objects, which does not yet exist (the package is not yet installed), and would be horribly wrong anyway.

I did not find any practical use of the general File{} definition, so I removed it, and so far it works.
