### PR TITLE
(MODULES-1383) Add restart parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ Value to pass through to the `package` resource when creating the server instanc
 ####`plperl_package_name`
 This sets the default package name for the PL/Perl extension. Defaults to utilising the operating system default.
 
+####`restart`
+Whether the service should be restarted when things change. Defaults to `false`.
+
 ####`service_manage`
 This setting selects whether Puppet should manage the service. Defaults to `true`.
 
@@ -567,6 +570,12 @@ Name of the setting to change.
 
 ####`ensure`
 Set to `absent` to remove an entry.
+
+####`restart`
+Whether the service should be restarted when things change. Defaults to
+`false`.
+Note that the service will still be restarted if the setting requires one in
+order for the change to take effect.
 
 ####`value`
 Value for the setting.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class postgresql::params inherits postgresql::globals {
   $ipv6acls                   = []
   $encoding                   = $postgresql::globals::encoding
   $locale                     = $postgresql::globals::locale
+  $restart                    = false
   $service_ensure             = 'running'
   $service_enable             = true
   $service_manage             = true

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -16,6 +16,13 @@ class postgresql::server::config {
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
   $datadir                    = $postgresql::server::datadir
+  $restart                    = $postgresql::server::restart
+
+  if $restart {
+    $refreshed_class = 'postgresql::server::service'
+  } else {
+    $refreshed_class = 'postgresql::server::reload'
+  }
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -24,7 +31,7 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
-      notify => Class['postgresql::server::reload'],
+      notify => Class[$refreshed_class],
     }
 
     if $pg_hba_conf_defaults {
@@ -133,7 +140,7 @@ class postgresql::server::config {
       force  => true, # do not crash if there is no pg_ident_rules
       mode   => '0640',
       warn   => true,
-      notify => Class['postgresql::server::reload'],
+      notify => Class[$refreshed_class],
     }
   }
 

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -1,10 +1,17 @@
 # Manage a postgresql.conf entry. See README.md for more details.
 define postgresql::server::config_entry (
-  $ensure = 'present',
-  $value  = undef,
-  $path   = false
+  $ensure  = 'present',
+  $value   = undef,
+  $path    = false,
+  $restart = $postgresql::server::restart,
 ) {
   $postgresql_conf_path = $postgresql::server::postgresql_conf_path
+
+  if $restart {
+    $refreshed_class = 'postgresql::server::service'
+  } else {
+    $refreshed_class = 'postgresql::server::reload'
+  }
 
   $target = $path ? {
     false   => $postgresql_conf_path,
@@ -25,7 +32,7 @@ define postgresql::server::config_entry (
 
     default: {
       Postgresql_conf {
-        notify => Class['postgresql::server::reload'],
+        notify => Class[$refreshed_class],
       }
     }
   }

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'postgresql::server::config', :type => :class do
+  let :facts do
+    {
+      :osfamily => 'RedHat',
+      :operatingsystem => 'RedHat',
+      :operatingsystemrelease => '6.4',
+      :kernel => 'Linux',
+      :concat_basedir => tmpfilename('contrib'),
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  context 'with postgresql::server defaults' do
+    let :pre_condition do
+      "class {'postgresql::server': }"
+    end
+
+    it 'should reload the service when changing pg_hba.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_hba.conf').that_notifies('Class[postgresql::server::reload]')
+    end
+
+    it 'should reload the service when changing pg_ident.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_ident.conf').that_notifies('Class[postgresql::server::reload]')
+    end
+  end
+
+  context 'with postgresql::server, restart => true' do
+    let :pre_condition do
+      "class {'postgresql::server': restart => true}"
+    end
+
+    it 'should restart the service when changing pg_hba.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_hba.conf').that_notifies('Class[postgresql::server::service]')
+    end
+
+    it 'should restart the service when changing pg_ident.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_ident.conf').that_notifies('Class[postgresql::server::service]')
+    end
+  end
+
+  context 'with postgresql::server, restart => false' do
+    let :pre_condition do
+      "class {'postgresql::server': restart => false}"
+    end
+
+    it 'should reload the service when changing pg_hba.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_hba.conf').that_notifies('Class[postgresql::server::reload]')
+    end
+
+    it 'should reload the service when changing pg_ident.conf' do
+      is_expected.to contain_concat('/var/lib/pgsql/data/pg_ident.conf').that_notifies('Class[postgresql::server::reload]')
+    end
+  end
+end

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -106,4 +106,20 @@ describe 'postgresql::server::config_entry', :type => :define do
         :value => 'off' })
     end
   end
+
+  context 'with restart => true' do
+    let(:params) {{ :ensure => 'present', :name => 'foo', :value => 'foovalue', :restart => true }}
+
+    it 'the service should be restarted when applying the config entry' do
+      is_expected.to contain_postgresql_conf('foo').that_notifies('Class[postgresql::server::service]')
+    end
+  end
+
+  context 'with restart => false' do
+    let(:params) {{ :ensure => 'present', :name => 'foo', :value => 'foovalue', :restart => false }}
+
+    it 'the service should be reloaded when applying the config entry' do
+      is_expected.to contain_postgresql_conf('foo').that_notifies('Class[postgresql::server::reload]')
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a restart parameter to both postgresql::server and postgresql::server::config_entry.

When set to true, a restart of the postgresql service will be preferred when changing config settings, rather than a reload. The parameter in server::config_entry takes the value set in postgresql::server by default, but can be set independently.

I'm open to suggestions in making the code less kludgy.
Should more rspec tests be added?