### PR TITLE
Postgis dep

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -106,7 +106,11 @@ class postgresql::globals (
     '93'    => '2.1',
     default => undef,
   }
-  $globals_postgis_version = pick($postgis_version, $default_postgis_version)
+  if $postgis_version {
+    $globals_postgis_version = $postgis_version
+  } else {
+    $globals_postgis_version = $default_postgis_version
+  }
 
   # Setup of the repo only makes sense globally, so we are doing this here.
   if($manage_package_repo) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,15 +63,18 @@ class postgresql::params inherits postgresql::globals {
       $perl_package_name   = pick($perl_package_name, 'perl-DBD-Pg')
       $python_package_name = pick($python_package_name, 'python-psycopg2')
 
-      $postgis_package_name = pick(
-        $postgis_package_name,
-        $::operatingsystemrelease ? {
-          /5/     => 'postgis',
-          default => versioncmp($postgis_version, '2') ? {
-            '-1'    => "postgis${package_version}",
-            default => "postgis2_${package_version}",}
+      if ! $postgis_package_name {
+        $postgis_package_name = $postgis_version ? {
+          undef   => undef,
+          default => $::operatingsystemrelease ? {
+            /5/     => 'postgis',
+            default => versioncmp($postgis_version, '2') ? {
+              '-1'    => "postgis${package_version}",
+              default => "postgis2_${package_version}",
+            }
+          }
         }
-      )
+      }
     }
 
     'Archlinux': {
@@ -126,13 +129,16 @@ class postgresql::params inherits postgresql::globals {
       $client_package_name  = pick($client_package_name, "postgresql-client-${version}")
       $server_package_name  = pick($server_package_name, "postgresql-${version}")
       $contrib_package_name = pick($contrib_package_name, "postgresql-contrib-${version}")
-      $postgis_package_name = pick(
-        $postgis_package_name,
-        versioncmp($postgis_version, '2') ? {
-          '-1'    => "postgresql-${version}-postgis",
-          default => "postgresql-${version}-postgis-${postgis_version}",
+
+      if ! $postgis_package_name {
+        $postgis_package_name = $postgis_version ? {
+          undef   => 'UNDEFINED',
+          default =>  versioncmp($postgis_version, '2') ? {
+            '-1'    => "postgresql-${version}-postgis",
+            default => "postgresql-${version}-postgis-${postgis_version}",
+          }
         }
-      )
+      }
       $devel_package_name   = pick($devel_package_name, 'libpq-dev')
       $java_package_name    = pick($java_package_name, 'libpostgresql-jdbc-java')
       $perl_package_name    = pick($perl_package_name, 'libdbd-pg-perl')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -132,7 +132,7 @@ class postgresql::params inherits postgresql::globals {
 
       if ! $postgis_package_name {
         $postgis_package_name = $postgis_version ? {
-          undef   => 'UNDEFINED',
+          undef   => undef,
           default =>  versioncmp($postgis_version, '2') ? {
             '-1'    => "postgresql-${version}-postgis",
             default => "postgresql-${version}-postgis-${postgis_version}",

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -3,7 +3,7 @@ class postgresql::server::postgis (
   $package_name   = $postgresql::params::postgis_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {
-  validate_string($package_name, "Valid postgis package could not be identified. Specify postgis package name') 
+  validate_string($package_name, "Valid postgis package could not be identified. Specify postgis package name')
 
   package { 'postgresql-postgis':
     ensure => $package_ensure,

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -3,7 +3,7 @@ class postgresql::server::postgis (
   $package_name   = $postgresql::params::postgis_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {
-  validate_string($package_name)
+  validate_string($package_name, "Valid postgis package could not be identified. Specify postgis package name') 
 
   package { 'postgresql-postgis':
     ensure => $package_ensure,


### PR DESCRIPTION
Prevent pick() of postgis_version failure

globals.pp always trys to identify the default what version of postgis even when postgis is not being installed. 

The problem comes when using a custom packaged version of postsql that does not match the default major.minor version of postgresql for the current OS. In that case default_postgis _version is set to undef If postgis_version is also undefined the pick statement tthat set globals_postgis_version fails.

This changes the pick statement in globals.pp to an if statment than can pass undefs safely.
It changes params.pp to pass undef as a package name if postgis_version is equal to undef.
Finally I changed the postgis.pp class to give a meanful error message when no valid package name can be found.

I performed simple testing of this code but I lack the facilities to fullly exercise it. Additionally I do not know rspec. As a result I a submitting the code for a pull request right now incase someone finds it useful or wishes to add the missing test. I plan to learn rspec in the next couple months as I need it for a project and at that time, if the pull request is still waiting, I will add tests then.