### PR TITLE
create role before database

### DIFF
--- a/manifests/server/db.pp
+++ b/manifests/server/db.pp
@@ -29,6 +29,7 @@ define postgresql::server::db (
   if ! defined(Postgresql::Server::Role[$user]) {
     postgresql::server::role { $user:
       password_hash => $password,
+      before        => Postgresql::Server::Database[$dbname],
     }
   }
 

--- a/spec/unit/defines/server/db_spec.rb
+++ b/spec/unit/defines/server/db_spec.rb
@@ -33,7 +33,7 @@ describe 'postgresql::server::db', :type => :define do
 
     it { is_expected.to contain_postgresql__server__db('test') }
     it { is_expected.to contain_postgresql__server__database('test').with_owner('tester') }
-    it { is_expected.to contain_postgresql__server__role('test') }
+    it { is_expected.to contain_postgresql__server__role('test').that_comes_before('Postgresql::Server::Database[test]') }
     it { is_expected.to contain_postgresql__server__database_grant('GRANT test - ALL - test') }
 
   end


### PR DESCRIPTION
Creating the role before creating the database is mandatory because otherwise
granting the access right to the database fails.