### PR TITLE
Repair version deprecation warning

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,9 +53,9 @@ class postgresql::server (
 
   if $version != undef {
     warning('Passing "version" to postgresql::server is deprecated; please use postgresql::globals instead.')
-    $_version = $postgresql::params::version
-  } else {
     $_version = $version
+  } else {
+    $_version = $postgresql::params::version
   }
 
   if ($ensure == 'present' or $ensure == true) {


### PR DESCRIPTION
I kept getting the deprecation warning

```
Warning: Scope(Class[Postgresql::Server]): Passing "version" to postgresql::server is deprecated; please use postgresql::globals instead.
```

when using the `postgresql::server` class.

This happened regardless if I passed a `version` parameter to the class or not.

Since I do not know how to test for deprecation warnings, I could not add a test for that. I also refrained from testing wether the version passed to the class is actually taking effect, because this is a deprecated way of setting the version.

If needed, I can add try to add a failing test for the state before this patch. Personally, I do not want to endorse a deprecated API by adding a test using it.
