### PR TITLE
pg_hba_rules: An helper class to create various pg_hba_rule resource

### DIFF
--- a/manifests/server/pg_hba_rules.pp
+++ b/manifests/server/pg_hba_rules.pp
@@ -1,0 +1,11 @@
+# == Class: postgresql::server::pg_hba_rules
+#
+#  Helper class to create serveral pg_hba_rule ressource
+#  in one call
+#
+class postgresql::server::pg_hba_rules (
+  $pg_hba_rules = {}
+) {
+  validate_hash($pg_hba_rules)
+  create_resources('postgresql::server::pg_hba_rule', $pg_hba_rules)
+}


### PR DESCRIPTION
This helper class allows on to create several pg_hba_rule resource at once.
It is necessary when using 100% data-driven architecture.

With a manifest like the following :

``` puppet
include ::postgresql::globals
include ::postgresql::server
include ::postgresql::server::pg_hba_rules
```

One could write the following hiera file

``` yaml

---
postresql::server:pg_hba_rules::pg_hba_rules:
  puppetdb:
    type: host
    database: puppetdb
    user: puppetdb
  gitlab:
    type: host
    database: gitlab
    user: gitlab
```
