### PR TITLE
Fix URLs in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,8 +4,8 @@
   "author": "Inkling/Puppet Labs",
   "summary": "Offers support for basic management of PostgreSQL databases.",
   "license": "Apache-2.0",
-  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
-  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "source": "git://github.com/puppetlabs/puppetlabs-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-postgresql",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This is a detail, as github redirects to `puppetlabs-postgresql` anyway in the browser, but it fails when using the Github API.