### PR TITLE
Add local_auth_option_postgres to modify postgres and user/database pg_hba rules to be able to pass auth-options like custom maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,9 @@ This value defaults to `0.0.0.0/0`. Sometimes it can be useful to block the supe
 ####`ip_mask_allow_all_users`
 This value defaults to `127.0.0.1/32`. By default, Postgres does not allow any database user accounts to connect via TCP from remote machines. If you'd like to allow them to, you can override this setting. You might set it to `0.0.0.0/0` to allow database users to connect from any remote machine, or `192.168.0.0/16` to allow connections from any machine on your local 192.168 subnet.
 
+####`local_auth_option_postgres`
+This value defaults to undef. If you specify it, it will append a pg_hba auth-option to the postgres and user/database rules so you can apply auth-options like custom maps; see [postgresql documentation](http://www.postgresql.org/docs/9.2/static/auth-pg-hba-conf.html) about `pg_hba.conf` for information (please note that the link will take you to documentation for the most recent version of Postgres, however links for earlier versions can be found on that page).
+
 ####`ipv4acls`
 List of strings for access control for connection method, users, databases, IPv4 addresses; see [postgresql documentation](http://www.postgresql.org/docs/9.2/static/auth-pg-hba-conf.html) about `pg_hba.conf` for information (please note that the link will take you to documentation for the most recent version of Postgres, however links for earlier versions can be found on that page).
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class postgresql::params inherits postgresql::globals {
   $ip_mask_allow_all_users    = '127.0.0.1/32'
   $ipv4acls                   = []
   $ipv6acls                   = []
+  $local_auth_option_postgres = undef
   $encoding                   = $encoding
   $locale                     = $locale
   $service_ensure             = 'running'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,6 +22,7 @@ class postgresql::server (
   $ip_mask_allow_all_users    = $postgresql::params::ip_mask_allow_all_users,
   $ipv4acls                   = $postgresql::params::ipv4acls,
   $ipv6acls                   = $postgresql::params::ipv6acls,
+  $local_auth_option_postgres = $postgresql::params::local_auth_option_postgres,
 
   $initdb_path                = $postgresql::params::initdb_path,
   $createdb_path              = $postgresql::params::createdb_path,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -10,6 +10,7 @@ class postgresql::server::config {
   $pg_ident_conf_path         = $postgresql::server::pg_ident_conf_path
   $postgresql_conf_path       = $postgresql::server::postgresql_conf_path
   $pg_hba_conf_defaults       = $postgresql::server::pg_hba_conf_defaults
+  $local_auth_option_postgres = $postgresql::server::local_auth_option_postgres
   $user                       = $postgresql::server::user
   $group                      = $postgresql::server::group
   $version                    = $postgresql::server::_version
@@ -35,8 +36,8 @@ class postgresql::server::config {
 
       # Lets setup the base rules
       $local_auth_option = $version ? {
-        '8.1'   => 'sameuser',
-        default => undef,
+        '8.1'   => "sameuser ${local_auth_option_postgres}",
+        default => $local_auth_option_postgres,
       }
       postgresql::server::pg_hba_rule { 'local access as postgres user':
         type        => 'local',


### PR DESCRIPTION
If you specify it, it will append a pg_hba auth-option to the postgres and user/database rules so you can apply auth-options like custom maps