### PR TITLE
Fix setting postgres role password

### DIFF
--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -21,8 +21,8 @@ class postgresql::server::passwd {
       logoutput   => true,
       cwd         => '/tmp',
       environment => [
-        "PGPASSWORD='${postgres_password}'",
-        "NEWPASSWD_ESCAPED='${escaped}'",
+        "PGPASSWORD=${postgres_password}",
+        "NEWPASSWD_ESCAPED=${escaped}",
       ],
       # With this command we're passing -h to force TCP authentication, which
       # does require a password.  We specify the password via the PGPASSWORD

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -43,8 +43,8 @@ describe 'postgresql::server', :type => :class do
         'command'     => '/usr/bin/psql -c "ALTER ROLE \"postgres\" PASSWORD ${NEWPASSWD_ESCAPED}"',
         'user'        => 'postgres',
         'environment' => [
-          "PGPASSWORD='new-p@s$word-to-set'",
-          "NEWPASSWD_ESCAPED='$$new-p@s$word-to-set$$'"
+          "PGPASSWORD=new-p@s$word-to-set",
+          "NEWPASSWD_ESCAPED=$$new-p@s$word-to-set$$"
         ],
         'unless'      => "/usr/bin/psql -h localhost -p 5432 -c 'select 1' > /dev/null",
       })


### PR DESCRIPTION
Discussed in https://tickets.puppetlabs.com/browse/MODULES-1869

It seems env variables passed via `exec`'s `environment` parameter must not be single-quoted, otherwise the single-quotes are interpreted literally in the command strings in `command` and `unless`. For a postgres password of `foobar` this leads to the `unless` code trying to use literally `'foobar'` as password, and the `psql` line in `command` setting literally `'$$foobar$$'` as password.