### PR TITLE
(MODULES-2007) Fix Puppet.newtype deprecation warning

### DIFF
--- a/lib/puppet/type/postgresql_conf.rb
+++ b/lib/puppet/type/postgresql_conf.rb
@@ -1,31 +1,29 @@
-module Puppet
-  newtype(:postgresql_conf) do
+Puppet::Type.newtype(:postgresql_conf) do
 
-    @doc = "This type allows puppet to manage postgresql.conf parameters."
+  @doc = "This type allows puppet to manage postgresql.conf parameters."
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      desc "The postgresql parameter name to manage."
-      isnamevar
+  newparam(:name) do
+    desc "The postgresql parameter name to manage."
+    isnamevar
 
-      newvalues(/^[\w\.]+$/)
-    end
-
-    newproperty(:value) do
-      desc "The value to set for this parameter."
-    end
-
-    newproperty(:target) do
-      desc "The path to postgresql.conf"
-      defaultto {
-        if @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
-          @resource.class.defaultprovider.default_target
-        else
-          nil
-        end
-      }
-    end
-
+    newvalues(/^[\w\.]+$/)
   end
+
+  newproperty(:value) do
+    desc "The value to set for this parameter."
+  end
+
+  newproperty(:target) do
+    desc "The path to postgresql.conf"
+    defaultto {
+      if @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
+        @resource.class.defaultprovider.default_target
+      else
+        nil
+      end
+    }
+  end
+
 end


### PR DESCRIPTION
On Puppet 4 this module is throwing a deprecation warning because it is using Puppet.newtype to create the postgresql_conf type.  
This PR converts it to use Puppet::Type.newtype.