### PR TITLE
Update metadata dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,10 @@ Current it is only actively tested with the following operating systems:
 
 Although patches are welcome for making it work with other OS distros, it is considered best effort.
 
+### Apt module support
+
+While this module supports both 1.x and 2.x versions of the puppetlabs-apt module, it does not support puppetlabs-apt 2.0.0 or 2.0.1.
+
 ### Postgis support
 
 Postgis is currently considered an unsupported feature as it doesn't work on

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <3.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <3.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]
 }


### PR DESCRIPTION
Once puppetlabs-apt 2.1.0 is released (2015-06-16) the postgresql module
will be compatible with apt 1.x (>= 1.8.0) and 2.x (>= 2.1.0). This will
*not* work with puppetlabs-apt 2.0.x.