### PR TITLE
Fixed description for schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ This defined type can be used to create a schema. For example:
       db    => 'janedb',
     }
 
-It will create the schema `jane` in the database `janedb` if neccessary,
+It will create the schema `isolated` in the database `janedb` if neccessary,
 assigning the user `jane` ownership permissions.
 
 ####`namevar`


### PR DESCRIPTION
The schema example referenced isolated as the namevar but in the description it said that the schema jane would be created.  Fixed by updating description to say schema named isolated will be created.
