### PR TITLE
Ordering fixups

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -90,7 +90,11 @@ define postgresql::server::database(
     }
   }
 
-  # Build up dependencies on tablespace
+  # Build up dependencies
+  if($owner != undef) {
+    Postgresql::Server::Role <| username == $owner |> -> Exec[$createdb_command]
+  }
+
   if($tablespace != undef and defined(Postgresql::Server::Tablespace[$tablespace])) {
     Postgresql::Server::Tablespace[$tablespace]->Exec[$createdb_command]
   }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -95,7 +95,7 @@ define postgresql::server::database(
     Postgresql::Server::Role <| username == $owner |> -> Exec[$createdb_command]
   }
 
-  if($tablespace != undef and defined(Postgresql::Server::Tablespace[$tablespace])) {
-    Postgresql::Server::Tablespace[$tablespace]->Exec[$createdb_command]
+  if ($tablespace != undef) {
+    Postgresql::Server::Tablespace <| spcname == $tablespace |> -> Exec[$createdb_command]
   }
 }

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -42,7 +42,7 @@ define postgresql::server::tablespace(
     require => [Class['postgresql::server'], File[$location]],
   }
 
-  if($owner != undef and defined(Postgresql::Server::Role[$owner])) {
-    Postgresql::Server::Role[$owner]->Postgresql_psql[$create_ts]
+  if($owner != undef) {
+    Postgresql::Server::Role <| username == $owner |> -> Postgresql_psql[$create_ts]
   }
 }


### PR DESCRIPTION
An additional ordering constraint and a bit more robustness around existing ones.
 * If a role is declared along with a database owned by it, make sure the role is created first
 * Use resource collectors to match on the specific parameters of `postgresql::server::role` and `postgresql::server::tablespace`, instead of just matching the resource title (which may be different).