### PR TITLE
Ensure that data_directory is set in the config.

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -15,6 +15,7 @@ class postgresql::server::config {
   $version                    = $postgresql::server::_version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
+  $datadir                    = $postgresql::server::datadir
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -99,6 +100,10 @@ class postgresql::server::config {
   }
   postgresql::server::config_entry { 'port':
     value => $port,
+  }
+
+  postgresql::server::config_entry { 'data_directory':
+    value => $datadir,
   }
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden


### PR DESCRIPTION
This change ensures that setting $datadir for postgresql::server actually does what I'd expect.
