### PR TITLE
change pg_hba.conf to be owned by postgres user account

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -19,7 +19,7 @@ class postgresql::server::config {
     if ($manage_pg_hba_conf == true) {
       # Prepare the main pg_hba file
       concat { $pg_hba_conf_path:
-        owner  => 0,
+        owner  => $user,
         group  => $group,
         mode   => '0640',
         warn   => true,

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -19,6 +19,13 @@ describe 'server:' do
     it { should be_listening }
   end
 
+  describe file('/var/lib/pgsql/data/pg_hba.conf') do
+    it { should be_file }
+    it { should be_owned_by 'postgres' }
+    it { should be_grouped_into 'postgres' }
+    it { should be_mode 640 }
+  end
+
   describe 'setting postgres password' do
     it 'should install and successfully adjust the password' do
       pp = <<-EOS.unindent


### PR DESCRIPTION
At present, the ownership of pg_hba.conf is hardwired to be uid 0.  It should have the same ownership as all of the other postgressql configuration files in the same cluster so that they can be managed/edited by the postgres role user (system) account.
