### PR TITLE
(MODULES-1834) Be less strict when changing template1 encoding

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -94,7 +94,7 @@ class postgresql::server::initdb {
         SET encoding = pg_char_to_encoding('${encoding}'), datistemplate = TRUE
         WHERE datname = 'template1'",
       unless  => "SELECT datname FROM pg_database WHERE
-        datname = 'template1' AND pg_encoding_to_char(encoding) = '${encoding}'",
+        datname = 'template1' AND encoding = pg_char_to_encoding('${encoding}')",
     }
   }
 }


### PR DESCRIPTION
We currently use: UTF8 != UTF-8
We should instead use: pg_char_to_encoding(UTF8) == pg_char_to_encoding(UTF-8)