### PR TITLE
Initdb should create xlogdir if it has been set.

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -38,6 +38,15 @@ class postgresql::server::initdb {
       undef   => $ic_base,
       default => "${ic_base} --xlogdir '${xlogdir}'"
     }
+
+    # The xlogdir need to be present before initdb runs.
+    # If xlogdir is default it's created by package installer
+    if($xlogdir) {
+      $require_before_initdb = [$datadir, $xlogdir]
+    } else {
+      $require_before_initdb = [$datadir]
+    }
+
     $initdb_command = $locale ? {
       undef   => $ic_xlog,
       default => "${ic_xlog} --locale '${locale}'"
@@ -51,7 +60,7 @@ class postgresql::server::initdb {
       user      => $user,
       group     => $group,
       logoutput => on_failure,
-      require   => File[$datadir],
+      require   => File[$require_before_initdb],
     }
   }
 }


### PR DESCRIPTION
Initdb script fails if the xlogdir variable has been set but hasn't
been created upon execution of postgresql_initdb if the directory already
exists but not is owned by the postgresql user.
Therefor I've made the require in the exec optional.

Below you find the output when postgresql_initdb runs and the evaluation
of file{$xlogdir} afterwards.

```
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: The files belonging to this database system will be owned by user "postgres".
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: This user must also own the server process.
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: 
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: The database cluster will be initialized with locale "en_US.UTF-8".
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: The default database encoding has accordingly been set to "UTF8".
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: The default text search configuration will be set to "english".
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: 
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: Data page checksums are disabled.
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: 
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: fixing permissions on existing directory /srv/pg/data ... ok
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: fixing permissions on existing directory /srv/pglog ... initdb: could not change permissions of directory "/srv/pglog": Operation not permitted
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: initdb: removing contents of data directory "/srv/pg/data"
Error: /usr/lib/postgresql/9.3/bin/initdb --encoding '' --pgdata '/srv/pg/data' --xlogdir '/srv/pglog' returned 1 instead of one of [0]
Error: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: change from notrun to 0 failed: /usr/lib/postgresql/9.3/bin/initdb --encoding '' --pgdata '/srv/pg/data' --xlogdir '/srv/pglog' returned 1 instead of one of [0]
Notice: /Stage[main]/Postgresql::Server::Initdb/File[/srv/pglog]/owner: owner changed 'root' to 'postgres'
Notice: /Stage[main]/Postgresql::Server::Initdb/File[/srv/pglog]/group: group changed 'root' to 'postgres'
Notice: /Stage[main]/Postgresql::Server::Initdb/File[/srv/pglog]/mode: mode changed '0755' to '0700'
```

Please forgive me for not adding a proper acceptancetest to this because
I have no clue how to check that. I think it passed acceptancetests
before because of ordering issues.
