### PR TITLE
Fix lsbmajdistreleasee fact for Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,7 +116,7 @@ class postgresql::params inherits postgresql::globals {
         $service_name = $::operatingsystem ? {
           'Debian' => pick($service_name, 'postgresql'),
           'Ubuntu' => $::lsbmajdistrelease ? {
-            '10' => pick($service_name, "postgresql-${version}"),
+            /^10/ => pick($service_name, "postgresql-${version}"),
             default => pick($service_name, 'postgresql'),
           },
           default => undef


### PR DESCRIPTION
Since facter 2.2.0 'fixed' the lsbmajdistrelease fact for Ubuntu, we now have to regexp
for the value. The new value would be '10.04' whereas the old is '10'.

Signed-off-by: Ken Barber ken@bob.sh
