### PR TITLE
Fix the handling of run_unless_sql_command in puppet 4

### DIFF
--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -34,12 +34,7 @@ Puppet::Type.newtype(:postgresql_psql) do
 
     # Return true if a matching row is found
     def matches(value)
-      if Puppet::PUPPETVERSION.to_f < 4
-        output, status = provider.run_unless_sql_command(value)
-      else
-        output = provider.run_unless_sql_command(value)
-        status = output.exitcode
-      end
+      output, status = provider.run_unless_sql_command(value)
       self.fail("Error evaluating 'unless' clause, returned #{status}: '#{output}'") unless status == 0
 
       result_count = output.strip.to_i


### PR DESCRIPTION
`Puppet::Util::SUIDManager.run_and_capture` (in puppet < 3.4) returns an
array of the output and the `Process::Status` object.
`Puppet::Util::Execution.execute` (in puppet >= 3.4) returns the output
and saves the `Process::Status` object to `$CHILD_STATUS`

This is handled in the provider, but the type was also trying to handle
it, and was not last updated when the provider was.