### PR TITLE
Adding support for plaintext passwords passed to postgresql::server::role

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,9 @@ This resource creates a role or user in PostgreSQL.
 ####`namevar`
 The role name to create.
 
+####`password`
+The plaintext password to use. It will be hashed with the `postgresql_password` function to provide a MD5 hash.
+
 ####`password_hash`
 The hash to use during password creation. If the password is not already pre-encrypted in a format that PostgreSQL supports, use the `postgresql_password` function to provide an MD5 hash here, for example:
 


### PR DESCRIPTION
I wanted to manage roles with hiera hashes using the create_resource() function so I didn't know how to utilize the postgresql_password() password function in that way, so I added a new parameter and the defined type hashes it for me.
