### PR TITLE
Add proxy option for yum repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Summary
+- support setting a proxy for yum operations
+
 ## 2015-07-07 - Supported Release 4.4.2
 ### Summary
 This release fixes a bug introduced in 4.4.0.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ This will set the default encoding encoding for all databases created with this 
 ####`locale`
 This will set the default database locale for all databases created with this module. On certain operating systems this will be used during the `template1` initialization as well so it becomes a default outside of the module as well. Defaults to `undef` which is effectively `C`.
 
+####`repo_proxy`
+This will set the proxy option for the official PostgreSQL yum-repositories only, Debian is currently not supported. This is useful if your server is behind a corporate firewall and needs to use proxyservers for outside connectivity.
+
+
 #####Debian
 
 On Debian you'll need to ensure that the 'locales-all' package is installed for full functionality of Postgres.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -41,6 +41,7 @@ class postgresql::globals (
 
   $version                = undef,
   $postgis_version        = undef,
+  $repo_proxy             = undef,
 
   $needs_initdb           = undef,
 
@@ -64,6 +65,12 @@ class postgresql::globals (
         default => undef,
       },
       'Amazon' => '9.2',
+      default => $::operatingsystemrelease ? {
+        /^7\./ => '9.2',
+        /^6\./ => '8.4',
+        /^5\./ => '8.1',
+        default => undef,
+      },
       default => $::operatingsystemrelease ? {
         /^7\./ => '9.2',
         /^6\./ => '8.4',
@@ -131,7 +138,8 @@ class postgresql::globals (
   # Setup of the repo only makes sense globally, so we are doing this here.
   if($manage_package_repo) {
     class { 'postgresql::repo':
-      version => $globals_version
+      version => $globals_version,
+      proxy   => $repo_proxy,
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,7 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::repo (
-  $version = undef
+  $version = undef,
+  $proxy = undef,
 ) inherits postgresql::params {
   case $::osfamily {
     'RedHat', 'Linux': {

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -23,6 +23,7 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
     enabled  => 1,
     gpgcheck => 1,
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
+    proxy    => $postgresql::repo::proxy,
   }
 
   Yumrepo['yum.postgresql.org'] -> Package<|tag == 'postgresql'|>

--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -1,30 +1,67 @@
 require 'spec_helper'
 
 describe 'postgresql::globals', :type => :class do
-  let :facts do
-    {
-      :osfamily               => 'Debian',
-      :operatingsystem        => 'Debian',
-      :operatingsystemrelease => '6.0',
-      :lsbdistid              => 'Debian',
-      :lsbdistcodename        => 'squeeze',
-    }
-  end
-
-  describe 'with no parameters' do
-    it 'should work' do
-      is_expected.to contain_class("postgresql::globals")
-    end
-  end
-
-  describe 'manage_package_repo => true' do
-    let(:params) do
+  context "on a debian 6" do
+    let (:facts) do
       {
-        :manage_package_repo => true,
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
+        :operatingsystemrelease => '6.0',
+        :lsbdistid              => 'Debian',
+        :lsbdistcodename        => 'squeeze',
       }
     end
-    it 'should pull in class postgresql::repo' do
-      is_expected.to contain_class("postgresql::repo")
+
+    describe 'with no parameters' do
+      it 'should work' do
+        is_expected.to contain_class("postgresql::globals")
+      end
+    end
+
+    describe 'manage_package_repo => true' do
+      let(:params) do
+        {
+          :manage_package_repo => true,
+        }
+      end
+      it 'should pull in class postgresql::repo' do
+        is_expected.to contain_class("postgresql::repo")
+      end
+    end
+  end
+
+  context 'on redhat family systems' do
+    let (:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '7.1',
+      }
+    end
+    describe 'with no parameters' do
+      it 'should work' do
+        is_expected.to contain_class("postgresql::globals")
+      end
+    end
+    
+    describe 'manage_package_repo on RHEL => true' do
+      let(:params) do
+        {
+          :manage_package_repo => true,
+          :repo_proxy          => 'http://proxy-server:8080',
+        }
+      end
+      
+      it 'should pull in class postgresql::repo' do
+        is_expected.to contain_class("postgresql::repo")
+      end
+
+      it do
+        should contain_yumrepo('yum.postgresql.org').with(
+          'enabled' => '1',
+          'proxy'   => 'http://proxy-server:8080'
+          )
+      end
     end
   end
 end


### PR DESCRIPTION
There was currently no option to set proxies for the postgresql yum repositories, which is especially tedious in enterprise environments where the network environments and permissions are tightly controlled.