### PR TITLE
(MODULES-2185) Fix `withenv` execution under Puppet 2.7

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -50,7 +50,12 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
   def run_command(command, user, group)
     command = command.join ' '
     environment = get_environment
-    if Puppet::PUPPETVERSION.to_f < 3.4
+    if Puppet::PUPPETVERSION.to_f < 3.0
+      require 'puppet/util/execution'
+      Puppet::Util::Execution.withenv environment do
+        Puppet::Util::SUIDManager.run_and_capture(command, user, group)
+      end
+    elsif Puppet::PUPPETVERSION.to_f < 3.4
       Puppet::Util.withenv environment do
         Puppet::Util::SUIDManager.run_and_capture(command, user, group)
       end


### PR DESCRIPTION
When executing a command with environment variables, the withenv helper
under Puppet 2.7 is on Puppet::Util::Execution and on 3.0 to 3.3, it's
on Puppet::Util.

Replaces #663.