### PR TITLE
update apt module version requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]
 }


### PR DESCRIPTION
The reworked APT module has some backwards compatible changes.
So the dependency for APT module version can now be more relaxed.