### PR TITLE
Update apt key to full 40characters

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -13,7 +13,7 @@ include ::apt
     location    => 'http://apt.postgresql.org/pub/repos/apt/',
     release     => "${::lsbdistcodename}-pgdg",
     repos       => "main ${postgresql::repo::version}",
-    key         => 'ACCC4CF8',
+    key         => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
     key_source  => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
     include_src => false,
   }


### PR DESCRIPTION
Latest version of puppetlabs/apt module shows warning on every puppet run if using a short key so this update includes the full 40 character key.