### PR TITLE
    Changes to support OpenBSD.

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -83,6 +83,7 @@ class postgresql::globals (
       default => '9.2',
     },
     'FreeBSD' => '93',
+    'OpenBSD' => '9.3',
     'Suse' => $::operatingsystem ? {
       'SLES' => '91',
       default => undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,9 +173,9 @@ class postgresql::params inherits postgresql::globals {
       $user                = pick($user, '_postgresql')
       $group               = pick($group, '_postgresql')
 
-      $client_package_name  = pick($client_package_name, "postgresql-client")
-      $server_package_name  = pick($server_package_name, "postgresql-server")
-      $contrib_package_name = pick($contrib_package_name, "postgresql-contrib")
+      $client_package_name  = pick($client_package_name, 'postgresql-client')
+      $server_package_name  = pick($server_package_name, 'postgresql-server')
+      $contrib_package_name = pick($contrib_package_name, 'postgresql-contrib')
       $devel_package_name   = pick($devel_package_name, 'postgresql-client')
       $java_package_name    = pick($java_package_name, 'postgresql-jdbc')
       $perl_package_name    = pick($perl_package_name, 'databases/p5-DBD-Pg')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class postgresql::params inherits postgresql::globals {
   $version                    = $globals_version
   $postgis_version            = $globals_postgis_version
   $listen_addresses           = 'localhost'
-  $port                       = 5432
+  $port                       = '5432'
   $ip_mask_deny_postgres_user = '0.0.0.0/0'
   $ip_mask_allow_all_users    = '127.0.0.1/32'
   $ipv4acls                   = []
@@ -58,6 +58,7 @@ class postgresql::params inherits postgresql::globals {
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $service_status      = $service_status
+      $service_reload      = "service ${service_name} reload"
       $perl_package_name   = pick($perl_package_name, 'perl-DBD-Pg')
       $python_package_name = pick($python_package_name, 'python-psycopg2')
 
@@ -95,6 +96,7 @@ class postgresql::params inherits postgresql::globals {
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $service_status      = $service_status
+      $service_reload      = "service ${service_name} reload"
       $python_package_name = pick($python_package_name, 'python-psycopg2')
       # Archlinux does not have a perl::DBD::Pg package
       $perl_package_name = pick($perl_package_name, 'undef')
@@ -139,6 +141,7 @@ class postgresql::params inherits postgresql::globals {
       $datadir              = pick($datadir, "/var/lib/postgresql/${version}/main")
       $confdir              = pick($confdir, "/etc/postgresql/${version}/main")
       $service_status       = pick($service_status, "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+|online'")
+      $service_reload       = "service ${service_name} reload"
       $psql_path            = pick($psql_path, "/usr/bin/psql")
     }
 
@@ -160,6 +163,31 @@ class postgresql::params inherits postgresql::globals {
       $datadir              = pick($datadir, '/usr/local/pgsql/data')
       $confdir              = pick($confdir, $datadir)
       $service_status       = pick($service_status, "/usr/local/etc/rc.d/${service_name} status")
+      $service_reload       = "service ${service_name} reload"
+      $psql_path            = pick($psql_path, "${bindir}/psql")
+
+      $needs_initdb         = pick($needs_initdb, true)
+    }
+
+    'OpenBSD': {
+      $user                = pick($user, '_postgresql')
+      $group               = pick($group, '_postgresql')
+
+      $client_package_name  = pick($client_package_name, "postgresql-client")
+      $server_package_name  = pick($server_package_name, "postgresql-server")
+      $contrib_package_name = pick($contrib_package_name, "postgresql-contrib")
+      $devel_package_name   = pick($devel_package_name, 'postgresql-client')
+      $java_package_name    = pick($java_package_name, 'postgresql-jdbc')
+      $perl_package_name    = pick($perl_package_name, 'databases/p5-DBD-Pg')
+      $plperl_package_name  = undef
+      $python_package_name  = pick($python_package_name, 'py-psycopg2')
+
+      $service_name         = pick($service_name, 'postgresql')
+      $bindir               = pick($bindir, '/usr/local/bin')
+      $datadir              = pick($datadir, '/var/postgresql/data')
+      $confdir              = pick($confdir, $datadir)
+      $service_status       = pick($service_status, "/etc/rc.d/${service_name} check")
+      $service_reload       = "/etc/rc.d/${service_name} reload"
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $needs_initdb         = pick($needs_initdb, true)
@@ -183,6 +211,7 @@ class postgresql::params inherits postgresql::globals {
       $datadir              = pick($datadir, '/var/lib/pgsql/data')
       $confdir              = pick($confdir, $datadir)
       $service_status       = pick($service_status, "/etc/init.d/${service_name} status")
+      $service_reload       = "/etc/init.d/${service_name} reload"
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $needs_initdb         = pick($needs_initdb, true)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,6 +12,7 @@ class postgresql::server (
   $service_enable             = $postgresql::params::service_enable,
   $service_name               = $postgresql::params::service_name,
   $service_provider           = $postgresql::params::service_provider,
+  $service_reload             = $postgresql::params::service_reload,
   $service_status             = $postgresql::params::service_status,
   $default_database           = $postgresql::params::default_database,
 

--- a/manifests/server/reload.pp
+++ b/manifests/server/reload.pp
@@ -2,10 +2,11 @@
 class postgresql::server::reload {
   $service_name   = $postgresql::server::service_name
   $service_status = $postgresql::server::service_status
+  $service_reload = $postgresql::server::service_reload
 
   exec { 'postgresql_reload':
     path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-    command     => "service ${service_name} reload",
+    command     => $service_reload,
     onlyif      => $service_status,
     refreshonly => true,
     require     => Class['postgresql::server::service'],


### PR DESCRIPTION
I messed up the other fork a bit, therefore created just new one, and new pull request 
for the same changes to support OpenBSD:    

Added $service_reload parameter to params.pp, in order to allow
    a reload of the postgresql server on OpenBSD, which apparently doesn't
    have a service binary.

    Add $service_reload to the global variables.

    document service_reload parameter in README.md

    Add the service_reload parameter to the freshly added Suse OS.

    undef is a keyword, not a string.
    remove the firewall_supported parameter from OpenBSD too, as
    it got removed from original master.

    pick function doesn't work with undef, so don't use it,
    and fix the default package name for the perl package.
    Both just for OpenBSD.