### PR TITLE
Allow management of logdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Table of Contents
 2. [Module Description - What does the module do?](#module-description)
 3. [Setup - The basics of getting started with PostgreSQL module](#setup)
     * [PE 3.2 supported module](#pe-32-supported-module)
-    * [Configuring the server](#configuring-the-server) 
+    * [Configuring the server](#configuring-the-server)
 4. [Usage - How to use the module for various tasks](#usage)
 5. [Upgrading - Guide for upgrading from older revisions of this module](#upgrading)
 6. [Reference - The classes, defines,functions and facts available in this module](#reference)
@@ -346,6 +346,9 @@ This setting can be used to override the default postgresql binaries directory f
 
 ####`xlogdir`
 This setting can be used to override the default postgresql xlog directory. If not specified the module will use initdb's default path.
+
+####`logdir`
+This setting can be used to override the default postgresql log directory. If not specified the module will use initdb's default path.
 
 ####`user`
 This setting can be used to override the default postgresql super user and owner of postgresql related files in the file system. If not specified, the module will use the user name 'postgres'.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -29,6 +29,7 @@ class postgresql::globals (
   $confdir              = undef,
   $bindir               = undef,
   $xlogdir              = undef,
+  $logdir               = undef,
 
   $user                 = undef,
   $group                = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,6 +32,7 @@ class postgresql::server (
 
   $datadir                    = $postgresql::params::datadir,
   $xlogdir                    = $postgresql::params::xlogdir,
+  $logdir                     = $postgresql::params::logdir,
 
   $pg_hba_conf_defaults       = $postgresql::params::pg_hba_conf_defaults,
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -16,6 +16,7 @@ class postgresql::server::config {
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
   $datadir                    = $postgresql::server::datadir
+  $logdir                     = $postgresql::server::logdir
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -103,6 +104,12 @@ class postgresql::server::config {
   }
   postgresql::server::config_entry { 'data_directory':
     value => $datadir,
+  }
+  if $logdir {
+    postgresql::server::config_entry { 'log_directory':
+      value => $logdir,
+    }
+
   }
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -4,6 +4,7 @@ class postgresql::server::initdb {
   $initdb_path  = $postgresql::server::initdb_path
   $datadir      = $postgresql::server::datadir
   $xlogdir      = $postgresql::server::xlogdir
+  $logdir       = $postgresql::server::logdir
   $encoding     = $postgresql::server::encoding
   $locale       = $postgresql::server::locale
   $group        = $postgresql::server::group
@@ -24,6 +25,15 @@ class postgresql::server::initdb {
       owner  => $user,
       group  => $group,
       mode   => '0700',
+    }
+  }
+
+  if($logdir) {
+    # Make sure the log directory exists, and has the correct permissions.
+    file { $logdir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
     }
   }
 


### PR DESCRIPTION
Simple request to allow management of the logdir when installing and setting up postgres for the first time. 

I didn't find a way to do this when changing the log dir and on a initial install of postgres it will fail with this class since the log_directory isn't installed.

Sorry if there is easier way to do this.