### PR TITLE
(MODULES-2181) Fix variable scope for systemd-override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2015-07-01 - Supported Release 4.4.1
+### Summary
+This release fixes RHEL 7 & Fedora with manage_package_repo switched on.
+
+#### Bugfixes
+- Ensure manage_package_repo variable is in scope for systemd-override file for RHEL7
+
 ## 2015-06-30 - Supported Release 4.4.0
 ### Summary
 This release has several new features, bugfixes, and test improvements.

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -14,6 +14,7 @@ class postgresql::server::config {
   $user                       = $postgresql::server::user
   $group                      = $postgresql::server::group
   $version                    = $postgresql::server::_version
+  $manage_package_repo        = $postgresql::server::manage_package_repo
   $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
   $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
   $manage_recovery_conf       = $postgresql::server::manage_recovery_conf

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'postgresql::server::config', :type => :class do
+  let (:pre_condition) do
+    "include postgresql::server"
+  end
+
+  describe 'on RedHat 7' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '7.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it 'should have the correct systemd-override file' do
+      is_expected.to contain_file('systemd-override').with ({
+        :ensure => 'present',
+        :path => '/etc/systemd/system/postgresql.service',
+        :owner => 'root',
+        :group => 'root',
+      })
+      is_expected.to contain_file('systemd-override') \
+        .with_content(/postgresql.service/)
+    end
+
+    describe 'with manage_package_repo => true and a version' do
+      let (:pre_condition) do
+        <<-EOS
+          class { 'postgresql::globals':
+            manage_package_repo => true,
+            version => '9.4',
+          }->
+          class { 'postgresql::server': }
+        EOS
+      end
+
+      it 'should have the correct systemd-override file' do
+        is_expected.to contain_file('systemd-override').with ({
+          :ensure => 'present',
+          :path => '/etc/systemd/system/postgresql-9.4.service',
+          :owner => 'root',
+          :group => 'root',
+        })
+        is_expected.to contain_file('systemd-override') \
+          .with_content(/postgresql-9.4.service/)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
$manage_package_repo wasn't in scope. This was causing all RHEL7 systems with
manage_package_repo on to fail on startup using systemctl, since the template
systemd-override.erb relies on that variable in a conditional, to ensure the
correct PGDG path is set.

Signed-off-by: Ken Barber <ken@bob.sh>