### PR TITLE
Reorder environment and require parameter, to unbreak

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -46,8 +46,8 @@ define postgresql::server::role(
   postgresql_psql { "CREATE ROLE ${username} ENCRYPTED PASSWORD ****":
     command     => "CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}",
     unless      => "SELECT rolname FROM pg_roles WHERE rolname='${username}'",
-    require     => Class['Postgresql::Server'],
     environment => $environment,
+    require     => Class['Postgresql::Server'],
   }
 
   postgresql_psql {"ALTER ROLE \"${username}\" ${superuser_sql}":


### PR DESCRIPTION
on OpenBSD puppet 3.7.4, with future parser, and ruby 2.1.5.

Without the change, I ran into error:

Info: Loading facts
    Info: Loading facts
    Error: Could not retrieve catalog from remote server: Error 400 on SERVER: I
nvalid parameter environment on Postgresql_psql[CREATE ROLE puppetdb ENCRYPTED P
ASSWORD ****] at /etc/puppet/environments/production/modules/postgresql/manifest
s/server/role.pp:46 on node puppetdb.srv.intern
    Warning: Not using cache on failed catalog
    Error: Could not retrieve catalog; skipping run

I guess the future parser requires adhering to the order?