### PR TITLE
allow RHEL7 yum repositories

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -108,11 +108,8 @@ class postgresql::globals (
 
   # Setup of the repo only makes sense globally, so we are doing this here.
   if($manage_package_repo) {
-    # Workaround the lack of RHEL7 repositories for now.
-    if ! ($::operatingsystem == 'RedHat' and $::operatingsystemrelease =~ /^7/) {
-      class { 'postgresql::repo':
-        version => $globals_version
-      }
+    class { 'postgresql::repo':
+      version => $globals_version
     }
   }
 }


### PR DESCRIPTION
postgresql.org now has a RHEL7 repo available, so this workaround should no longer be necessary.
