### PR TITLE
Adds support for PGDATA changing

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -15,6 +15,7 @@ class postgresql::server::config {
   $version                    = $postgresql::server::_version
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
+  $datadir                    = $postgresql::server::datadir
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -99,6 +100,9 @@ class postgresql::server::config {
   }
   postgresql::server::config_entry { 'port':
     value => $port,
+  }
+  postgresql::server::config_entry { 'data_directory':
+    value => $datadir,
   }
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden

--- a/spec/acceptance/alternative_pgdata_spec.rb
+++ b/spec/acceptance/alternative_pgdata_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper_acceptance'
+
+# These tests ensure that postgres can change itself to an alternative pgdata
+# location properly.
+describe 'postgres::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  it 'on an alternative pgdata location' do
+    pp = <<-EOS
+      class { 'postgresql::server': datadir => '/var/pgsql' }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+  
+  describe "Alternate Directory" do
+    File.directory?("/var/pgsql").should be true
+  end
+
+  it 'can connect with psql' do
+    psql('--command="\l" postgres', 'postgres') do |r|
+      expect(r.stdout).to match(/List of databases/)
+    end
+  end
+
+end

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -88,6 +88,15 @@ describe 'postgresql::server::config_entry', :type => :define do
     end
   end
 
+  context "data_directory" do
+    let(:params) {{ :ensure => 'present', :name => 'data_directory_spec', :value => '/var/pgsql' }}
+
+    it 'stops postgresql and changes the data directory' do
+      is_expected.to contain_exec('postgresql_data_directory')
+      is_expected.to contain_augeas('override PGDATA in /etc/sysconfig/pgsql/postgresql')
+    end
+  end
+
   context "passes values through appropriately" do
     let(:params) {{ :ensure => 'present', :name => 'check_function_bodies', :value => 'off' }}
 


### PR DESCRIPTION
Commit implements a method for module to change location of PGDATA in /etc/sysconfig/pgsql. I've closed original pull request that had all commits together and I'm breaking it into few smaller additions.

Tested on CentOS 6.x  - PostgreSQL 9.x 
