### PR TITLE
Require server package before user permissions

### DIFF
--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -32,6 +32,7 @@ define postgresql::server::tablespace(
     seluser => 'system_u',
     selrole => 'object_r',
     seltype => 'postgresql_db_t',
+    require => Class['postgresql::server'],
   }
 
   $create_ts = "Create tablespace '${spcname}'"


### PR DESCRIPTION
The postgresql user is created by the server package, but this file
resource may be evaluated before the package is installed resulting in
permission failures.