### PR TITLE
set priority on yum repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,16 @@ The ensure parameter passed on to postgresql contrib package resource.
 
 ###Class: postgresql::server::postgis
 Installs the postgresql postgis packages.
+Requires EPEL repository on RedHat based distributions.
+
+Example:
+
+      class { 'postgresql::globals':
+        manage_package_repo => true,
+        version             => '9.4',
+      } -> 
+      class { 'postgresql::server': } 
+      class { 'postgresql::server::postgis': }
 
 ###Class: postgresql::lib::devel
 Installs the packages containing the development libraries for PostgreSQL and

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -1,5 +1,7 @@
 # PRIVATE CLASS: do not use directly
-class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
+class postgresql::repo::yum_postgresql_org ( 
+      $repo_priority = 10 
+    ) inherits postgresql::repo {
   $version_parts   = split($postgresql::repo::version, '[.]')
   $package_version = "${version_parts[0]}${version_parts[1]}"
   $gpg_key_path    = "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}"
@@ -22,6 +24,7 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
     baseurl  => "http://yum.postgresql.org/${postgresql::repo::version}/${label1}/${label2}-\$releasever-\$basearch",
     enabled  => 1,
     gpgcheck => 1,
+    priority => $repo_priority,
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
   }
 

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -1,6 +1,6 @@
 # PRIVATE CLASS: do not use directly
-class postgresql::repo::yum_postgresql_org ( 
-      $repo_priority = 10 
+class postgresql::repo::yum_postgresql_org (
+      $repo_priority = 10
     ) inherits postgresql::repo {
   $version_parts   = split($postgresql::repo::version, '[.]')
   $package_version = "${version_parts[0]}${version_parts[1]}"


### PR DESCRIPTION
Some required packages are newer in the postgresql repo than in base or epel
In the case of postgis, they need to be the later version and priority was
holding back the geos version from yum.postgresql.org, which broke installation
of the postgis package for postgresql 9.2 and up.