### PR TITLE
Supported Release 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-##2014-03-04 - Supported Release 3.3.x
+##2014-03-04 - Supported Release 3.3.2
 ###Summary
-
-####Features
+This is a supported release. It fixes a problem with updating passwords on postgresql.org distributed versions of PostgreSQL.
 
 ####Bugfixes
+- Correct psql path when setting password on custom versions.
+- Documentation updates
+- Test updates
 
 ####Known Bugs
-
 * SLES is not supported.
 
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-postgresql'
-version '3.3.1'
+version '3.3.2'
 source 'git://github.com/puppetlabs/puppet-postgresql.git'
 author 'Inkling/Puppet Labs'
 description 'PostgreSQL defined resource types'


### PR DESCRIPTION
### Summary

This is a supported release. It fixes a problem with updating passwords
on postgresql.org distributed versions of PostgreSQL.
#### Bugfixes
- Correct psql path when setting password on custom versions.
- Documentation updates
- Test updates
#### Known Bugs
- SLES is not supported.
