### PR TITLE
add option to make postgresql.conf unmanaged

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
   $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
   $package_ensure             = 'present'
+  $manage_postgresql_conf     = true
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,6 +44,7 @@ class postgresql::server (
 
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
+  $manage_postgresql_conf     = $postgresql::params::manage_postgresql_conf,
 
   #Deprecated
   $version                    = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -16,6 +16,7 @@ class postgresql::server::config {
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
   $datadir                    = $postgresql::server::datadir
+  $manage_postgresql_conf     = $postgresql::server::manage_postgresql_conf
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -93,18 +94,19 @@ class postgresql::server::config {
     }
   }
 
-  # We must set a "listen_addresses" line in the postgresql.conf if we
-  # want to allow any connections from remote hosts.
-  postgresql::server::config_entry { 'listen_addresses':
-    value => $listen_addresses,
+  if ($manage_postgresql_conf == true) {
+	  # We must set a "listen_addresses" line in the postgresql.conf if we
+	  # want to allow any connections from remote hosts.
+	  postgresql::server::config_entry { 'listen_addresses':
+	    value => $listen_addresses,
+	  }
+	  postgresql::server::config_entry { 'port':
+	    value => $port,
+	  }
+	  postgresql::server::config_entry { 'data_directory':
+	    value => $datadir,
+	  }
   }
-  postgresql::server::config_entry { 'port':
-    value => $port,
-  }
-  postgresql::server::config_entry { 'data_directory':
-    value => $datadir,
-  }
-
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
   # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
   if ($::osfamily == 'RedHat') and ($::operatingsystemrelease !~ /^7/) and ($::operatingsystem != 'Fedora') {


### PR DESCRIPTION
add option to make postgresql.conf file unmanaged by puppet. 
at this time it's impossible to use own config file.