### PR TITLE
Fix Fedora support by configuring systemd, not /etc/sysconfig

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -104,7 +104,7 @@ class postgresql::server::config {
 
     # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
     # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
-    if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) {
+    if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) and ($::operatingsystem != 'Fedora') {
       file { '/etc/sysconfig/pgsql/postgresql':
         ensure  => present,
         replace => false,

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -30,7 +30,7 @@ define postgresql::server::config_entry (
   # have to create a systemd override for the port or update the sysconfig
   # file.
   if $::osfamily == 'RedHat' {
-    if $::operatingsystemrelease =~ /^7/ {
+    if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       if $name == 'port' {
         file { 'systemd-port-override':
           ensure  => present,

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'postgresql::server::config_entry', :type => :define do
-  let :facts do
+  let :default_facts do
     {
       :osfamily => 'RedHat',
       :operatingsystem => 'RedHat',
@@ -12,6 +12,7 @@ describe 'postgresql::server::config_entry', :type => :define do
       :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end
+  let(:facts) { default_facts }
 
   let(:title) { 'config_entry'}
 
@@ -26,6 +27,45 @@ describe 'postgresql::server::config_entry', :type => :define do
 
     let(:params) { { :ensure => 'present'} }
     it { should contain_postgresql__server__config_entry('config_entry') }
+  end
+
+  context "setting port" do
+    let :pre_condition do
+      # ensuring present causes duplicate port declaration
+      "class {'postgresql::server': ensure => false}"
+    end
+
+    let(:title) { 'port'}
+    let(:params) { { :ensure => 'present', :value => 9000 } }
+
+    describe "on EL6" do
+      it { should contain_postgresql_conf('port').with_value(9000) }
+      it { should contain_augeas('override PGPORT in /etc/sysconfig/pgsql/postgresql').
+             with_context('/files/etc/sysconfig/pgsql/postgresql').
+             with_changes('set PGPORT 9000') }
+      it { should contain_exec('postgresql_stop') }
+    end
+
+    describe "on EL7" do
+      let(:facts) { default_facts.merge({ :operatingsystemrelease => '7.0' }) }
+
+      it { should contain_postgresql_conf('port').with_value(9000) }
+      it { should contain_file('systemd-port-override').
+             with_path('/etc/systemd/system/postgresql.service') }
+      it { should contain_exec('restart-systemd') }
+    end
+
+    describe "on Fedora" do
+      let(:facts) { default_facts.merge({
+        :operatingsystem => 'Fedora',
+        :operatingsystemrelease => '19'
+      }) }
+
+      it { should contain_postgresql_conf('port').with_value(9000) }
+      it { should contain_file('systemd-port-override').
+             with_path('/etc/systemd/system/postgresql.service') }
+      it { should contain_exec('restart-systemd') }
+    end
   end
 end
 


### PR DESCRIPTION
https://gist.github.com/domcleal/9a9d92504991e0f66957 has logs showing the issue and verifying the fix.

Please note that this is broken in master, the latest released module works fine.
