### PR TITLE
postgresql::server::extension needs to have defaults for postgresql_psql

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -5,18 +5,18 @@ define postgresql::server::extension (
   $package_name = undef,
   $package_ensure = undef,
 ) {
-    $user          = $postgresql::server::user
-    $group         = $postgresql::server::group
-    $psql_path     = $postgresql::server::psql_path
-    $port          = $postgresql::server::port
+  $user          = $postgresql::server::user
+  $group         = $postgresql::server::group
+  $psql_path     = $postgresql::server::psql_path
+  $port          = $postgresql::server::port
   
-    # Set the defaults for the postgresql_psql resource
-    Postgresql_psql {
-      psql_user  => $user,
-      psql_group => $group,
-      psql_path  => $psql_path,
-      port       => $port,
-    }
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+  }
 
   case $ensure {
     'present': {

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -5,6 +5,19 @@ define postgresql::server::extension (
   $package_name = undef,
   $package_ensure = undef,
 ) {
+    $user          = $postgresql::server::user
+    $group         = $postgresql::server::group
+    $psql_path     = $postgresql::server::psql_path
+    $port          = $postgresql::server::port
+  
+    # Set the defaults for the postgresql_psql resource
+    Postgresql_psql {
+      psql_user  => $user,
+      psql_group => $group,
+      psql_path  => $psql_path,
+      port       => $port,
+    }
+
   case $ensure {
     'present': {
       $command = "CREATE EXTENSION ${name}"

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -9,6 +9,16 @@ class postgresql::server::initdb {
   $locale       = $postgresql::server::locale
   $group        = $postgresql::server::group
   $user         = $postgresql::server::user
+  $psql_path    = $postgresql::server::psql_path
+  $port         = $postgresql::server::port
+
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+  }
 
   # Make sure the data directory exists, and has the correct permissions.
   file { $datadir:


### PR DESCRIPTION
Using same pattern as with postgresql::server::database.
observed when installing the pg_trgm using pgsql 9.4 for puppetdb

affects: puppetlabs-postgresql 4.2.0

code used:

class { 'postgresql::globals':
manage_package_repo => true,
version => $postgres_version,
}->
class { 'postgresql::server':
listen_addresses => '*',
}->
class { '::puppetdb::database::postgresql':
manage_server => false,
database_name => $database_name,
database_username => $database_username,
database_password => $database_password,
before => [Class['puppetdb::server'],
Class['puppetdb::server::validate_db']],
}

class { 'postgresql::server::contrib':
}->
postgresql::server::extension { 'pg_trgm':
database => $database_name,
}

class { '::puppetdb::server':
listen_address => '0.0.0.0',
listen_port => '8080',
ssl_listen_address => '0.0.0.0',
ssl_listen_port => '8081',
open_ssl_listen_port => true,
database => 'postgres',
}
