### PR TITLE
Fix comment detection

### DIFF
--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -29,7 +29,14 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
         expect(r.stdout).to match(/\(1 row\)/)
       end
 
-      psql('--command="SELECT pg_catalog.shobj_description(d.oid, \'pg_database\') FROM pg_catalog.pg_database d WHERE datname = \'postgresql_test_db\' AND pg_catalog.shobj_description(d.oid, \'pg_database\') = \'testcomment\'"') do |r|
+      result = shell('psql --version')
+      version = result.stdout.match(%r{\s(8\.\d)})[1]
+      if version > "8.1"
+        comment_information_function = "shobj_description"
+      else
+        comment_information_function = "obj_description"
+      end
+      psql("--dbname postgresql_test_db --command=\"SELECT pg_catalog.#{comment_information_function}(d.oid, 'pg_database') FROM pg_catalog.pg_database d WHERE datname = 'postgresql_test_db' AND pg_catalog.#{comment_information_function}(d.oid, 'pg_database') = 'testcomment'\"") do |r|
         expect(r.stdout).to match(/\(1 row\)/)
       end
     ensure


### PR DESCRIPTION
On psql 8.1, `pg_catalog.shobj_description` does not exist. Also, if the
database to comment is not the current db then this warning will be
raised and the comment will not be applied: `WARNING:  database comments
may only be applied to the current database`

This fix uses the pg_* databases to find the comment based on the
database oid rather than the shared object description function.