### PR TITLE
Allowing validation of db connection for more than one user and port

### DIFF
--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -47,7 +47,7 @@ define postgresql::validate_db_connection(
   # time it takes to run each psql command.
   $timeout = (($sleep + 2) * $tries)
 
-  $exec_name = "validate postgres connection for ${database_host}/${database_name}"
+  $exec_name = "validate postgres connection for ${database_username}@${database_host}:${database_port}/${database_name}"
   exec { $exec_name:
     command     => "echo 'Unable to connect to defined database using: ${cmd}' && false",
     unless      => $validate_cmd,


### PR DESCRIPTION
I came across the problem that i couldn't validate the db connections for two different users on the same host, due to the namevar of the exec in validate_db_connection. I've added username and port to the name.