### PR TITLE
Update apt.postgresql.org key url

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -15,7 +15,7 @@ include ::apt
       release           => "${::lsbdistcodename}-pgdg",
       repos             => "main ${version}",
       key               => 'ACCC4CF8',
-      key_source        => 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc',
+      key_source        => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
       include_src       => false,
     }
 


### PR DESCRIPTION
Accordingly to http://wiki.postgresql.org/wiki/Apt the correc key_source url is https://www.postgresql.org/media/keys/ACCC4CF8.asc

Today the old file was removed, so it's urgent to update this file and made a new release
