### PR TITLE
(MODULES-661) Add host parameter to psql commands

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -14,6 +14,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
     command = [resource[:psql_path]]
     command.push("-d", resource[:db]) if resource[:db]
     command.push("-p", resource[:port]) if resource[:port]
+    command.push("-h", resource[:host]) if resource[:host]
     command.push("-t", "-c", sql)
 
     if resource[:cwd]

--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:postgresql_psql) do
     desc "The name of the database to execute the SQL command against."
   end
 
+  newparam(:host) do
+    desc "The host to run the PSQL against"
+  end
+
   newparam(:port) do
     desc "The port of the database server to execute the SQL command against."
   end

--- a/spec/acceptance/alternative_host_spec.rb
+++ b/spec/acceptance/alternative_host_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper_acceptance'
+
+# These tests ensure that postgres commands can be specified by host
+# TODO: Setup Postgres on different server and try remote connetions
+describe 'postgresql_psql', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  it 'with a host parameter' do
+    setup_postgres = <<-EOS
+      class { 'postgresql::server':
+        pg_hba_conf_defaults => false,
+      }
+
+      # For ease of testing, allow anyone to access Postgres
+      # NEVER DO THIS IN THE REAL WORLD!
+      postgresql::server::pg_hba_rule { 'allow full yolo access local':
+        type        => 'local',
+        database    => 'all',
+        user        => 'all',
+        auth_method => 'ident',
+        order       => '000',
+      }
+
+      postgresql::server::pg_hba_rule { 'allow full yolo access host':
+        type        => 'host',
+        database    => 'all',
+        user        => 'all',
+        address     => '127.0.0.1/32',
+        auth_method => 'trust',
+        order       => '001',
+      }
+    EOS
+
+    run_different_host = <<-EOS
+    postgresql_psql { 'run against different host':
+      db            => 'postgres',
+      host          => '127.0.0.1',
+      command       => 'select 1',
+    }
+    EOS
+
+    apply_manifest(setup_postgres, :catch_failures => true)
+    apply_manifest(run_different_host, :catch_failures => true)
+  end
+
+end

--- a/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
@@ -67,6 +67,31 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       end
     end
   end
+   describe "with port string" do
+      let(:attributes) do { :port => '5555' } end
+
+      it "executes with the given psql_path on the given DB" do
+        expect(provider).to receive(:run_command).with(["psql",
+        "-p", "5555",
+        "-t", "-c", "SELECT something"],
+        "postgres", "postgres")
+
+        provider.run_sql_command("SELECT something")
+      end
+    end
+    describe "with host string" do
+      let(:attributes) do { :host => '127.0.0.1' } end
+
+      it "executes with the given psql_path on the given DB" do
+        expect(provider).to receive(:run_command).with(["psql",
+          "-h", "127.0.0.1",
+          "-t", "-c",
+          "SELECT something"],
+          "postgres", "postgres")
+
+        provider.run_sql_command("SELECT something")
+      end
+    end
 
   context("#run_unless_sql_command") do
     let(:attributes) do { } end

--- a/spec/unit/puppet/type/postgresql_psql_spec.rb
+++ b/spec/unit/puppet/type/postgresql_psql_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:postgresql_psql), "when validating attributes" do
-  [:name, :unless, :db, :psql_path, :psql_user, :psql_group].each do |attr|
+  [:name, :unless, :db, :psql_path, :psql_user, :psql_group, :host].each do |attr|
     it "should have a #{attr} parameter" do
       expect(Puppet::Type.type(:postgresql_psql).attrtype(attr)).to eq(:param)
     end
@@ -30,7 +30,8 @@ describe Puppet::Type.type(:postgresql_psql), :unless => Puppet.features.microso
       :psql_group  => "postgres",
       :cwd         => "/var/lib",
       :refreshonly => :true,
-      :search_path => [ "schema1", "schema2"]
+      :search_path => [ "schema1", "schema2"],
+      :host        => 'postgres-db-server',
     }.each do |attr, value|
       context attr do
         let(:attributes) do { attr => value } end


### PR DESCRIPTION
This allows you to use `postgres_pqsl` commands to be run against a specified host. The ultimate goal being that you can use `puppetlabs-postsgresql` to run against remote instances, especially things such as Amazons RDS service.

This PR will be further extended to do things like allow remote `table_grant` and the like.