### PR TITLE
(MODULES-160) Fix creating and checking role in Postgresql::server::role

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -31,6 +31,7 @@ define postgresql::server::role(
     $environment  = []
   }
 
+  # Set the defaults for the postgresql_psql resource
   Postgresql_psql {
     db         => $db,
     port       => $port,
@@ -43,10 +44,12 @@ define postgresql::server::role(
     ],
   }
 
-  postgresql_psql { "CREATE ROLE ${username} ENCRYPTED PASSWORD ****":
+  postgresql_psql { "Check for existence of role '${username}'":
     command     => "CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}",
     unless      => "SELECT rolname FROM pg_roles WHERE rolname='${username}'",
     require     => Class['Postgresql::Server'],
+    db          => $db,
+    port        => $port,
     environment => $environment,
   }
 


### PR DESCRIPTION
A role will not be created when updating puppet if it was not created the first
time without this patch. This is a problem when puppet fails to switch locales
on certain systems. This patch changes the behavior of Postgresql::server::role
similar to logic in Postgresql::server::database.