### PR TITLE
Create postgis template with extensions

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -15,6 +15,7 @@ define postgresql::server::extension (
     package { "Postgresql extension ${title}":
       ensure => $package_ensure,
       name   => $package_name,
+      before => Postgresql_psql["Add ${title} extension to ${database}"],
     }
   }
 }

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -39,10 +39,11 @@ define postgresql::server::extension (
     }
 
     package { "Postgresql extension ${title}":
-      ensure => $_package_ensure,
-      name   => $package_name,
+      ensure  => $_package_ensure,
+      name    => $package_name,
+      tag     => 'postgresql',
       require => $package_require,
-      before => $package_before,
+      before  => $package_before,
     }
   }
 }

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,0 +1,11 @@
+# Activate an extension on a postgresql database
+define postgresql::server::extension (
+  $database,
+) {
+  postgresql_psql {"Add ${title} extension to ${database}":
+    db      => $database,
+    command => "CREATE EXTENSION ${name}",
+    unless  => "SELECT extname FROM pg_extension WHERE extname = '${name}'",
+    require => Postgresql::Server::Database[$database],
+  }
+}

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,11 +1,20 @@
 # Activate an extension on a postgresql database
 define postgresql::server::extension (
   $database,
+  $package_name = undef,
+  $package_ensure = 'present',
 ) {
   postgresql_psql {"Add ${title} extension to ${database}":
     db      => $database,
     command => "CREATE EXTENSION ${name}",
     unless  => "SELECT extname FROM pg_extension WHERE extname = '${name}'",
     require => Postgresql::Server::Database[$database],
+  }
+
+  if $package_name {
+    package { "Postgresql extension ${title}":
+      ensure => $package_ensure,
+      name   => $package_name,
+    }
   }
 }

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,21 +1,48 @@
 # Activate an extension on a postgresql database
 define postgresql::server::extension (
   $database,
+  $ensure = 'present',
   $package_name = undef,
-  $package_ensure = 'present',
+  $package_ensure = undef,
 ) {
+  case $ensure {
+    'present': {
+      $command = "CREATE EXTENSION ${name}"
+      $unless_comp = '='
+      $package_require = undef
+      $package_before = Postgresql_psql["Add ${title} extension to ${database}"]
+    }
+
+    'absent': {
+      $command = "DROP EXTENSION ${name}"
+      $unless_comp = '!='
+      $package_require = Postgresql_psql["Add ${title} extension to ${database}"]
+      $package_before = undef
+    }
+
+    default: {
+      fail("Unknown value for ensure '${ensure}'.")
+    }
+  }
+
   postgresql_psql {"Add ${title} extension to ${database}":
     db      => $database,
-    command => "CREATE EXTENSION ${name}",
-    unless  => "SELECT extname FROM pg_extension WHERE extname = '${name}'",
+    command => $command,
+    unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${name}') as t WHERE t.count ${unless_comp} 1",
     require => Postgresql::Server::Database[$database],
   }
 
   if $package_name {
+    $_package_ensure = $package_ensure ? {
+      undef   => $ensure,
+      default => $package_ensure,
+    }
+
     package { "Postgresql extension ${title}":
-      ensure => $package_ensure,
+      ensure => $_package_ensure,
       name   => $package_name,
-      before => Postgresql_psql["Add ${title} extension to ${database}"],
+      require => $package_require,
+      before => $package_before,
     }
   }
 }

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -1,7 +1,11 @@
 # Install the postgis postgresql packaging. See README.md for more details.
 class postgresql::server::postgis (
   $package_name   = $postgresql::params::postgis_package_name,
-  $package_ensure = 'present'
+  $package_ensure = 'present',
+  $template = false,
+  $template_name = 'template_postgis',
+  $base_template = 'template1',
+  $extensions = ['postgis', 'postgis_topology'],
 ) inherits postgresql::params {
   validate_string($package_name)
 
@@ -9,6 +13,17 @@ class postgresql::server::postgis (
     ensure => $package_ensure,
     name   => $package_name,
     tag    => 'postgresql',
+  }
+
+  if $template {
+    postgresql::server::database { 'postgis template':
+      dbname     => $template_name,
+      istemplate => true,
+      template   => $base_template,
+    }
+    postgresql::server::extension { $extensions:
+      database => $template_name,
+    }
   }
 
   anchor { 'postgresql::server::postgis::start': }->

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -1,19 +1,14 @@
 # Install the postgis postgresql packaging. See README.md for more details.
 class postgresql::server::postgis (
   $package_name   = $postgresql::params::postgis_package_name,
-  $package_ensure = 'present',
+  $extension_ensure = 'present',
+  $package_ensure = undef,
   $template = false,
   $template_name = 'template_postgis',
   $base_template = 'template1',
   $extensions = ['postgis', 'postgis_topology'],
 ) inherits postgresql::params {
   validate_string($package_name)
-
-  package { 'postgresql-postgis':
-    ensure => $package_ensure,
-    name   => $package_name,
-    tag    => 'postgresql',
-  }
 
   if $template {
     postgresql::server::database { 'postgis template':
@@ -22,7 +17,10 @@ class postgresql::server::postgis (
       template   => $base_template,
     }
     postgresql::server::extension { $extensions:
-      database => $template_name,
+      database       => $template_name,
+      ensure         => $extension_ensure,
+      package_name   => $package_name,
+      package_ensure => $package_ensure,
     }
   }
 

--- a/spec/unit/classes/server/postgis_spec.rb
+++ b/spec/unit/classes/server/postgis_spec.rb
@@ -17,7 +17,7 @@ describe 'postgresql::server::postgis', :type => :class do
     }
   end
 
-  describe 'with parameters' do
+  describe 'when setting package' do
     let(:params) do
       {
         :package_name => 'mypackage',
@@ -30,6 +30,31 @@ describe 'postgresql::server::postgis', :type => :class do
         :ensure => 'absent',
         :name => 'mypackage',
         :tag => 'postgresql',
+      })
+    end
+  end
+
+  describe 'when setting up template' do
+    let(:params) do
+      {
+        :template => true,
+      }
+    end
+
+    it 'should create the template database' do
+      is_expected.to contain_postgresql__server__database('postgis template').with({
+        :dbname     => 'template_postgis',
+        :istemplate => true,
+        :template   => 'template1',
+      })
+    end
+
+    it 'should create database extensions' do
+      is_expected.to contain_postgresql__server__extension('postgis').with({
+        :database => 'template_postgis',
+      })
+      is_expected.to contain_postgresql__server__extension('postgis_topology').with({
+        :database => 'template_postgis',
       })
     end
   end

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -25,11 +25,31 @@ describe 'postgresql::server::extension', :type => :define do
     :database => 'template_postgis',
   } }
 
-  it { 
-    is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
-      :db      => 'template_postgis',
-      :command => 'CREATE EXTENSION postgis',
-      :unless  => "SELECT extname FROM pg_extension WHERE extname = 'postgis'",
-    })
-  }
+  context "with mandatory arguments only" do
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+        :db      => 'template_postgis',
+        :command => 'CREATE EXTENSION postgis',
+        :unless  => "SELECT extname FROM pg_extension WHERE extname = 'postgis'",
+      })
+    }
+  end
+
+  context "when setting package name" do
+    let (:params) { super().merge({
+      :package_name => 'postgis',
+    }) }
+
+    it "should take a package_name optional argument" do
+
+      is_expected.to compile.with_all_deps
+
+      is_expected.to contain_package('Postgresql extension postgis').with({
+          :ensure  => 'present',
+          :name    => 'postgis',
+        })
+    end
+  end
 end

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -32,8 +32,8 @@ describe 'postgresql::server::extension', :type => :define do
       is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
         :db      => 'template_postgis',
         :command => 'CREATE EXTENSION postgis',
-        :unless  => "SELECT extname FROM pg_extension WHERE extname = 'postgis'",
-      })
+        :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count = 1",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
     }
   end
 
@@ -42,14 +42,60 @@ describe 'postgresql::server::extension', :type => :define do
       :package_name => 'postgis',
     }) }
 
-    it "should take a package_name optional argument" do
+    it { is_expected.to compile.with_all_deps }
 
-      is_expected.to compile.with_all_deps
-
+    it {
       is_expected.to contain_package('Postgresql extension postgis').with({
+        :ensure  => 'present',
+        :name    => 'postgis',
+      }).that_comes_before('Postgresql_psql[Add postgis extension to template_postgis]')
+    }
+  end
+
+  context "when ensuring absence" do
+    let (:params) { super().merge({
+      :ensure       => 'absent',
+      :package_name => 'postgis',
+    }) }
+
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+        :db      => 'template_postgis',
+        :command => 'DROP EXTENSION postgis',
+        :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
+    }
+
+    it {
+      is_expected.to contain_package('Postgresql extension postgis').with({
+        :ensure  => 'absent',
+        :name    => 'postgis',
+      })
+    }
+
+    context "when keeping package installed" do
+      let (:params) { super().merge({
+        :package_ensure => 'present',
+      }) }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+          :db      => 'template_postgis',
+          :command => 'DROP EXTENSION postgis',
+          :unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = 'postgis') as t WHERE t.count != 1",
+        }).that_requires('Postgresql::Server::Database[template_postgis]')
+      }
+
+      it {
+        is_expected.to contain_package('Postgresql extension postgis').with({
           :ensure  => 'present',
           :name    => 'postgis',
-        })
+        }).that_requires('Postgresql_psql[Add postgis extension to template_postgis]')
+      }
     end
   end
 end

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'postgresql::server::extension', :type => :define do
+  let :pre_condition do
+    "class { 'postgresql::server': }
+     postgresql::server::database { 'template_postgis':
+       template   => 'template1',
+     }"
+  end
+
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :concat_basedir => tmpfilename('postgis'),
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let (:title) { 'postgis' }
+  let (:params) { {
+    :database => 'template_postgis',
+  } }
+
+  it { 
+    is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
+      :db      => 'template_postgis',
+      :command => 'CREATE EXTENSION postgis',
+      :unless  => "SELECT extname FROM pg_extension WHERE extname = 'postgis'",
+    })
+  }
+end

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -26,8 +26,6 @@ describe 'postgresql::server::extension', :type => :define do
   } }
 
   context "with mandatory arguments only" do
-    it { is_expected.to compile.with_all_deps }
-
     it {
       is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
         :db      => 'template_postgis',
@@ -42,8 +40,6 @@ describe 'postgresql::server::extension', :type => :define do
       :package_name => 'postgis',
     }) }
 
-    it { is_expected.to compile.with_all_deps }
-
     it {
       is_expected.to contain_package('Postgresql extension postgis').with({
         :ensure  => 'present',
@@ -57,8 +53,6 @@ describe 'postgresql::server::extension', :type => :define do
       :ensure       => 'absent',
       :package_name => 'postgis',
     }) }
-
-    it { is_expected.to compile.with_all_deps }
 
     it {
       is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({
@@ -79,8 +73,6 @@ describe 'postgresql::server::extension', :type => :define do
       let (:params) { super().merge({
         :package_ensure => 'present',
       }) }
-
-      it { is_expected.to compile.with_all_deps }
 
       it {
         is_expected.to contain_postgresql_psql('Add postgis extension to template_postgis').with({


### PR DESCRIPTION
This PR allows to automatically create a postgis template and activate postgis extensions on it.

It depends on #521 (whose commit is included here).