### PR TITLE
Fix $service_status in postgresql::params for 'RedHat', 'Linux' and 'Archlinux'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class postgresql::params inherits postgresql::globals {
       }
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
-      $service_status      = $service_status
+      $service_status      = pick($service_status, "service ${service_name} status")
       $perl_package_name   = pick($perl_package_name, 'perl-DBD-Pg')
       $python_package_name = pick($python_package_name, 'python-psycopg2')
 
@@ -94,7 +94,7 @@ class postgresql::params inherits postgresql::globals {
       $confdir              = pick($confdir, $datadir)
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
-      $service_status      = $service_status
+      $service_status      = pick($service_status, "systemctl status ${service_name}")
       $python_package_name = pick($python_package_name, 'python-psycopg2')
       # Archlinux does not have a perl::DBD::Pg package
       $perl_package_name = pick($perl_package_name, 'undef')


### PR DESCRIPTION
Hi!

I experienced some problems restarting postgresql due to the empty variable $postfix::params::service_status on CentOS. I fixed setting the variable where it was missing.

Please have a look at it.