### PR TITLE
Fix invalid byte sequence in US-ASCII error

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -89,7 +89,7 @@ define postgresql::server::grant (
   # If you need such grant, use:
   # postgresql::grant { 'table:foo':
   #   role        => 'joe',
-  #   …
+  #   ...
   #   object_type => 'TABLE',
   #   object_name => [$schema, $table],
   # }


### PR DESCRIPTION
This patch fixes:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: invalid byte sequence in US-ASCII at /etc/puppet/environments/development/modules/postgresql/manifests/server/grant.pp:1 on node example.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```