### PR TITLE
(MODULES-630) Deprecate postgresql::server::version

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,6 @@ The following list are options that you can set in the `config_hash` parameter o
 ####`ensure`
 This value default to `present`. When set to `absent` it will remove all packages, configuration and data so use this with extreme caution.
 
-####`version`
-This will set the version of the PostgreSQL software to install. Defaults to your operating systems default.
-
 ####`postgres_password`
 This value defaults to `undef`, meaning the super user account in the postgres database is a user called `postgres` and this account does not have a password. If you provide this setting, the module will set the password for the `postgres` user to your specified value.
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,8 +2,6 @@
 class postgresql::server (
   $ensure                     = $postgresql::params::ensure,
 
-  $version                    = $postgresql::params::version,
-
   $postgres_password          = undef,
 
   $package_name               = $postgresql::params::server_package_name,
@@ -45,9 +43,16 @@ class postgresql::server (
 
   $manage_firewall            = $postgresql::params::manage_firewall,
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
-  $firewall_supported         = $postgresql::params::firewall_supported
+  $firewall_supported         = $postgresql::params::firewall_supported,
+
+  #Deprecated
+  $version                    = $postgresql::params::version,
 ) inherits postgresql::params {
   $pg = 'postgresql::server'
+
+  if $version != $postgresql::params::version {
+    warning('Passing "version" to postgresql::server is deprecated; please use postgresql::globals instead.')
+  }
 
   if ($ensure == 'present' or $ensure == true) {
     # Reload has its own ordering, specified by other defines

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -113,6 +113,27 @@ describe 'server without defaults:', :unless => UNSUPPORTED_PLATFORMS.include?(f
     end
   end
 
+  context 'test deprecating non-default version of postgresql to postgresql::server' do
+    after :all do
+      pp = <<-EOS.unindent
+        class { 'postgresql::server':
+          ensure  => absent,
+          version => '9.3',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'raises a warning' do
+      pp = <<-EOS.unindent
+      class { 'postgresql::server':
+        version => '9.3',
+      }
+      EOS
+      expect(apply_manifest(pp, :catch_failures => true).stderr).to match(/Passing "version" to postgresql::server is deprecated/i)
+    end
+  end
+
   unless ((fact('osfamily') == 'RedHat' and fact('lsbmajdistrelease') == '5') ||
     fact('osfamily') == 'Debian')
 


### PR DESCRIPTION
Adjusting the version is explicitly done though the postgresql::globals
class, as this affects many parts of the module. This parameter did not
function correctly on systems that did not have a default, as described
in the ticket.
