### PR TITLE
Add support for sequence grants

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -25,7 +25,7 @@ define postgresql::server::grant (
     #'FUNCTION',
     #'PROCEDURAL LANGUAGE',
     'SCHEMA',
-    #'SEQUENCE',
+    'SEQUENCE',
     'TABLE',
     'ALL TABLES IN SCHEMA',
     #'TABLESPACE',
@@ -72,6 +72,15 @@ define postgresql::server::grant (
       validate_string($unless_privilege,'SELECT','INSERT','UPDATE','DELETE',
         'TRUNCATE','REFERENCES','TRIGGER','ALL','ALL PRIVILEGES')
       $unless_function = 'has_table_privilege'
+      $on_db = $db
+    }
+    'SEQUENCE': {
+      $unless_privilege = $_privilege ? {
+        'ALL'   => 'UPDATE',
+        default => $_privilege,
+      }
+      validate_string($unless_privilege,'SELECT','USAGE','UPDATE')
+      $unless_function = 'has_sequence_privilege'
       $on_db = $db
     }
     'ALL TABLES IN SCHEMA': {

--- a/manifests/server/sequence_grant.pp
+++ b/manifests/server/sequence_grant.pp
@@ -1,0 +1,22 @@
+# This resource wraps the grant resource to manage sequence grants specifically.
+# See README.md for more details.
+define postgresql::server::sequence_grant(
+  $privilege,
+  $sequence,
+  $db,
+  $role,
+  $port      = $postgresql::server::port,
+  $psql_db   = undef,
+  $psql_user = undef
+) {
+  postgresql::server::grant { "sequence:${name}":
+    role        => $role,
+    db          => $db,
+    port        => $port,
+    privilege   => $privilege,
+    object_type => 'SEQUENCE',
+    object_name => $sequence,
+    psql_db     => $psql_db,
+    psql_user   => $psql_user,
+  }
+}


### PR DESCRIPTION
I needed to be able to grant at the sequence level for my project, so I uncommented the SEQUENCE type and added privilege validation in the same form as the other grant types. Like table and database grant, I also added a wrapper around sequence grant.
Please let me know if this is desirable to be accepted into mainline, and what further changes I should make.