### PR TITLE
Update server.pp

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -48,15 +48,15 @@ class postgresql::server (
   $firewall_supported         = $postgresql::params::firewall_supported,
 
   #Deprecated
-  $version                    = $postgresql::params::version,
+  $version                    = 'DEPRECATED',
 ) inherits postgresql::params {
   $pg = 'postgresql::server'
 
-  if $version != undef {
+  if $version != 'DEPRECATED' {
     warning('Passing "version" to postgresql::server is deprecated; please use postgresql::globals instead.')
-    $_version = $postgresql::params::version
-  } else {
     $_version = $version
+  } else {
+    $_version = $postgresql::params::version
   }
 
   # Reload has its own ordering, specified by other defines


### PR DESCRIPTION
In @8db4a0c, the deprecation warning code was (silently) extended. This lead to deprecation warnings when you did _NOT_ specify the version in "class { 'postgresql::server': }", because the parameter was always set by the inheritance down from postgresql::params::version (which is in turn set by postgresql::globals).

So in postgresql::server, this value could never ever be version==undef, thus forcing the if-statement always being true, which lead to the "false positive". This wasn't catched by the unit tests.

Maybe I'll extend the unit test further, if I find the time...
