### PR TITLE
Adding postgresql class with $databases hash for Hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,4 @@
+class postgresql($databases = {}) {
+  validate_hash($databases)
+  create_resources('postgresql::server::db', hiera_hash('postgresql::databases', {}))
+}


### PR DESCRIPTION
Will create `postgresql::server::db` resources using Hiera from the
`postgresql::databases` hash. Can totally add other resources this easily
in the future.
