### PR TITLE
Repo priority centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,16 @@ The ensure parameter passed on to postgresql contrib package resource.
 
 ###Class: postgresql::server::postgis
 Installs the postgresql postgis packages.
+Requires EPEL repository on RedHat based distributions.
+
+Example:
+
+      class { 'postgresql::globals':
+        manage_package_repo => true,
+        version             => '9.4',
+      } -> 
+      class { 'postgresql::server': } 
+      class { 'postgresql::server::postgis': }
 
 ###Class: postgresql::lib::devel
 Installs the packages containing the development libraries for PostgreSQL and

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -1,5 +1,7 @@
 # PRIVATE CLASS: do not use directly
-class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
+class postgresql::repo::yum_postgresql_org ( 
+      $repo_priority = 10 
+    ) inherits postgresql::repo {
   $version_parts   = split($postgresql::repo::version, '[.]')
   $package_version = "${version_parts[0]}${version_parts[1]}"
   $gpg_key_path    = "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}"
@@ -22,6 +24,7 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
     baseurl  => "http://yum.postgresql.org/${postgresql::repo::version}/${label1}/${label2}-\$releasever-\$basearch",
     enabled  => 1,
     gpgcheck => 1,
+    priority => $repo_priority,
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
   }
 

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -1,6 +1,6 @@
 # PRIVATE CLASS: do not use directly
-class postgresql::repo::yum_postgresql_org ( 
-      $repo_priority = 10 
+class postgresql::repo::yum_postgresql_org (
+      $repo_priority = 10
     ) inherits postgresql::repo {
   $version_parts   = split($postgresql::repo::version, '[.]')
   $package_version = "${version_parts[0]}${version_parts[1]}"


### PR DESCRIPTION
When using a non-default version of postgresql, the yum.postgresql.org repo is needed on Centos6 in order to get the requested version of postgresql and the postgis extension. The priority of the postgresql repository wasn't set, causing at the least the geos dependency to pick the older package found in epel over the correct version found in the yum.postgresql.org repo.
See issue: https://tickets.puppetlabs.com/browse/MODULES-1913
This pull request does the following:
- set the yum repo priority to 10 when using the manage repo option
- document that epel is required in the README and provide a small example to install postgis
