### PR TITLE
Fixed travis by updating Gemfile to pin Rake to 10.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake'
+  gem 'rake', '10.1.1'
   gem 'puppetlabs_spec_helper', :require => false
   gem 'rspec-puppet', '~> 1.0'
   gem 'puppet-lint', '~> 0.3.2'


### PR DESCRIPTION
The latest Rake update requires Ruby >= 1.9. This update
fixes the failing 1.8.7 tests by pinning Rake to the last
supported version on ruby 1.8.7.

This patch is borrowed from @blkperl
