### PR TITLE
(#2049) Make title of psql resource for schema creation unique

### DIFF
--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -31,7 +31,7 @@ define postgresql::server::schema(
     port       => $port,
   }
 
-  $schema_title   = "Create Schema '${schema}'"
+  $schema_title   = "Create Schema '${title}'"
   $authorization = $owner? {
     undef   => '',
     default => "AUTHORIZATION \"${owner}\"",


### PR DESCRIPTION
In order to avoid duplicate resource definitions when defining schemas with the same name in different databases on the same server.