### PR TITLE
Allow for undefined PostGIS version.

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -123,7 +123,10 @@ class postgresql::globals (
     '93'    => '2.1',
     default => undef,
   }
-  $globals_postgis_version = pick($postgis_version, $default_postgis_version)
+  $globals_postgis_version = $postgis_version ? {
+    undef   => $default_postgis_version,
+    default => $postgis_version,
+  }
 
   # Setup of the repo only makes sense globally, so we are doing this here.
   if($manage_package_repo) {


### PR DESCRIPTION
Using `pick()` caused an error if both the class parameter `$postgis_version` and the value of `$default_postgis_version` were `undef`. This change allows both to be `undef`, which is useful if you're using a yet unrecognised version of PostgreSQL.