### PR TITLE
Remove dependency on puppetlabs/apt since it is not required.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,6 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.1.0 <2.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]
 }


### PR DESCRIPTION
Section 8.1 of the Puppet Labs Style Guide states that soft dependencies
must not be enforced as a hard requirement in the metadata. This will
allow users who do not use systems with apt to no longer manage the
puppetlabs/apt module and its dependencies.