### PR TITLE
Fix Exec syntax to comply with Future Parser

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -70,7 +70,7 @@ define postgresql::server::database(
     refreshonly => true,
   }
 
-  Exec [ $createdb_command ]->
+  Exec[ $createdb_command ]->
   postgresql_psql {"UPDATE pg_database SET datistemplate = ${istemplate} WHERE datname = '${dbname}'":
     unless => "SELECT datname FROM pg_database WHERE datname = '${dbname}' AND datistemplate = ${istemplate}",
     db     => $default_db,


### PR DESCRIPTION
In the Future Parser it seems you are not allowed a space between `Class` and its `[`. The validate command gives this error:

`This Type-Name is not productive. A non productive construct may only be placed last in a block/sequence`.

Removing the space makes it happy and ready for Puppet 4.
