### PR TITLE
Fixed systemd override for managed_repo package versions

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -19,6 +19,7 @@ class postgresql::server::config {
   $manage_recovery_conf       = $postgresql::server::manage_recovery_conf
   $datadir                    = $postgresql::server::datadir
   $logdir                     = $postgresql::server::logdir
+  $manage_package_repo        = $postgresql::globals::manage_package_repo
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,4 +1,8 @@
+<% if @managed_package_repo -%>
+  .include /lib/systemd/system/postgresql-<%= @version %>.service
+<% else -%>
 .include /lib/systemd/system/postgresql.service
+<% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>
 Environment=PGDATA=<%= @datadir %>


### PR DESCRIPTION
When using PGDG repo with manage_package_repo the systemd override is including a missing file and needs to be modified to include the version number.