### PR TITLE
Fix comment detection

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -80,7 +80,8 @@ define postgresql::server::database(
   if $comment {
     Exec[ $createdb_command ]->
     postgresql_psql {"COMMENT ON DATABASE ${dbname} IS '${comment}'":
-      unless  => "SELECT pg_catalog.shobj_description(d.oid, 'pg_database') as \"Description\" FROM pg_catalog.pg_database d WHERE datname = '${dbname}' AND pg_catalog.shobj_description(d.oid, 'pg_database') = '${comment}'",
+      unless  => "SELECT description FROM pg_description JOIN pg_database ON objoid = pg_database.oid WHERE datname = '${dbname}' AND description = '${comment}'",
+      db      => $dbname,
     }
   }
 


### PR DESCRIPTION
On psql 8.1, `pg_catalog.shobj_description` does not exist. Also, if the
database to comment is not the current db then this warning will be
raised and the comment will not be applied: `WARNING:  database comments
may only be applied to the current database`

This fix uses the pg_* databases to find the comment based on the
database oid rather than the shared object description function.