### PR TITLE
Support Debian Jessie

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -68,6 +68,7 @@ class postgresql::globals (
       'Debian' => $::operatingsystemrelease ? {
         /^6\./ => '8.4',
         /^(wheezy|7\.)/ => '9.1',
+        /^(jessie|8\.)/ => '9.3',
         default => undef,
       },
       'Ubuntu' => $::operatingsystemrelease ? {


### PR DESCRIPTION
According to https://packages.debian.org/jessie/postgresql, Jessie's repo contains postgresql 9.3
