### PR TITLE
Ensure db user exists before validating db connection

### DIFF
--- a/manifests/server/db.pp
+++ b/manifests/server/db.pp
@@ -35,7 +35,7 @@ define postgresql::server::db (
       privilege => $grant,
       db        => $dbname,
       role      => $user,
-    }
+    } -> Postgresql::Validate_db_connection<| database_name == $dbname |>
   }
 
   if($tablespace != undef and defined(Postgresql::Server::Tablespace[$tablespace])) {


### PR DESCRIPTION
The validate_db_connection class takes a user to connect as, but if we're
using the progresql::server::db defined type then the user might not be
created yet, and might not have any permissions granted yet.  This patch
uses a collector to ensure that the that the user and grants are active
before validating.
