### PR TITLE
Temporary Ubuntu Raring support

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -5,13 +5,19 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
     #
     # http://www.postgresql.org/download/linux/debian/
     #
+    # Temporary workaround until PostgreSQL supports Ubuntu raring 13.04
+    if ($::lsbdistcodename == 'raring') { 
+      $repo = 'precise'
+    } else {
+      $repo = $::lsbdistcodename
+    }
     apt::pin { 'apt.postgresql.org':
       originator => 'apt.postgresql.org',
       priority   => 500,
     }->
     apt::source { 'apt.postgresql.org':
       location          => 'http://apt.postgresql.org/pub/repos/apt/',
-      release           => "${::lsbdistcodename}-pgdg",
+      release           => "${repo}-pgdg",
       repos             => "main ${version}",
       key               => 'ACCC4CF8',
       key_source        => 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc',


### PR DESCRIPTION
Hi all,

I know this is a hack and a temporary workaround but it might be useful for people deploying on Ubuntu Raring until the official PostgreSQL repository gets released.

Unless there is another way of going around it?

You don't need to merge this in but it may come in handy for people deploying on Raring that could apply the patch themselves.

Regards,
Darío
