### PR TITLE
Add postgresql::server::extension definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Resources:
 * [postgresql::server::db](#resource-postgresqlserverdb)
 * [postgresql::server::database](#resource-postgresqlserverdatabase)
 * [postgresql::server::database_grant](#resource-postgresqlserverdatabase_grant)
+* [postgresql::server::extension](#resource-postgresqlserverextension)
 * [postgresql::server::pg_hba_rule](#resource-postgresqlserverpg_hba_rule)
 * [postgresql::server::pg_ident_rule](#resource-postgresqlserver_pg_identrule)
 * [postgresql::server::role](#resource-postgresqlserverrole)
@@ -662,6 +663,21 @@ Database to execute the grant against. This should not ordinarily be changed fro
 ####`psql_user`
 OS user for running `psql`. Defaults to the default user for the module, usually `postgres`.
 
+
+###Resource: postgresql::server::extension
+Manages a postgresql extension.
+
+####`database`
+The database on which to activate the extension.
+
+####`ensure`
+Whether to activate (`present`) or deactivate (`absent`) the extension.
+
+####`package_name`
+If provided, this will install the given package prior to activating the extension.
+
+####`package_ensure`
+By default, the package specified with `package_name` will be installed when the extension is activated, and removed when the extension is deactivated. You can override this behavior by setting the `ensure` value for the package.
 
 ###Resource: postgresql::server::pg\_hba\_rule
 This defined type allows you to create an access rule for `pg_hba.conf`. For more details see the [PostgreSQL documentation](http://www.postgresql.org/docs/8.2/static/auth-pg-hba-conf.html).

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,0 +1,49 @@
+# Activate an extension on a postgresql database
+define postgresql::server::extension (
+  $database,
+  $ensure = 'present',
+  $package_name = undef,
+  $package_ensure = undef,
+) {
+  case $ensure {
+    'present': {
+      $command = "CREATE EXTENSION ${name}"
+      $unless_comp = '='
+      $package_require = undef
+      $package_before = Postgresql_psql["Add ${title} extension to ${database}"]
+    }
+
+    'absent': {
+      $command = "DROP EXTENSION ${name}"
+      $unless_comp = '!='
+      $package_require = Postgresql_psql["Add ${title} extension to ${database}"]
+      $package_before = undef
+    }
+
+    default: {
+      fail("Unknown value for ensure '${ensure}'.")
+    }
+  }
+
+  postgresql_psql {"Add ${title} extension to ${database}":
+    db      => $database,
+    command => $command,
+    unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${name}') as t WHERE t.count ${unless_comp} 1",
+    require => Postgresql::Server::Database[$database],
+  }
+
+  if $package_name {
+    $_package_ensure = $package_ensure ? {
+      undef   => $ensure,
+      default => $package_ensure,
+    }
+
+    package { "Postgresql extension ${title}":
+      ensure  => $_package_ensure,
+      name    => $package_name,
+      tag     => 'postgresql',
+      require => $package_require,
+      before  => $package_before,
+    }
+  }
+}

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+describe 'postgresql::server::extension', :type => :define do
+  let :pre_condition do
+    "class { 'postgresql::server': }
+     postgresql::server::database { 'template_postgis':
+       template   => 'template1',
+     }"
+  end
+
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :concat_basedir => tmpfilename('postgis'),
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let (:title) { 'postgis' }
+  let (:params) { {
+    :database => 'template_postgis',
+  } }
+
+  context "with mandatory arguments only" do
+    it {
+      is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+        :db      => 'template_postgis',
+        :command => 'CREATE EXTENSION postgis',
+        :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count = 1",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
+    }
+  end
+
+  context "when setting package name" do
+    let (:params) { super().merge({
+      :package_name => 'postgis',
+    }) }
+
+    it {
+      is_expected.to contain_package('Postgresql extension postgis').with({
+        :ensure  => 'present',
+        :name    => 'postgis',
+      }).that_comes_before('Postgresql_psql[Add postgis extension to template_postgis]')
+    }
+  end
+
+  context "when ensuring absence" do
+    let (:params) { super().merge({
+      :ensure       => 'absent',
+      :package_name => 'postgis',
+    }) }
+
+    it {
+      is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+        :db      => 'template_postgis',
+        :command => 'DROP EXTENSION postgis',
+        :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
+    }
+
+    it {
+      is_expected.to contain_package('Postgresql extension postgis').with({
+        :ensure  => 'absent',
+        :name    => 'postgis',
+      })
+    }
+
+    context "when keeping package installed" do
+      let (:params) { super().merge({
+        :package_ensure => 'present',
+      }) }
+
+      it {
+        is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+          :db      => 'template_postgis',
+          :command => 'DROP EXTENSION postgis',
+          :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
+        }).that_requires('Postgresql::Server::Database[template_postgis]')
+      }
+
+      it {
+        is_expected.to contain_package('Postgresql extension postgis').with({
+          :ensure  => 'present',
+          :name    => 'postgis',
+        }).that_requires('Postgresql_psql[Add postgis extension to template_postgis]')
+      }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `postgresql::server::extension` definition used to activate an extension on a given database.