### PR TITLE
Fixed deprecation warning for class param  in server.pp.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -48,15 +48,15 @@ class postgresql::server (
   $firewall_supported         = $postgresql::params::firewall_supported,
 
   #Deprecated
-  $version                    = $postgresql::params::version,
+  $version                    = undef,
 ) inherits postgresql::params {
   $pg = 'postgresql::server'
 
   if $version != undef {
     warning('Passing "version" to postgresql::server is deprecated; please use postgresql::globals instead.')
-    $_version = $postgresql::params::version
-  } else {
     $_version = $version
+  } else {
+    $_version = $postgresql::params::version
   }
 
   # Reload has its own ordering, specified by other defines

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -12,7 +12,7 @@ class postgresql::server::config {
   $pg_hba_conf_defaults       = $postgresql::server::pg_hba_conf_defaults
   $user                       = $postgresql::server::user
   $group                      = $postgresql::server::group
-  $version                    = $postgresql::server::version
+  $version                    = $postgresql::server::_version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_hba_conf
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -13,7 +13,7 @@ define postgresql::server::database(
   $group         = $postgresql::server::group
   $psql_path     = $postgresql::server::psql_path
   $port          = $postgresql::server::port
-  $version       = $postgresql::server::version
+  $version       = $postgresql::server::_version
   $default_db    = $postgresql::server::default_database
 
   # Set the defaults for the postgresql_psql resource

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -25,7 +25,7 @@ define postgresql::server::pg_hba_rule(
       fail('You must specify an address property when type is host based')
     }
 
-    $allowed_auth_methods = $postgresql::server::version ? {
+    $allowed_auth_methods = $postgresql::server::_version ? {
       '9.3' => ['trust', 'reject', 'md5', 'sha1', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.2' => ['trust', 'reject', 'md5', 'sha1', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.1' => ['trust', 'reject', 'md5', 'sha1', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -15,7 +15,7 @@ define postgresql::server::role(
   $psql_user  = $postgresql::server::user
   $psql_group = $postgresql::server::group
   $psql_path  = $postgresql::server::psql_path
-  $version    = $postgresql::server::version
+  $version    = $postgresql::server::_version
 
   $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
   $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -8,7 +8,7 @@ define postgresql::server::schema(
   $group     = $postgresql::server::group
   $port      = $postgresql::server::port
   $psql_path = $postgresql::server::psql_path
-  $version   = $postgresql::server::version
+  $version   = $postgresql::server::_version
 
   Postgresql_psql {
     db         => $db,


### PR DESCRIPTION
- Changed subclasses of server to use ::_version, which will be assigned the value from globals or (deprecated) class param.
- Could not write a test for the warning, according to https://github.com/rodjek/rspec-puppet/issues/108 this isn't possible right now with rspec-puppet.

This is in reference to my comment on #438.
