### PR TITLE
(maint) Add beaker-puppet_install_helper and fix fact bug  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',    :require => false
+  gem 'beaker-puppet_install_helper', :require => false
 end
 
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,10 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
+
+UNSUPPORTED_PLATFORMS = ['AIX','windows','Solaris','Suse']
 
 class String
   # Provide ability to remove indentation from strings, for the purpose of
@@ -34,27 +39,6 @@ def psql(psql_cmd, user = 'postgres', exit_codes = [0,1], &block)
   shell("su #{shellescape(user)} -c #{shellescape(psql)}", :acceptable_exit_codes => exit_codes, &block)
 end
 
-unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
-  # This will install the latest available package on el and deb based
-  # systems fail on windows and osx, and install via gem on other *nixes
-  foss_opts = { :default_action => 'gem_install' }
-
-  if default.is_pe?; then install_pe; else install_puppet( foss_opts ); end
-
-  hosts.each do |host|
-    shell("mkdir -p #{host['distmoduledir']}")
-    if ! host.is_pe?
-      # Augeas is only used in one place, for Redhat.
-      if fact('osfamily') == 'RedHat'
-        install_package host, 'ruby-devel'
-        #install_package host, 'augeas-devel'
-        #install_package host, 'ruby-augeas'
-      end
-    end
-  end
-end
-
-UNSUPPORTED_PLATFORMS = ['AIX','windows','Solaris','Suse']
 
 RSpec.configure do |c|
   # Project root
@@ -92,7 +76,7 @@ RSpec.configure do |c|
     hosts.each do |host|
       on host, "/bin/touch #{default['puppetpath']}/hiera.yaml"
       on host, 'chmod 755 /root'
-      if fact('osfamily') == 'Debian'
+      if fact_on(host, 'osfamily') == 'Debian'
         on host, "echo \"en_US ISO-8859-1\nen_NG.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\n\" > /etc/locale.gen"
         on host, '/usr/sbin/locale-gen'
         on host, '/usr/sbin/update-locale'


### PR DESCRIPTION
- Issue with fact() was being called against default instead of    using fact_on when iterating against each host, also was installing 3.8.1 despite   specifying PUPPET_VERSION=1.1.1 so updated to use beaker-puppet_install_helper