### PR TITLE
(MODULES-1153) Add database comment parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,9 @@ For example, to create a database called `test1` with a corresponding user of th
 ####`namevar`
 The namevar for the resource designates the name of the database.
 
+####`comment`
+A comment to be stored about the database using the PostgreSQL COMMENT command.
+
 ####`dbname`
 The name of the database to be created. Defaults to `namevar`.
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -1,5 +1,6 @@
 # Define for creating a database. See README.md for more details.
 define postgresql::server::database(
+  $comment    = undef,
   $dbname     = $title,
   $owner      = $postgresql::server::user,
   $tablespace = undef,
@@ -74,6 +75,13 @@ define postgresql::server::database(
   postgresql_psql {"UPDATE pg_database SET datistemplate = ${istemplate} WHERE datname = '${dbname}'":
     unless => "SELECT datname FROM pg_database WHERE datname = '${dbname}' AND datistemplate = ${istemplate}",
     db     => $default_db,
+  }
+
+  if $comment {
+    Exec[ $createdb_command ]->
+    postgresql_psql {"COMMENT ON DATABASE ${dbname} IS '${comment}'":
+      unless  => "SELECT pg_catalog.shobj_description(d.oid, 'pg_database') as \"Description\" FROM pg_catalog.pg_database d WHERE datname = '${dbname}' AND pg_catalog.shobj_description(d.oid, 'pg_database') = '${comment}'",
+    }
   }
 
   # Build up dependencies on tablespace

--- a/manifests/server/db.pp
+++ b/manifests/server/db.pp
@@ -3,6 +3,7 @@
 define postgresql::server::db (
   $user,
   $password,
+  $comment    = undef,
   $dbname     = $title,
   $encoding   = $postgresql::server::encoding,
   $locale     = $postgresql::server::locale,
@@ -15,6 +16,7 @@ define postgresql::server::db (
 
   if ! defined(Postgresql::Server::Database[$dbname]) {
     postgresql::server::database { $dbname:
+      comment    => $comment,
       encoding   => $encoding,
       tablespace => $tablespace,
       template   => $template,

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -10,6 +10,7 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
           location => '#{tmpdir}',
         } ->
         postgresql::server::db { 'postgresql_test_db':
+          comment    => 'testcomment',
           user       => 'test',
           password   => 'test1',
           tablespace => 'postgresql_test_db',
@@ -25,6 +26,10 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
       end
 
       psql('--command="SELECT 1 FROM pg_roles WHERE rolname=\'test\'"') do |r|
+        expect(r.stdout).to match(/\(1 row\)/)
+      end
+
+      psql('--command="SELECT pg_catalog.shobj_description(d.oid, \'pg_database\') FROM pg_catalog.pg_database d WHERE datname = \'postgresql_test_db\' AND pg_catalog.shobj_description(d.oid, \'pg_database\') = \'testcomment\'"') do |r|
         expect(r.stdout).to match(/\(1 row\)/)
       end
     ensure

--- a/spec/unit/defines/server/database_spec.rb
+++ b/spec/unit/defines/server/database_spec.rb
@@ -22,4 +22,10 @@ describe 'postgresql::server::database', :type => :define do
 
   it { is_expected.to contain_postgresql__server__database('test') }
   it { is_expected.to contain_postgresql_psql("Check for existence of db 'test'") }
+
+  context "with comment set to 'test comment'" do
+    let (:params) {{ :comment => 'test comment' }}
+
+    it { is_expected.to contain_postgresql_psql("COMMENT ON DATABASE test IS 'test comment'") }
+  end
 end


### PR DESCRIPTION
This commit adds a comment parameter to postgresql::server::db so that one can add a database description using PostgreSQL's COMMENT command.

Refer to the following links for documentation on the queries used:
http://www.postgresql.org/docs/8.1/static/sql-comment.html
http://stackoverflow.com/questions/11493978/how-to-retrieve-the-comment-of-a-postgresql-database
http://www.postgresql.org/docs/current/interactive/functions-info.html#FUNCTIONS-INFO-COMMENT-TABLE