### PR TITLE
Remove the ensure => absent uninstall code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,6 @@ If `true` this will setup the official PostgreSQL repositories on your host. Def
 ###Class: postgresql::server
 The following list are options that you can set in the `config_hash` parameter of `postgresql::server`.
 
-####`ensure`
-This value default to `present`. When set to `absent` it will remove all packages, configuration and data so use this with extreme caution.
-
 ####`postgres_password`
 This value defaults to `undef`, meaning the super user account in the postgres database is a user called `postgres` and this account does not have a password. If you provide this setting, the module will set the password for the `postgres` user to your specified value.
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,5 +1,6 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
+  $file_ensure    = 'file',
   $package_name   = $postgresql::params::client_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {
@@ -11,19 +12,12 @@ class postgresql::client (
     tag     => 'postgresql',
   }
 
-  $file_ensure = $package_ensure ? {
-    'present' => 'file',
-    true      => 'file',
-    'absent'  => 'absent',
-    false     => 'absent',
-    default   => 'file',
-  }
-  file { "/usr/local/bin/validate_postgresql_connection.sh":
+  file { '/usr/local/bin/validate_postgresql_connection.sh':
     ensure => $file_ensure,
-    source => "puppet:///modules/postgresql/validate_postgresql_connection.sh",
+    source => 'puppet:///modules/postgresql/validate_postgresql_connection.sh',
     owner  => 0,
     group  => 0,
-    mode   => 0755,
+    mode   => '0755',
   }
 
 }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,8 +1,6 @@
 # Class for setting cross-class global overrides. See README.md for more
 # details.
 class postgresql::globals (
-  $ensure               = undef,
-
   $client_package_name  = undef,
   $server_package_name  = undef,
   $contrib_package_name = undef,
@@ -108,7 +106,6 @@ class postgresql::globals (
     # Workaround the lack of RHEL7 repositories for now.
     if ! ($::operatingsystem == 'RedHat' and $::operatingsystemrelease =~ /^7/) {
       class { 'postgresql::repo':
-        ensure  => $ensure,
         version => $globals_version
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::params inherits postgresql::globals {
-  $ensure                     = present
   $version                    = $globals_version
   $postgis_version            = $globals_postgis_version
   $listen_addresses           = 'localhost'
@@ -11,10 +10,12 @@ class postgresql::params inherits postgresql::globals {
   $ipv6acls                   = []
   $encoding                   = $encoding
   $locale                     = $locale
-  $service_ensure             = undef
+  $service_ensure             = 'running'
+  $service_enable             = true
   $service_provider           = $service_provider
   $manage_firewall            = $manage_firewall
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
+  $package_ensure             = 'present'
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::repo (
-  $ensure  = $postgresql::params::ensure,
   $version = undef
 ) inherits postgresql::params {
   case $::osfamily {

--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -1,31 +1,22 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
 include ::apt
-  if($ensure == 'present' or $ensure == true) {
-    # Here we have tried to replicate the instructions on the PostgreSQL site:
-    #
-    # http://www.postgresql.org/download/linux/debian/
-    #
-    apt::pin { 'apt.postgresql.org':
-      originator => 'apt.postgresql.org',
-      priority   => 500,
-    }->
-    apt::source { 'apt.postgresql.org':
-      location          => 'http://apt.postgresql.org/pub/repos/apt/',
-      release           => "${::lsbdistcodename}-pgdg",
-      repos             => "main ${version}",
-      key               => 'ACCC4CF8',
-      key_source        => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-      include_src       => false,
-    }
-
-    Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>
-  } else {
-    apt::source { 'apt.postgresql.org':
-      ensure => absent,
-    }
-    apt::pin { 'apt.postgresql.org':
-      ensure => absent,
-    }
+  # Here we have tried to replicate the instructions on the PostgreSQL site:
+  #
+  # http://www.postgresql.org/download/linux/debian/
+  #
+  apt::pin { 'apt.postgresql.org':
+    originator => 'apt.postgresql.org',
+    priority   => 500,
+  }->
+  apt::source { 'apt.postgresql.org':
+    location          => 'http://apt.postgresql.org/pub/repos/apt/',
+    release           => "${::lsbdistcodename}-pgdg",
+    repos             => "main ${version}",
+    key               => 'ACCC4CF8',
+    key_source        => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
+    include_src       => false,
   }
+
+  Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>
 }

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -4,35 +4,26 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
   $package_version = "${version_parts[0]}${version_parts[1]}"
   $gpg_key_path    = "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}"
 
-  if ($ensure == 'present' or $ensure == true) {
-    file { $gpg_key_path:
-      source => 'puppet:///modules/postgresql/RPM-GPG-KEY-PGDG',
-      before => Yumrepo['yum.postgresql.org']
-    }
-
-    if($::operatingsystem == 'Fedora') {
-      $label1 = 'fedora'
-      $label2 = $label1
-    } else {
-      $label1 = 'redhat'
-      $label2 = 'rhel'
-    }
-
-    yumrepo { 'yum.postgresql.org':
-      descr    => "PostgreSQL ${version} \$releasever - \$basearch",
-      baseurl  => "http://yum.postgresql.org/${version}/${label1}/${label2}-\$releasever-\$basearch",
-      enabled  => 1,
-      gpgcheck => 1,
-      gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
-    }
-
-    Yumrepo['yum.postgresql.org'] -> Package<|tag == 'postgresql'|>
-  } else {
-    yumrepo { 'yum.postgresql.org':
-      enabled => absent,
-    }->
-    file { $gpg_key_path:
-      ensure => absent,
-    }
+  file { $gpg_key_path:
+    source => 'puppet:///modules/postgresql/RPM-GPG-KEY-PGDG',
+    before => Yumrepo['yum.postgresql.org']
   }
+
+  if($::operatingsystem == 'Fedora') {
+    $label1 = 'fedora'
+    $label2 = $label1
+  } else {
+    $label1 = 'redhat'
+    $label2 = 'rhel'
+  }
+
+  yumrepo { 'yum.postgresql.org':
+    descr    => "PostgreSQL ${version} \$releasever - \$basearch",
+    baseurl  => "http://yum.postgresql.org/${version}/${label1}/${label2}-\$releasever-\$basearch",
+    enabled  => 1,
+    gpgcheck => 1,
+    gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
+  }
+
+  Yumrepo['yum.postgresql.org'] -> Package<|tag == 'postgresql'|>
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,16 +1,15 @@
 # This installs a PostgreSQL server. See README.md for more details.
 class postgresql::server (
-  $ensure                     = $postgresql::params::ensure,
-
   $postgres_password          = undef,
 
   $package_name               = $postgresql::params::server_package_name,
   $client_package_name        = $postgresql::params::client_package_name,
-  $package_ensure             = $ensure,
+  $package_ensure             = $postgresql::params::package_ensure,
 
   $plperl_package_name        = $postgresql::params::plperl_package_name,
 
   $service_ensure             = $postgresql::params::service_ensure,
+  $service_enable             = $postgresql::params::service_enable,
   $service_name               = $postgresql::params::service_name,
   $service_provider           = $postgresql::params::service_provider,
   $service_status             = $postgresql::params::service_status,
@@ -58,26 +57,15 @@ class postgresql::server (
     $_version = $version
   }
 
-  if ($ensure == 'present' or $ensure == true) {
-    # Reload has its own ordering, specified by other defines
-    class { "${pg}::reload": require => Class["${pg}::install"] }
+  # Reload has its own ordering, specified by other defines
+  class { "${pg}::reload": require => Class["${pg}::install"] }
 
-    anchor { "${pg}::start": }->
-    class { "${pg}::install": }->
-    class { "${pg}::initdb": }->
-    class { "${pg}::config": }->
-    class { "${pg}::service": }->
-    class { "${pg}::passwd": }->
-    class { "${pg}::firewall": }->
-    anchor { "${pg}::end": }
-  } else {
-    anchor { "${pg}::start": }->
-    class { "${pg}::firewall": }->
-    class { "${pg}::passwd": }->
-    class { "${pg}::service": }->
-    class { "${pg}::install": }->
-    class { "${pg}::initdb": }->
-    class { "${pg}::config": }->
-    anchor { "${pg}::end": }
-  }
+  anchor { "${pg}::start": }->
+  class { "${pg}::install": }->
+  class { "${pg}::initdb": }->
+  class { "${pg}::config": }->
+  class { "${pg}::service": }->
+  class { "${pg}::passwd": }->
+  class { "${pg}::firewall": }->
+  anchor { "${pg}::end": }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::config {
-  $ensure                     = $postgresql::server::ensure
   $ip_mask_deny_postgres_user = $postgresql::server::ip_mask_deny_postgres_user
   $ip_mask_allow_all_users    = $postgresql::server::ip_mask_allow_all_users
   $listen_addresses           = $postgresql::server::listen_addresses
@@ -15,107 +14,97 @@ class postgresql::server::config {
   $version                    = $postgresql::server::version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
 
-  if ($ensure == 'present' or $ensure == true) {
+  if ($manage_pg_hba_conf == true) {
+    # Prepare the main pg_hba file
+    concat { $pg_hba_conf_path:
+      owner  => $user,
+      group  => $group,
+      mode   => '0640',
+      warn   => true,
+      notify => Class['postgresql::server::reload'],
+    }
 
-    if ($manage_pg_hba_conf == true) {
-      # Prepare the main pg_hba file
-      concat { $pg_hba_conf_path:
-        owner  => $user,
-        group  => $group,
-        mode   => '0640',
-        warn   => true,
-        notify => Class['postgresql::server::reload'],
+    if $pg_hba_conf_defaults {
+      Postgresql::Server::Pg_hba_rule {
+        database => 'all',
+        user => 'all',
       }
 
-      if $pg_hba_conf_defaults {
-        Postgresql::Server::Pg_hba_rule {
-          database => 'all',
-          user => 'all',
-        }
-
-        # Lets setup the base rules
-        $local_auth_option = $version ? {
-          '8.1'   => 'sameuser',
-          default => undef,
-        }
-        postgresql::server::pg_hba_rule { 'local access as postgres user':
-          type        => 'local',
-          user        => $user,
-          auth_method => 'ident',
-          auth_option => $local_auth_option,
-          order       => '001',
-        }
-        postgresql::server::pg_hba_rule { 'local access to database with same name':
-          type        => 'local',
-          auth_method => 'ident',
-          auth_option => $local_auth_option,
-          order       => '002',
-        }
-        postgresql::server::pg_hba_rule { 'allow localhost TCP access to postgresql user':
-          type        => 'host',
-          user        => $user,
-          address     => '127.0.0.1/32',
-          auth_method => 'md5',
-          order       => '003',
-        }
-        postgresql::server::pg_hba_rule { 'deny access to postgresql user':
-          type        => 'host',
-          user        => $user,
-          address     => $ip_mask_deny_postgres_user,
-          auth_method => 'reject',
-          order       => '004',
-        }
-
-        # ipv4acls are passed as an array of rule strings, here we transform
-        # them into a resources hash, and pass the result to create_resources
-        $ipv4acl_resources = postgresql_acls_to_resources_hash($ipv4acls,
-        'ipv4acls', 10)
-        create_resources('postgresql::server::pg_hba_rule', $ipv4acl_resources)
-
-        postgresql::server::pg_hba_rule { 'allow access to all users':
-          type        => 'host',
-          address     => $ip_mask_allow_all_users,
-          auth_method => 'md5',
-          order       => '100',
-        }
-        postgresql::server::pg_hba_rule { 'allow access to ipv6 localhost':
-          type        => 'host',
-          address     => '::1/128',
-          auth_method => 'md5',
-          order       => '101',
-        }
-
-        # ipv6acls are passed as an array of rule strings, here we transform
-        # them into a resources hash, and pass the result to create_resources
-        $ipv6acl_resources = postgresql_acls_to_resources_hash($ipv6acls,
-        'ipv6acls', 102)
-        create_resources('postgresql::server::pg_hba_rule', $ipv6acl_resources)
+      # Lets setup the base rules
+      $local_auth_option = $version ? {
+        '8.1'   => 'sameuser',
+        default => undef,
       }
-    }
-
-    # We must set a "listen_addresses" line in the postgresql.conf if we
-    # want to allow any connections from remote hosts.
-    postgresql::server::config_entry { 'listen_addresses':
-      value => $listen_addresses,
-    }
-    postgresql::server::config_entry { 'port':
-      value => "${port}",
-    }
-
-    # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
-    # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
-    if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) {
-      file { '/etc/sysconfig/pgsql/postgresql':
-        ensure  => present,
-        replace => false,
+      postgresql::server::pg_hba_rule { 'local access as postgres user':
+        type        => 'local',
+        user        => $user,
+        auth_method => 'ident',
+        auth_option => $local_auth_option,
+        order       => '001',
       }
+      postgresql::server::pg_hba_rule { 'local access to database with same name':
+        type        => 'local',
+        auth_method => 'ident',
+        auth_option => $local_auth_option,
+        order       => '002',
+      }
+      postgresql::server::pg_hba_rule { 'allow localhost TCP access to postgresql user':
+        type        => 'host',
+        user        => $user,
+        address     => '127.0.0.1/32',
+        auth_method => 'md5',
+        order       => '003',
+      }
+      postgresql::server::pg_hba_rule { 'deny access to postgresql user':
+        type        => 'host',
+        user        => $user,
+        address     => $ip_mask_deny_postgres_user,
+        auth_method => 'reject',
+        order       => '004',
+      }
+
+      # ipv4acls are passed as an array of rule strings, here we transform
+      # them into a resources hash, and pass the result to create_resources
+      $ipv4acl_resources = postgresql_acls_to_resources_hash($ipv4acls,
+      'ipv4acls', 10)
+      create_resources('postgresql::server::pg_hba_rule', $ipv4acl_resources)
+
+      postgresql::server::pg_hba_rule { 'allow access to all users':
+        type        => 'host',
+        address     => $ip_mask_allow_all_users,
+        auth_method => 'md5',
+        order       => '100',
+      }
+      postgresql::server::pg_hba_rule { 'allow access to ipv6 localhost':
+        type        => 'host',
+        address     => '::1/128',
+        auth_method => 'md5',
+        order       => '101',
+      }
+
+      # ipv6acls are passed as an array of rule strings, here we transform
+      # them into a resources hash, and pass the result to create_resources
+      $ipv6acl_resources = postgresql_acls_to_resources_hash($ipv6acls,
+      'ipv6acls', 102)
+      create_resources('postgresql::server::pg_hba_rule', $ipv6acl_resources)
     }
-  } else {
-    file { $pg_hba_conf_path:
-      ensure => absent,
-    }
-    file { $postgresql_conf_path:
-      ensure => absent,
+  }
+
+  # We must set a "listen_addresses" line in the postgresql.conf if we
+  # want to allow any connections from remote hosts.
+  postgresql::server::config_entry { 'listen_addresses':
+    value => $listen_addresses,
+  }
+  postgresql::server::config_entry { 'port':
+    value => $port,
+  }
+
+  # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
+  # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
+  if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) {
+    file { '/etc/sysconfig/pgsql/postgresql':
+      ensure  => present,
+      replace => false,
     }
   }
 }

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -11,17 +11,9 @@ class postgresql::server::contrib (
     tag    => 'postgresql',
   }
 
-  if($package_ensure == 'present' or $package_ensure == true) {
-    anchor { 'postgresql::server::contrib::start': }->
-    Class['postgresql::server::install']->
-    Package['postgresql-contrib']->
-    Class['postgresql::server::service']->
-    anchor { 'postgresql::server::contrib::end': }
-  } else {
-    anchor { 'postgresql::server::contrib::start': }->
-    Class['postgresql::server::service']->
-    Package['postgresql-contrib']->
-    Class['postgresql::server::install']->
-    anchor { 'postgresql::server::contrib::end': }
-  }
+  anchor { 'postgresql::server::contrib::start': }->
+  Class['postgresql::server::install']->
+  Package['postgresql-contrib']->
+  Class['postgresql::server::service']->
+  anchor { 'postgresql::server::contrib::end': }
 }

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -1,21 +1,14 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::server::firewall {
-  $ensure             = $postgresql::server::ensure
   $manage_firewall    = $postgresql::server::manage_firewall
   $firewall_supported = $postgresql::server::firewall_supported
   $port               = $postgresql::server::port
 
   if ($manage_firewall and $firewall_supported) {
-    if ($ensure == 'present' or $ensure == true) {
-      firewall { "$port accept - postgres":
-        port   => $port,
-        proto  => 'tcp',
-        action => 'accept',
-      }
-    } else {
-      firewall { "$port accept - postgres":
-        ensure => absent,
-      }
+    firewall { "${port} accept - postgres":
+      port   => $port,
+      proto  => 'tcp',
+      action => 'accept',
     }
   }
 }

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::initdb {
-  $ensure       = $postgresql::server::ensure
   $needs_initdb = $postgresql::server::needs_initdb
   $initdb_path  = $postgresql::server::initdb_path
   $datadir      = $postgresql::server::datadir
@@ -10,67 +9,49 @@ class postgresql::server::initdb {
   $group        = $postgresql::server::group
   $user         = $postgresql::server::user
 
-  if($ensure == 'present' or $ensure == true) {
-    # Make sure the data directory exists, and has the correct permissions.
-    file { $datadir:
+  # Make sure the data directory exists, and has the correct permissions.
+  file { $datadir:
+    ensure => directory,
+    owner  => $user,
+    group  => $group,
+    mode   => '0700',
+  }
+
+  if($xlogdir) {
+    # Make sure the xlog directory exists, and has the correct permissions.
+    file { $xlogdir:
       ensure => directory,
       owner  => $user,
       group  => $group,
       mode   => '0700',
     }
+  }
 
-    if($xlogdir) {
-      # Make sure the xlog directory exists, and has the correct permissions.
-      file { $xlogdir:
-        ensure => directory,
-        owner  => $user,
-        group  => $group,
-        mode   => '0700',
-      }
+  if($needs_initdb) {
+    # Build up the initdb command.
+    #
+    # We optionally add the locale switch if specified. Older versions of the
+    # initdb command don't accept this switch. So if the user didn't pass the
+    # parameter, lets not pass the switch at all.
+    $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
+    $ic_xlog = $xlogdir ? {
+      undef   => $ic_base,
+      default => "${ic_base} --xlogdir '${xlogdir}'"
+    }
+    $initdb_command = $locale ? {
+      undef   => $ic_xlog,
+      default => "${ic_xlog} --locale '${locale}'"
     }
 
-    if($needs_initdb) {
-      # Build up the initdb command.
-      #
-      # We optionally add the locale switch if specified. Older versions of the
-      # initdb command don't accept this switch. So if the user didn't pass the
-      # parameter, lets not pass the switch at all.
-      $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
-      $ic_xlog = $xlogdir ? {
-        undef   => $ic_base,
-        default => "${ic_base} --xlogdir '${xlogdir}'"
-      }
-      $initdb_command = $locale ? {
-        undef   => $ic_xlog,
-        default => "${ic_xlog} --locale '${locale}'"
-      }
-
-      # This runs the initdb command, we use the existance of the PG_VERSION
-      # file to ensure we don't keep running this command.
-      exec { 'postgresql_initdb':
-        command   => $initdb_command,
-        creates   => "${datadir}/PG_VERSION",
-        user      => $user,
-        group     => $group,
-        logoutput => on_failure,
-        require   => File[$datadir],
-      }
-    }
-  } else {
-    # Purge data directory if ensure => absent
-    file { $datadir:
-      ensure  => absent,
-      recurse => true,
-      force   => true,
-    }
-
-    if($xlogdir) {
-      # Make sure the xlog directory exists, and has the correct permissions.
-      file { $xlogdir:
-        ensure  => absent,
-        recurse => true,
-        force   => true,
-      }
+    # This runs the initdb command, we use the existance of the PG_VERSION
+    # file to ensure we don't keep running this command.
+    exec { 'postgresql_initdb':
+      command   => $initdb_command,
+      creates   => "${datadir}/PG_VERSION",
+      user      => $user,
+      group     => $group,
+      logoutput => on_failure,
+      require   => File[$datadir],
     }
   }
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -4,32 +4,6 @@ class postgresql::server::install {
   $package_name        = $postgresql::server::package_name
   $client_package_name = $postgresql::server::client_package_name
 
-  # This is necessary to ensure that the extra client package that was
-  # installed automatically by the server package is removed and all
-  # of its dependencies are removed also. Without this later installation
-  # of the native Ubuntu packages will fail.
-  if($::operatingsystem == 'Ubuntu' and $package_ensure == 'absent') {
-    # This is an exec, because we want to invoke autoremove.
-    #
-    # An alternative would be to have a full list of packages, but that seemed
-    # more problematic to maintain, not to mention the conflict with the
-    # client class will create duplicate resources.
-    exec { 'apt-get-autoremove-postgresql-client-XX':
-      command   => "apt-get autoremove --purge --yes ${client_package_name}",
-      onlyif    => "dpkg -l ${client_package_name} | grep -e '^ii'",
-      logoutput => on_failure,
-      path      => '/usr/bin:/bin:/usr/sbin/:/sbin',
-    }
-
-    # This will clean up anything we miss
-    exec { 'apt-get-autoremove-postgresql-client-brute':
-      command   => 'dpkg -P postgresql*',
-      onlyif    => "dpkg -l postgresql* | grep -e '^ii'",
-      logoutput => on_failure,
-      path      => '/usr/bin:/bin:/usr/sbin/:/sbin',
-    }
-  }
-
   $_package_ensure = $package_ensure ? {
     true     => 'present',
     false    => 'purged',

--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -1,35 +1,32 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::passwd {
-  $ensure            = $postgresql::server::ensure
   $postgres_password = $postgresql::server::postgres_password
   $user              = $postgresql::server::user
   $group             = $postgresql::server::group
   $psql_path         = $postgresql::server::psql_path
 
-  if($ensure == 'present' or $ensure == true) {
-    if ($postgres_password != undef) {
-      # NOTE: this password-setting logic relies on the pg_hba.conf being
-      #  configured to allow the postgres system user to connect via psql
-      #  without specifying a password ('ident' or 'trust' security). This is
-      #  the default for pg_hba.conf.
-      $escaped = postgresql_escape($postgres_password)
-      $env = "env PGPASSWORD='${postgres_password}'"
-      exec { 'set_postgres_postgrespw':
-        # This command works w/no password because we run it as postgres system
-        # user
-        command     => "${psql_path} -c 'ALTER ROLE \"${user}\" PASSWORD ${escaped}'",
-        user        => $user,
-        group       => $group,
-        logoutput   => true,
-        cwd         => '/tmp',
-        # With this command we're passing -h to force TCP authentication, which
-        # does require a password.  We specify the password via the PGPASSWORD
-        # environment variable. If the password is correct (current), this
-        # command will exit with an exit code of 0, which will prevent the main
-        # command from running.
-        unless      => "${env} ${psql_path} -h localhost -c 'select 1' > /dev/null",
-        path        => '/usr/bin:/usr/local/bin:/bin',
-      }
+  if ($postgres_password != undef) {
+    # NOTE: this password-setting logic relies on the pg_hba.conf being
+    #  configured to allow the postgres system user to connect via psql
+    #  without specifying a password ('ident' or 'trust' security). This is
+    #  the default for pg_hba.conf.
+    $escaped = postgresql_escape($postgres_password)
+    $env = "env PGPASSWORD='${postgres_password}'"
+    exec { 'set_postgres_postgrespw':
+      # This command works w/no password because we run it as postgres system
+      # user
+      command     => "${psql_path} -c 'ALTER ROLE \"${user}\" PASSWORD ${escaped}'",
+      user        => $user,
+      group       => $group,
+      logoutput   => true,
+      cwd         => '/tmp',
+      # With this command we're passing -h to force TCP authentication, which
+      # does require a password.  We specify the password via the PGPASSWORD
+      # environment variable. If the password is correct (current), this
+      # command will exit with an exit code of 0, which will prevent the main
+      # command from running.
+      unless      => "${env} ${psql_path} -h localhost -c 'select 1' > /dev/null",
+      path        => '/usr/bin:/usr/local/bin:/bin',
     }
   }
 }

--- a/manifests/server/plperl.pp
+++ b/manifests/server/plperl.pp
@@ -10,18 +10,10 @@ class postgresql::server::plperl(
     tag    => 'postgresql',
   }
 
-  if($package_ensure == 'present' or $package_ensure == true) {
-    anchor { 'postgresql::server::plperl::start': }->
-    Class['postgresql::server::install']->
-    Package['postgresql-plperl']->
-    Class['postgresql::server::service']->
-    anchor { 'postgresql::server::plperl::end': }
-  } else {
-    anchor { 'postgresql::server::plperl::start': }->
-    Class['postgresql::server::service']->
-    Package['postgresql-plperl']->
-    Class['postgresql::server::install']->
-    anchor { 'postgresql::server::plperl::end': }
-  }
+  anchor { 'postgresql::server::plperl::start': }->
+  Class['postgresql::server::install']->
+  Package['postgresql-plperl']->
+  Class['postgresql::server::service']->
+  anchor { 'postgresql::server::plperl::end': }
 
 }

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -11,22 +11,14 @@ class postgresql::server::postgis (
     tag    => 'postgresql',
   }
 
-  if($package_ensure == 'present' or $package_ensure == true) {
-    anchor { 'postgresql::server::postgis::start': }->
-    Class['postgresql::server::install']->
-    Package['postgresql-postgis']->
-    Class['postgresql::server::service']->
-    anchor { 'postgresql::server::postgis::end': }
+  anchor { 'postgresql::server::postgis::start': }->
+  Class['postgresql::server::install']->
+  Package['postgresql-postgis']->
+  Class['postgresql::server::service']->
+  anchor { 'postgresql::server::postgis::end': }
 
-    if $postgresql::globals::manage_package_repo {
-      Class['postgresql::repo'] ->
-      Package['postgresql-postgis']
-    }
-  } else {
-    anchor { 'postgresql::server::postgis::start': }->
-    Class['postgresql::server::service']->
-    Package['postgresql-postgis']->
-    Class['postgresql::server::install']->
-    anchor { 'postgresql::server::postgis::end': }
+  if $postgresql::globals::manage_package_repo {
+    Class['postgresql::repo'] ->
+    Package['postgresql-postgis']
   }
 }

--- a/manifests/server/reload.pp
+++ b/manifests/server/reload.pp
@@ -1,16 +1,13 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::server::reload {
-  $ensure         = $postgresql::server::ensure
   $service_name   = $postgresql::server::service_name
   $service_status = $postgresql::server::service_status
 
-  if($ensure == 'present' or $ensure == true) {
-    exec { 'postgresql_reload':
-      path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-      command     => "service ${service_name} reload",
-      onlyif      => $service_status,
-      refreshonly => true,
-      require     => Class['postgresql::server::service'],
-    }
+  exec { 'postgresql_reload':
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+    command     => "service ${service_name} reload",
+    onlyif      => $service_status,
+    refreshonly => true,
+    require     => Class['postgresql::server::service'],
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,7 +1,7 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::service {
-  $ensure           = $postgresql::server::ensure
   $service_ensure   = $postgresql::server::service_ensure
+  $service_enable   = $postgresql::server::service_enable
   $service_name     = $postgresql::server::service_name
   $service_provider = $postgresql::server::service_provider
   $service_status   = $postgresql::server::service_status
@@ -9,34 +9,18 @@ class postgresql::server::service {
   $port             = $postgresql::server::port
   $default_database = $postgresql::server::default_database
 
-  if $service_ensure {
-    $real_service_ensure = $service_ensure
-  } else {
-    $real_service_ensure = $ensure ? {
-      present => 'running',
-      absent  => 'stopped',
-      default => $ensure
-    }
-  }
-
-  $service_enable = $ensure ? {
-    present => true,
-    absent  => false,
-    default => $ensure
-  }
-
   anchor { 'postgresql::server::service::begin': }
 
   service { 'postgresqld':
-    ensure    => $real_service_ensure,
-    name      => $service_name,
+    ensure    => $service_ensure,
     enable    => $service_enable,
+    name      => $service_name,
     provider  => $service_provider,
     hasstatus => true,
     status    => $service_status,
   }
 
-  if $real_service_ensure == 'running' {
+  if $service_ensure == 'running' {
     # This blocks the class before continuing if chained correctly, making
     # sure the service really is 'up' before continuing.
     #

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -43,46 +43,11 @@ describe 'postgresql::server', :type => :class do
     let(:params) do
       {
         :manage_firewall => true,
-        :ensure => true,
       }
     end
 
     it 'should create firewall rule' do
       is_expected.to contain_firewall("5432 accept - postgres")
-    end
-  end
-
-  describe 'ensure => absent' do
-    let(:params) do
-      {
-        :ensure => 'absent',
-        :datadir => '/my/path',
-        :xlogdir => '/xlog/path',
-      }
-    end
-
-    it 'should make package purged' do
-      is_expected.to contain_package('postgresql-server').with({
-        :ensure => 'purged',
-      })
-    end
-
-    it 'stop the service' do
-      is_expected.to contain_service('postgresqld').with({
-        :ensure => 'stopped',
-      })
-    end
-
-    it 'should remove datadir' do
-      is_expected.to contain_file('/my/path').with({
-        :ensure => 'absent',
-      })
-    end
-
-    it 'should remove xlogdir' do
-      is_expected.to contain_file('/xlog/path').with({
-        :ensure => 'absent',
-      })
     end
   end
 


### PR DESCRIPTION
This is likely to be a controversial change so I wanted to put some
explanation of our reasoning into the commit message.  This gets
kind of complex so I'll start with the problem and then the reasoning.

Problem:

We rely heavily on the ability to uninstall and reinstall postgres
throughout our testing code, testing features like "can I move from the
distribution packages to the upstream packages through the module" and
over time we've learnt that the uninstall code simply doesn't work a lot
of the time.  It leaves traces of postgres behind or fails to remove
certain packages on Ubuntu, and generally causes bits to be left on your
system that you didn't expect.

When we then reinstall things fail because it's not a true clean slate,
and this causes us enormous problems during test.  We've spent weeks and
months working on these tests and they simply don't hold up well across
the full range of PE platforms.

Reasoning:

Due to all these problems we've decided to take a stance on uninstalling
in general.  We feel that in 2014 it's completely reasonable and normal
to have a good provisioning pipeline combined with your configuration
management and the "correct" way to uninstall a fully installed service
like postgresql is to simply reprovision the server without it in the
first place.  As a general rule this is how I personally like to work
and I think is a good practice.

WAIT A MINUTE:

We understand that there are environments and situations in which it's
not easy to do that.  What if you accidently deployed Postgres on
100,000 nodes?  When this work is finished I'm going to take a look at
building some example 'profiles' to be found under examples/ within this
module that can uninstall postgres on popular platforms.  These can be
modified and used in your specific case to uninstall postgresql.  They
will be much more brute force and reliant on deleting entire directories
and require you to do more work up front in specifying where things are
installed but we think it'll prove to be a much cleaner mechanism for
this kind of thing rather than trying to weave it into the main module
logic itself.
