### PR TITLE
Fix the APT handling.

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -15,7 +15,10 @@ include ::apt
     repos       => "main ${postgresql::repo::version}",
     key         => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
     key_source  => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-    include_src => false,
+    include     => {
+      'src'     => false,
+      'deb'     => true,
+    },
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>


### PR DESCRIPTION
The new APT module from puppetlabs doesn't use "include_src" anymore.
Changed it with the new style.