### PR TITLE
(MODULES-2211) Fixed systemd-override for RedHat systems with unmanag…

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -20,6 +20,7 @@ class postgresql::server::config {
   $manage_recovery_conf       = $postgresql::server::manage_recovery_conf
   $datadir                    = $postgresql::server::datadir
   $logdir                     = $postgresql::server::logdir
+  $service_name               = $postgresql::server::service_name
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -163,7 +164,7 @@ class postgresql::server::config {
     if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       file { 'systemd-override':
         ensure  => present,
-        path    => "/etc/systemd/system/${postgresql::params::service_name}.service",
+        path    => "/etc/systemd/system/${service_name}.service",
         owner   => root,
         group   => root,
         content => template('postgresql/systemd-override.erb'),

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,8 +1,4 @@
-<% if @manage_package_repo and (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
-.include /lib/systemd/system/postgresql-<%= @version %>.service
-<% else -%>
-.include /lib/systemd/system/postgresql.service
-<% end -%>
+.include /lib/systemd/system/<%= @service_name %>.service
 [Service]
 Environment=PGPORT=<%= @port %>
 Environment=PGDATA=<%= @datadir %>


### PR DESCRIPTION
…ed Yum repos

This change lets the params class compute the name of the correct systemd unit file
via $service_name.

I've tested the following scenarios successfully on a CentOS 7.1 vagrant box:
* manage_package_repo = true, version = specified
* manage_package_repo = false, version = specified (with manually configured repo)
* manage_package_repo = false, version = undef

This fixes the issues described in MODULES-2211 where the `.include` path in the systemd-override template doesn't exist if manage_package_repo = false and version is specified.