### PR TITLE
remove trailing whitespace

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,7 +7,7 @@ class postgresql::server (
   $postgres_password          = undef,
 
   $package_name               = $postgresql::params::server_package_name,
-  $client_package_name        = $postgresql::params::client_package_name,  
+  $client_package_name        = $postgresql::params::client_package_name,
   $package_ensure             = $ensure,
 
   $plperl_package_name        = $postgresql::params::plperl_package_name,


### PR DESCRIPTION
trailing whitespace is apparently an error that puppet-lint will fail the build with
