### PR TITLE
Fix postgis default package name on RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class postgresql::params inherits postgresql::globals {
       $postgis_package_name = pick(
         $postgis_package_name,
         $::operatingsystemrelease ? {
-          /5/     => 'postgis',
+          /^5\./     => 'postgis',
           default => versioncmp($postgis_version, '2') ? {
             '-1'    => "postgis${package_version}",
             default => "postgis2_${package_version}",}


### PR DESCRIPTION
The /5/ regex on $::operatingsystemrelease would match any distro release
with a 5 in it, including for example Centos "7.1.1503". Given the commit
message for this regex, it was meant to match RedHat / Centos 5.x.