### PR TITLE
removed inherits postgresql::params

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,7 +2,7 @@
 class postgresql::repo (
   $version = undef,
   $proxy = undef,
-) inherits postgresql::params {
+) {
   case $::osfamily {
     'RedHat', 'Linux': {
       if $version == undef {


### PR DESCRIPTION
inheriting `postgresql::params` creates a cycle, because `postgresql::repo` gets instantiated in `postgresql::globals` which is inherited by `postgresql::params`. Also `postgresql::params` are not needed, because only version is used by `postgresql::repo`, `postgresql::repo::yum_postgresql_org` and `postgresql::repo::apt_postgresql_org` and it get set in `postgresql::globals` by a resource like class instantiation.

The following error is created with puppet 4.2.1 if `manage_package_repo` is set to true in hiera:
```
 puppet apply --modulepath=/etc/puppetlabs/code/environments/production/modules -e 'include postgresql::server'
 Error: Evaluation Error: Error while evaluating a Resource Statement, Could not find scope for postgresql::params at /etc/puppetlabs/code/environments/production/modules/postgresql/manifests/globals.pp:140:5 on node test.local
```

Interestingly if `include postgresql::globals` is added prior to `include postgresql::server` then it works. Probably because `postgresql::repo` and `postgresql::params` are already loaded when `postgresql::server` is loading.
