### PR TITLE
Fixes the accidental erasing of pg_ident.conf

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -14,7 +14,7 @@ class postgresql::server::config {
   $group                      = $postgresql::server::group
   $version                    = $postgresql::server::version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
-  $manage_pg_ident_conf       = $postgresql::server::manage_pg_hba_conf
+  $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file


### PR DESCRIPTION
Even with manage_pg_ident_conf to false, or undef (witch defaults to
false), a concat object would be created, erasing the pg_ident.conf file. 
That bug was introduced by bf328c870be92fbd2426f579e162d3b038564ba5 
