### PR TITLE
updating puppetlabs/apt dependency to 2.0.0

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -15,7 +15,9 @@ include ::apt
     repos      => "main ${postgresql::repo::version}",
     key        => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
     key_source => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-    include    => { 'src' => false },
+    include    => {
+      'src' => false,
+    },
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>

--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -10,12 +10,12 @@ include ::apt
     priority   => 500,
   }->
   apt::source { 'apt.postgresql.org':
-    location    => 'http://apt.postgresql.org/pub/repos/apt/',
-    release     => "${::lsbdistcodename}-pgdg",
-    repos       => "main ${postgresql::repo::version}",
-    key         => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
-    key_source  => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-    include_src => false,
+    location   => 'http://apt.postgresql.org/pub/repos/apt/',
+    release    => "${::lsbdistcodename}-pgdg",
+    repos      => "main ${postgresql::repo::version}",
+    key        => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+    key_source => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
+    include    => { 'src' => false },
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
   ]
 }


### PR DESCRIPTION
Updating dependency to apt 2.0.0 which resolves "include_src" warning. 