### PR TITLE
Support puppetlabs-concat 2.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,5 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
-    file_concat: "https://github.com/electrical/puppet-lib-file_concat.git"
   symlinks:
     postgresql: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <3.0.0"}
   ]
 }


### PR DESCRIPTION
2.0.0 is compatible with current 1.x usage, so permit either 1.x or 2.x
to satisfy the concat dependency.  The fragment `force` parameter is
deprecated, but only results in a warning.  It can be removed at a later
date when 2.x is prevalent.