### PR TITLE
Fix Fedora support by configuring systemd, not /etc/sysconfig

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -101,7 +101,7 @@ class postgresql::server::config {
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
   # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
-  if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) {
+  if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) and ($::operatingsystem != 'Fedora') {
     file { '/etc/sysconfig/pgsql/postgresql':
       ensure  => present,
       replace => false,

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -30,7 +30,7 @@ define postgresql::server::config_entry (
   # have to create a systemd override for the port or update the sysconfig
   # file.
   if $::osfamily == 'RedHat' {
-    if $::operatingsystemrelease =~ /^7/ {
+    if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       if $name == 'port' {
         file { 'systemd-port-override':
           ensure  => present,

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -67,6 +67,25 @@ describe 'postgresql::server::config_entry', :type => :define do
         is_expected.to contain_exec('restart-systemd')
       end
     end
+    context 'fedora 19' do
+      let :facts do
+        {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'Fedora',
+          :operatingsystemrelease => '19',
+          :kernel => 'Linux',
+          :concat_basedir => tmpfilename('contrib'),
+          :id => 'root',
+          :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        }
+      end
+      let(:params) {{ :ensure => 'present', :name => 'port', :value => '5432' }}
+
+      it 'stops postgresql and changes the port' do
+        is_expected.to contain_file('systemd-port-override')
+        is_expected.to contain_exec('restart-systemd')
+      end
+    end
   end
 
   context "passes values through appropriately" do


### PR DESCRIPTION
Nabbed from @domcleal and rebased. From original PR:

https://gist.github.com/domcleal/9a9d92504991e0f66957 has logs showing the issue and verifying the fix.
