### PR TITLE
Add param for specifying validate connection script in postgresql::client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,9 @@ This value defaults to `true`. Whether or not manage the pg_ident.conf. If set t
 
 This class installs postgresql client software. Alter the following parameters if you have a custom version you would like to install (Note: don't forget to make sure to add any necessary yum or apt repositories if specifying a custom version):
 
+####`validcon_script_path`
+Path to validate connection script. Defaults to `/usr/local/bin/validate_postgresql_connection.sh`.
+
 ####`package_name`
 The name of the postgresql client package.
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,9 +1,11 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
   $file_ensure    = 'file',
+  $validcon_script_path  = $postgresql::params::validcon_script_path,
   $package_name   = $postgresql::params::client_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {
+  validate_absolute_path($validcon_script_path)
   validate_string($package_name)
 
   package { 'postgresql-client':
@@ -12,7 +14,7 @@ class postgresql::client (
     tag    => 'postgresql',
   }
 
-  file { '/usr/local/bin/validate_postgresql_connection.sh':
+  file { $validcon_script_path:
     ensure => $file_ensure,
     source => 'puppet:///modules/postgresql/validate_postgresql_connection.sh',
     owner  => 0,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -16,6 +16,8 @@ class postgresql::globals (
   $service_status       = undef,
   $default_database     = undef,
 
+  $validcon_script_path = undef,
+
   $initdb_path          = undef,
   $createdb_path        = undef,
   $psql_path            = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -244,6 +244,7 @@ class postgresql::params inherits postgresql::globals {
     }
   }
 
+  $validcon_script_path = pick($validcon_script_path, '/usr/local/bin/validate_postgresql_connection.sh')
   $initdb_path          = pick($initdb_path, "${bindir}/initdb")
   $createdb_path        = pick($createdb_path, "${bindir}/createdb")
   $pg_hba_conf_path     = pick($pg_hba_conf_path, "${confdir}/pg_hba.conf")

--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -18,6 +18,7 @@ define postgresql::validate_db_connection(
   include postgresql::params
 
   $psql_path = $postgresql::params::psql_path
+  $validcon_script_path = $postgresql::client::validcon_script_path
 
   $cmd_init = "${psql_path} --tuples-only --quiet "
   $cmd_host = $database_host ? {
@@ -41,7 +42,7 @@ define postgresql::validate_db_connection(
     default => "PGPASSWORD=${database_password}",
   }
   $cmd = join([$cmd_init, $cmd_host, $cmd_user, $cmd_port, $cmd_dbname], ' ')
-  $validate_cmd = "/usr/local/bin/validate_postgresql_connection.sh ${sleep} ${tries} '${cmd}'"
+  $validate_cmd = "${validcon_script_path} ${sleep} ${tries} '${cmd}'"
 
   # This is more of a safety valve, we add a little extra to compensate for the
   # time it takes to run each psql command.

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -12,8 +12,10 @@ describe 'postgresql::client', :type => :class do
   describe 'with parameters' do
     let :params do
       {
+        :validcon_script_path  => '/opt/bin/my-validate-con.sh',
         :package_ensure => 'absent',
-        :package_name => 'mypackage',
+        :package_name   => 'mypackage',
+        :file_ensure    => 'file'
       }
     end
 
@@ -22,6 +24,15 @@ describe 'postgresql::client', :type => :class do
         :ensure => 'absent',
         :name => 'mypackage',
         :tag => 'postgresql',
+      })
+    end
+
+    it 'should have specified validate connexion' do
+      should contain_file('/opt/bin/my-validate-con.sh').with({
+        :ensure => 'file',
+        :owner  => 0,
+        :group  => 0,
+        :mode   => '0755'
       })
     end
   end

--- a/spec/unit/defines/validate_db_connection_spec.rb
+++ b/spec/unit/defines/validate_db_connection_spec.rb
@@ -31,5 +31,36 @@ describe 'postgresql::validate_db_connection', :type => :define do
       }
     end
     it { is_expected.to contain_postgresql__validate_db_connection('test') }
+
+    it 'should have proper path for validate command' do
+      is_expected.to contain_exec('validate postgres connection for test@test:5432/test').with({
+        :unless => %r'^/usr/local/bin/validate_postgresql_connection.sh\s+\d+'
+      })
+    end
   end
+
+  describe 'should work while specifying validate_connection in postgresql::client' do
+
+    let :params do
+      {
+        :database_host => 'test',
+        :database_name => 'test',
+        :database_password => 'test',
+        :database_username => 'test',
+        :database_port => 5432
+      }
+    end
+
+    let :pre_condition do
+      "class { 'postgresql::client': validcon_script_path => '/opt/something/validate.sh' }"
+    end
+
+    it 'should have proper path for validate command' do
+      is_expected.to contain_exec('validate postgres connection for test@test:5432/test').with({
+        :unless => %r'^/opt/something/validate.sh\s+\d+'
+      })
+    end
+
+  end
+
 end


### PR DESCRIPTION
* Add param `validcon_path` in `postgresql::client` (defaults to
previous hard coded value).
* Add tests for this new parameter.

All tests runs successfully on Scientific Linux 6.4

```
$ bundle exec rake spec SPEC_OPTS='--format documentation'
[...]

Finished in 1 minute 58.61 seconds
159 examples, 0 failures
```

Travis passes all tests except for `PUPPET_GEM_VERSION="~> 3.5.0.rc3"` for an external reason:
```
/home/travis/.rvm/gems/ree-1.8.7-2012.02/gems/json-1.8.1/lib/json/ext/parser.so: [BUG] Segmentation fault
```