### PR TITLE
Fixes MODULES_2059 - adds extension argument

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,6 +1,7 @@
 # Activate an extension on a postgresql database
 define postgresql::server::extension (
   $database,
+  $extension = $name,
   $ensure = 'present',
   $package_name = undef,
   $package_ensure = undef,
@@ -20,16 +21,16 @@ define postgresql::server::extension (
 
   case $ensure {
     'present': {
-      $command = "CREATE EXTENSION \"${name}\""
+      $command = "CREATE EXTENSION \"${extension}\""
       $unless_comp = '='
       $package_require = undef
-      $package_before = Postgresql_psql["Add ${title} extension to ${database}"]
+      $package_before = Postgresql_psql["Add ${extension} extension to ${database}"]
     }
 
     'absent': {
-      $command = "DROP EXTENSION \"${name}\""
+      $command = "DROP EXTENSION \"${extension}\""
       $unless_comp = '!='
-      $package_require = Postgresql_psql["Add ${title} extension to ${database}"]
+      $package_require = Postgresql_psql["Add ${extension} extension to ${database}"]
       $package_before = undef
     }
 
@@ -38,10 +39,10 @@ define postgresql::server::extension (
     }
   }
 
-  postgresql_psql {"Add ${title} extension to ${database}":
+  postgresql_psql {"Add ${extension} extension to ${database}":
     db      => $database,
     command => $command,
-    unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${name}') as t WHERE t.count ${unless_comp} 1",
+    unless  => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${extension}') as t WHERE t.count ${unless_comp} 1",
     require => Postgresql::Server::Database[$database],
   }
 
@@ -51,12 +52,11 @@ define postgresql::server::extension (
       default => $package_ensure,
     }
 
-    package { "Postgresql extension ${title}":
+    ensure_packages($package_name, {
       ensure  => $_package_ensure,
-      name    => $package_name,
       tag     => 'postgresql',
       require => $package_require,
       before  => $package_before,
-    }
+    })
   }
 }

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -41,7 +41,7 @@ describe 'postgresql::server::extension', :type => :define do
     }) }
 
     it {
-      is_expected.to contain_package('Postgresql extension postgis').with({
+      is_expected.to contain_package('postgis').with({
         :ensure  => 'present',
         :name    => 'postgis',
       }).that_comes_before('Postgresql_psql[Add postgis extension to template_postgis]')
@@ -63,7 +63,7 @@ describe 'postgresql::server::extension', :type => :define do
     }
 
     it {
-      is_expected.to contain_package('Postgresql extension postgis').with({
+      is_expected.to contain_package('postgis').with({
         :ensure  => 'absent',
         :name    => 'postgis',
       })
@@ -83,7 +83,7 @@ describe 'postgresql::server::extension', :type => :define do
       }
 
       it {
-        is_expected.to contain_package('Postgresql extension postgis').with({
+        is_expected.to contain_package('postgis').with({
           :ensure  => 'present',
           :name    => 'postgis',
         }).that_requires('Postgresql_psql[Add postgis extension to template_postgis]')


### PR DESCRIPTION
This adds the ability to define the extension name separately from the "title" of the resource, which allows you to add the extension to more than one database.