### PR TITLE
Use space.  Join seems to be defaulting to comma.

### DIFF
--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -40,7 +40,7 @@ define postgresql::validate_db_connection(
     undef   => undef,
     default => "PGPASSWORD=${database_password}",
   }
-  $cmd = join([$cmd_init, $cmd_host, $cmd_user, $cmd_port, $cmd_dbname])
+  $cmd = join([$cmd_init, $cmd_host, $cmd_user, $cmd_port, $cmd_dbname], ' ')
   $validate_cmd = "/usr/local/bin/validate_postgresql_connection.sh ${sleep} ${tries} '${cmd}'"
 
   # This is more of a safety valve, we add a little extra to compensate for the


### PR DESCRIPTION
With v4.2.0 of the postgres module, we're getting a command string of:

Executing check '/usr/local/bin/validate_postgresql_connection.sh 1 60 '/usr/bin/psql --tuples-only --quiet ,,,-p 5432 ,--dbname postgres ''

This seems to be stemming from the Join function in 4.5.1 of Stdlib.

Specifying space as a separator seems to resolve this issue in validate_db_connection.pp.

All tests are currently passing in Travis.