### PR TITLE
Fixed the metadata of the module so you can install apt 2.0.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <=2.0.1"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]
 }


### PR DESCRIPTION
Simple cleanup to accept puppetlabs-apt 2.0.1 as a valid dependency so r10k/librarian and puppet module install won't complain about version dependency 