### PR TITLE
Fix typo, clearly from a copy/paste mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ The ensure parameter passed on to postgresql client package resource.
 Installs the postgresql contrib package.
 
 ####`package_name`
-The name of the postgresql client package.
+The name of the postgresql contrib package.
 
 ####`package_ensure`
 The ensure parameter passed on to postgresql contrib package resource.


### PR DESCRIPTION
Fixes a clear copy/paste error where "contrib" is referred to as "client"...
