### PR TITLE
Show support for Puppet v4 in the metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,11 +59,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
According to the Travis-ci matrix, this module supports Puppet v4. This update to the metadata reflects that.