### PR TITLE
Allow the ex- and import of postgresql::server::db

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,9 @@ For example, to create a database called `test1` with a corresponding user of th
 ####`namevar`
 The namevar for the resource designates the name of the database.
 
+####`dbname`
+The name of the database to be created. Defaults to `namevar`.
+
 ####`user`
 User to create and assign access to the database upon creation. Mandatory.
 

--- a/spec/unit/defines/server/db_spec.rb
+++ b/spec/unit/defines/server/db_spec.rb
@@ -13,16 +13,34 @@ describe 'postgresql::server::db', :type => :define do
     'test'
   end
 
-  let :params do
-    {
-      :user => 'test',
-      :password => 'test',
-      :owner => 'tester',
-    }
+  context 'without dbname param' do
+
+    let :params do
+      {
+        :user => 'test',
+        :password => 'test',
+        :owner => 'tester',
+      }
+    end
+
+    it { should contain_postgresql__server__db('test') }
+    it { should contain_postgresql__server__database('test').with_owner('tester') }
+    it { should contain_postgresql__server__role('test') }
+    it { should contain_postgresql__server__database_grant('GRANT test - ALL - test') }
+
   end
 
-  it { should contain_postgresql__server__db('test') }
-  it { should contain_postgresql__server__database('test').with_owner('tester') }
-  it { should contain_postgresql__server__role('test') }
-  it { should contain_postgresql__server__database_grant('GRANT test - ALL - test') }
+  context 'dbname' do
+
+    let :params do
+      {
+        :dbname => 'testtest',
+        :user => 'test',
+        :password => 'test',
+        :owner => 'tester',
+      }
+    end
+
+    it { should contain_postgresql__server__database('testtest') }
+  end
 end


### PR DESCRIPTION
When a database should be accessed from multiple systems, exporting and importing a `postgresql::server::db` resource results in the following error on the importing server:

 `err: Could not retrieve catalog from remote server: Error 400 on SERVER: Another local or imported resource exists with the type and title Postgresql::Server::Db[mydb] on node dbserver` 

It is exported as follows:

``` puppet
  @@postgresql::server::db { "mydb":
    user     => 'myuser',
    password => postgresql_password('myuser', 'mypassword'),
    tag      => 'mytag';
  }
```

And imported as follows:

``` puppet
Postgresql::Server::Db <<| tag == 'mytag' |>> 
```

This patch allows the setting of the name of the database as a parameter to `postgresql::server::db`, allowing it to be exported as:

``` puppet
  @@postgresql::server::db { "mydb from ${hostname}":
    user     => 'myuser',
    dbname   => 'mydb',
    password => postgresql_password('myuser', 'mypassword'),
    tag      => 'mytag';
  }
```

And be imported without the duplicate error.

This code doesn't contain any documentation yet, but if this code is considered for inclusion, I'll write it.
