### PR TITLE
Explicit support for `port' parameter in postgresql.conf

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class postgresql::params inherits postgresql::globals {
   $ensure                     = true
   $version                    = $globals_version
   $listen_addresses           = 'localhost'
+  $port                       = 5432
   $ip_mask_deny_postgres_user = '0.0.0.0/0'
   $ip_mask_allow_all_users    = '127.0.0.1/32'
   $ipv4acls                   = []

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -4,6 +4,7 @@ class postgresql::server::config {
   $ip_mask_deny_postgres_user = $postgresql::server::ip_mask_deny_postgres_user
   $ip_mask_allow_all_users    = $postgresql::server::ip_mask_allow_all_users
   $listen_addresses           = $postgresql::server::listen_addresses
+  $port                       = $postgresql::server::port
   $ipv4acls                   = $postgresql::server::ipv4acls
   $ipv6acls                   = $postgresql::server::ipv6acls
   $pg_hba_conf_path           = $postgresql::server::pg_hba_conf_path
@@ -97,6 +98,10 @@ class postgresql::server::config {
     postgresql::server::config_entry { 'listen_addresses':
       value => $listen_addresses,
     }
+    postgresql::server::config_entry { 'port':
+      value => "${port}",
+    }
+
   } else {
     file { $pg_hba_conf_path:
       ensure => absent,

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -45,7 +45,7 @@ define postgresql::server::database(
     default => "--tablespace='${tablespace}' ",
   }
 
-  $createdb_command = "${createdb_path} --owner='${owner}' --template=${template} ${encoding_option}${locale_option}${tablespace_option} '${dbname}'"
+  $createdb_command = "${createdb_path} --owner='${owner}' --port=${port} --template=${template} ${encoding_option}${locale_option}${tablespace_option} '${dbname}'"
 
   postgresql_psql { "Check for existence of db '${dbname}'":
     command => 'SELECT 1',


### PR DESCRIPTION
createdb wants port number as a parameter even if connected through Unix socket, thus `port' configuration value should be somehow visible.

This seems to be the least impact.

NB: for some reasons postgresql::server::config_entry complains about missing `match' method for numbers if used inside server::config. String value as a hack-around here.
