### PR TITLE
fix future parser error

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -70,7 +70,7 @@ define postgresql::server::database(
     refreshonly => true,
   }
 
-  Exec [ $createdb_command ]->
+  Exec[ $createdb_command ]->
   postgresql_psql {"UPDATE pg_database SET datistemplate = ${istemplate} WHERE datname = '${dbname}'":
     unless => "SELECT datname FROM pg_database WHERE datname = '${dbname}' AND datistemplate = ${istemplate}",
     db     => $default_db,


### PR DESCRIPTION
I was receiving this error when using future parser on Puppet 3.7.1:

```
This Type-Name is not productive. A non productive construct may only be placed last in a block/sequence at /srv/puppet-environments/staging/modules/postgresql/manifests/server/database.pp:73:3
```

This should fix it.
