### PR TITLE
Decouple pg_hba_rule from postgresql::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,19 @@ This would create a ruleset in `pg_hba.conf` similar to:
     # Order: 150
     host  app  app  200.1.2.0/24  md5
 
+By default, `pg_hba_rule` requires that you include `postgresql::server`, however, you can override that behavior by setting target and postgresql_version when declaring your rule.  That might look like the following.
+
+    postgresql::server::pg_hba_rule { 'allow application network to access app database':
+      description        => "Open up postgresql for access from 200.1.2.0/24",
+      type               => 'host',
+      database           => 'app',
+      user               => 'app',
+      address            => '200.1.2.0/24',
+      auth_method        => 'md5',
+      target             => '/path/to/pg_hba.conf',
+      postgresql_version => '9.4',
+    }
+
 ####`namevar`
 A unique identifier or short description for this rule. The namevar doesn't provide any functional usage, but it is stored in the comments of the produced `pg_hba.conf` so the originating resource can be identified.
 
@@ -730,6 +743,8 @@ An order for placing the rule in `pg_hba.conf`. Defaults to `150`.
 ####`target`
 This provides the target for the rule, and is generally an internal only property. Use with caution.
 
+####`postgresql_version`
+Defaults to the version set in `postgresql::server`.  Use this if you want to manage `pg_hba.conf` without managing the entire PostgreSQL instance.
 
 ###Resource: postgresql::server::pg\_ident\_rule
 This defined type allows you to create user name maps for `pg_ident.conf`. For more details see the [PostgreSQL documentation](http://www.postgresql.org/docs/current/static/auth-username-maps.html).

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -12,10 +12,19 @@ define postgresql::server::pg_hba_rule(
 
   # Needed for testing primarily, support for multiple files is not really
   # working.
-  $target      = $postgresql::server::pg_hba_conf_path
+  $target             = $postgresql::server::pg_hba_conf_path,
+  $postgresql_version = $postgresql::server::_version
 ) {
 
-  if $postgresql::server::manage_pg_hba_conf == false {
+  #Allow users to manage pg_hba.conf even if they are not managing the whole PostgreSQL instance
+  if !defined( 'postgresql::server' ) {
+    $manage_pg_hba_conf = true
+  }
+  else {
+    $manage_pg_hba_conf = $postgresql::server::manage_pg_hba_conf
+  }
+
+  if $manage_pg_hba_conf == false {
       fail('postgresql::server::manage_pg_hba_conf has been disabled, so this resource is now unused and redundant, either enable that option or remove this resource from your manifests')
   } else {
     validate_re($type, '^(local|host|hostssl|hostnossl)$',
@@ -25,7 +34,7 @@ define postgresql::server::pg_hba_rule(
       fail('You must specify an address property when type is host based')
     }
 
-    $allowed_auth_methods = $postgresql::server::_version ? {
+    $allowed_auth_methods = $postgresql_version ? {
       '9.4' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.3' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.2' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],


### PR DESCRIPTION
This change allows the pg_hba_rule defined type to be used
even if you have not included postgresql::server.

By default it will continue with the same behavior as before,
however, you can now specify some extra parameters that were
previously coming directly from postgresql::server