### PR TITLE
FreeBSD PostgreSQL wouldn't start first time

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -164,7 +164,7 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, '/usr/local/bin')
       $datadir              = pick($datadir, '/usr/local/pgsql/data')
       $confdir              = pick($confdir, $datadir)
-      $service_status       = pick($service_status, "/usr/local/etc/rc.d/${service_name} status")
+      $service_status       = pick($service_status, "/usr/local/etc/rc.d/${service_name} onestatus")
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $needs_initdb         = pick($needs_initdb, true)


### PR DESCRIPTION
It would be enabled, but it wouldn't work properly. This fixes that
issue the same way Puppet does itself; use the onestart/onestop and most
importantly in this case, the onestatus command.

By using this approach it means the Database server will actually start
whereas it would not before. It would enable, but not actually start.
onestatus means the service type gets the right response and behaves
properly.