### PR TITLE
Accept compatible versions of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0 < 6.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]


### PR DESCRIPTION
5.x will also be compatible, so this should accept that, too.

https://github.com/puppetlabs/puppetlabs-stdlib#version-compatibility