### PR TITLE
Add ability to migrata data between version upgr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ For example, if you wanted to overwrite the default `locale` and `encoding` for 
     class { 'postgresql::server':
     }
 
+Note that locale and encoding will be overwritten if migrate_data is selected and an older database with a different locale/encoding is found
+
 That would make the `encoding` and `locale` the default for all classes and defined resources in this module.
 
 If you want to use the upstream PostgreSQL packaging, and be specific about the version you wish to download, you could use something like this:
@@ -314,6 +316,9 @@ If `true` this will setup the official PostgreSQL repositories on your host. Def
 
 ###Class: postgresql::server
 The following list are options that you can set in the `config_hash` parameter of `postgresql::server`.
+
+####`migrate_data`
+Ensures that if an older version of PostgreSQL is already installed we migrate existing data from the old DB to the new one and shut down/disable the old DB. Note that if the old DB locale/encoding does not match the new this will overwrite those settings to match the old
 
 ####`postgres_password`
 This value defaults to `undef`, meaning the super user account in the postgres database is a user called `postgres` and this account does not have a password. If you provide this setting, the module will set the password for the `postgres` user to your specified value.

--- a/lib/facter/postgres_dirs_on_start.rb
+++ b/lib/facter/postgres_dirs_on_start.rb
@@ -1,0 +1,28 @@
+# Record postgres bin and data directories so data migrations can be performed
+# if postgres is upgraded
+require 'puppet'
+Facter.add(:postgres_most_current_bin_dir) do
+  confine :osfamily => %w{Debian Redhat}
+  os = Facter.value(:osfamily)
+  setcode do
+    if os == 'Debian'
+      cmd = 'find /usr/lib/postgresql -maxdepth 2 -type d -wholename "/usr/lib/postgresql/[0-9]*.[0-9]*/bin" | sort -V | tail -n 1'
+    else
+      cmd = 'find /usr -type f -name "psql" | sort -V | tail -n 2 | head -n 1 | xargs dirname'
+    end
+    Facter::Util::Resolution.exec(cmd)
+  end
+end
+
+Facter.add(:postgres_most_current_data_dir) do
+  confine :osfamily => %w{Debian Redhat}
+  os = Facter.value(:osfamily)
+  setcode do
+    if os == 'Debian'
+      cmd =  'find /var/lib/postgresql -maxdepth 2 -type d -regex ".*[0-9]\.[0-9]/main" | sort -V | tail -n 1'
+    else
+      cmd = 'find /var/lib -maxdepth 4 -type d -regex ".*\(pgsql\|postgres\)+.*/data" | sort -V | head -n 1'
+    end
+    Facter::Util::Resolution.exec(cmd)
+  end
+end

--- a/lib/facter/postgres_locale_encoding.rb
+++ b/lib/facter/postgres_locale_encoding.rb
@@ -1,0 +1,67 @@
+# Record postgres locale info so data migrations can be performed
+# if postgres is upgraded and new cluster can be created with the same locale
+require 'puppet'
+require 'etc'
+
+def run_sql_command(sql)
+  postgres_user = Etc.getpwnam("postgres")
+  user = postgres_user['uid']
+  group = postgres_user['gid']
+  command = "psql -qtc '#{sql}'"
+  if Puppet::PUPPETVERSION.to_f < 3.0
+    require 'puppet/util/execution'
+    Puppet::Util::Execution.withenv environment do
+      output = Puppet::Util::SUIDManager.run_and_capture(command, user, group)
+    end
+  elsif Puppet::PUPPETVERSION.to_f < 3.4
+    Puppet::Util.withenv environment do
+      output  = Puppet::Util::SUIDManager.run_and_capture(command, user, group)
+    end
+  else
+      output = Puppet::Util::Execution.execute(command, { :uid => user, :gid => group})
+  end
+  output.strip
+end
+
+Facter.add(:postgres_cluster_locale_collate) do
+  setcode do
+      run_sql_command('show LC_COLLATE;')
+  end
+end
+
+Facter.add(:postgres_cluster_locale_ctype) do
+  setcode do
+      run_sql_command('show LC_CTYPE;')
+  end
+end
+
+Facter.add(:postgres_cluster_locale_messages) do
+  setcode do
+      run_sql_command('show LC_MESSAGES;')
+  end
+end
+
+Facter.add(:postgres_cluster_locale_monetary) do
+  setcode do
+      run_sql_command('show LC_MONETARY;')
+  end
+end
+
+Facter.add(:postgres_cluster_locale_numeric) do
+  setcode do
+      run_sql_command('show LC_NUMERIC;')
+  end
+end
+
+Facter.add(:postgres_cluster_locale_time) do
+  setcode do
+      run_sql_command('show LC_TIME;')
+  end
+end
+
+Facter.add(:postgres_server_encoding) do
+  setcode do
+      run_sql_command('show SERVER_ENCODING;')
+  end
+end
+

--- a/lib/facter/postgres_service_name.rb
+++ b/lib/facter/postgres_service_name.rb
@@ -1,0 +1,17 @@
+# Find latest/highest version service name for postgres
+require 'puppet'
+Facter.add(:postgres_service_names) do
+  confine :osfamily => %w{Debian Redhat}
+  setcode do
+    cmd = 'find /etc/init.d/ -maxdepth 1 -type f -regex "/etc/init.d/postgresql-?[0-9]*.?[0-9]*" -exec basename {} \;'
+    Facter::Util::Resolution.exec(cmd).gsub(/\s+/m, ' ').strip.split(' ')
+  end
+end
+
+Facter.add(:postgres_latest_service_name) do
+  confine :osfamily => %w{Debian Redhat}
+  setcode do
+    cmd = 'find /etc/init.d/ -maxdepth 1 -type f -regex "/etc/init.d/postgresql-?[0-9]*.?[0-9]*" -exec basename {} \; | sort -V | tail -n 1'
+    Facter::Util::Resolution.exec(cmd).strip
+  end
+end

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -23,6 +23,7 @@ class postgresql::globals (
   $initdb_path            = undef,
   $createdb_path          = undef,
   $psql_path              = undef,
+  $pg_upgrade_path        = undef,
   $pg_hba_conf_path       = undef,
   $pg_ident_conf_path     = undef,
   $postgresql_conf_path   = undef,
@@ -45,6 +46,7 @@ class postgresql::globals (
 
   $needs_initdb           = undef,
 
+  $migrate_data           = undef,
   $encoding               = undef,
   $locale                 = undef,
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,14 @@ class postgresql::params inherits postgresql::globals {
   $ip_mask_allow_all_users    = '127.0.0.1/32'
   $ipv4acls                   = []
   $ipv6acls                   = []
-  $encoding                   = $postgresql::globals::encoding
-  $locale                     = $postgresql::globals::locale
+  $migrate_data               = $postgresql::globals::migrate_data
+  if $migrate_data {
+    $encoding                   = pick($postgres_server_encoding, $postgresql::globals::encoding)
+    $locale                     = pick($postgres_cluster_locale_ctype, $postgresql::globals::locale)
+  } else {
+    $encoding                   = $postgresql::globals::encoding
+    $locale                     = $postgresql::globals::locale
+  }
   $service_ensure             = 'running'
   $service_enable             = true
   $service_manage             = true
@@ -63,6 +69,7 @@ class postgresql::params inherits postgresql::globals {
         $confdir                = pick($confdir, $datadir)
       }
       $psql_path           = pick($psql_path, "${bindir}/psql")
+
 
       $service_status      = $service_status
       $service_reload      = "service ${service_name} reload"
@@ -157,6 +164,7 @@ class postgresql::params inherits postgresql::globals {
       }
       $service_reload         = "service ${service_name} reload"
       $psql_path              = pick($psql_path, '/usr/bin/psql')
+
     }
 
     'FreeBSD': {
@@ -250,14 +258,16 @@ class postgresql::params inherits postgresql::globals {
       if ($confdir == undef) { fail("${err_prefix}confdir") }
     }
   }
-
-  $validcon_script_path = pick($validcon_script_path, '/usr/local/bin/validate_postgresql_connection.sh')
-  $initdb_path          = pick($initdb_path, "${bindir}/initdb")
-  $createdb_path        = pick($createdb_path, "${bindir}/createdb")
-  $pg_hba_conf_path     = pick($pg_hba_conf_path, "${confdir}/pg_hba.conf")
-  $pg_hba_conf_defaults = pick($pg_hba_conf_defaults, true)
-  $pg_ident_conf_path   = pick($pg_ident_conf_path, "${confdir}/pg_ident.conf")
-  $postgresql_conf_path = pick($postgresql_conf_path, "${confdir}/postgresql.conf")
-  $recovery_conf_path   = pick($recovery_conf_path, "${datadir}/recovery.conf")
-  $default_database     = pick($default_database, 'postgres')
+  $validcon_script_path  = pick($validcon_script_path, '/usr/local/bin/validate_postgresql_connection.sh')
+  $initdb_path           = pick($initdb_path, "${bindir}/initdb")
+  $createdb_path         = pick($createdb_path, "${bindir}/createdb")
+  $pg_upgrade_path       = pick($pg_upgrade_path, "${bindir}/pg_upgrade")
+  $pg_ctl_path           = pick($pg_ctl_path, "${bindir}/pg_ctl")
+  $pg_hba_conf_path      = pick($pg_hba_conf_path, "${confdir}/pg_hba.conf")
+  $pg_hba_conf_defaults  = pick($pg_hba_conf_defaults, true)
+  $pg_ident_conf_path    = pick($pg_ident_conf_path, "${confdir}/pg_ident.conf")
+  $postgresql_conf_path  = pick($postgresql_conf_path, "${confdir}/postgresql.conf")
+  $start_conf_path       = pick($start_conf_path, "${confdir}/start.conf")
+  $recovery_conf_path    = pick($recovery_conf_path, "${datadir}/recovery.conf")
+  $default_database      = pick($default_database, 'postgres')
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -28,12 +28,14 @@ class postgresql::server (
   $initdb_path                = $postgresql::params::initdb_path,
   $createdb_path              = $postgresql::params::createdb_path,
   $psql_path                  = $postgresql::params::psql_path,
+  $pg_ctl_path                = $postgresql::params::pg_ctl_path,
   $pg_hba_conf_path           = $postgresql::params::pg_hba_conf_path,
   $pg_ident_conf_path         = $postgresql::params::pg_ident_conf_path,
   $postgresql_conf_path       = $postgresql::params::postgresql_conf_path,
   $recovery_conf_path         = $postgresql::params::recovery_conf_path,
 
   $datadir                    = $postgresql::params::datadir,
+  $bindir                     = $postgresql::params::bindir,
   $xlogdir                    = $postgresql::params::xlogdir,
   $logdir                     = $postgresql::params::logdir,
 
@@ -50,6 +52,8 @@ class postgresql::server (
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
+
+  $migrate_data               = $postgresql::params::migrate_data,
 
   #Deprecated
   $version                    = undef,
@@ -70,6 +74,7 @@ class postgresql::server (
   class { "${pg}::install": }->
   class { "${pg}::initdb": }->
   class { "${pg}::config": }->
+  class { "${pg}::migrate": }->
   class { "${pg}::service": }->
   class { "${pg}::passwd": }->
   anchor { "${pg}::end": }

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -1,16 +1,20 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::initdb {
-  $needs_initdb = $postgresql::server::needs_initdb
-  $initdb_path  = $postgresql::server::initdb_path
-  $datadir      = $postgresql::server::datadir
-  $xlogdir      = $postgresql::server::xlogdir
-  $logdir       = $postgresql::server::logdir
-  $encoding     = $postgresql::server::encoding
-  $locale       = $postgresql::server::locale
-  $group        = $postgresql::server::group
-  $user         = $postgresql::server::user
-  $psql_path    = $postgresql::server::psql_path
-  $port         = $postgresql::server::port
+  $needs_initdb          = $postgresql::server::needs_initdb
+  $initdb_path           = $postgresql::server::initdb_path
+  $datadir               = $postgresql::server::datadir
+  $xlogdir               = $postgresql::server::xlogdir
+  $logdir                = $postgresql::server::logdir
+  $encoding              = $postgresql::server::encoding
+  $locale                = $postgresql::server::locale
+  $group                 = $postgresql::server::group
+  $user                  = $postgresql::server::user
+  $psql_path             = $postgresql::server::psql_path
+  $pg_ctl_path           = $postgresql::server::pg_ctl_path
+  $port                  = $postgresql::server::port
+  $version               = $postgresql::server::_version
+  $bindir                = $postgresql::server::bindir
+  $postgresql_conf_path  = $postgresql::server::postgresql_conf_path
 
   # Set the defaults for the postgresql_psql resource
   Postgresql_psql {
@@ -47,13 +51,56 @@ class postgresql::server::initdb {
     }
   }
 
-  if($needs_initdb) {
+  if $locale != undef {
+    # [workaround]
+    # by default pg_createcluster encoding/locale derived from locale
+    # but it do does not work by installing postgresql via puppet because puppet
+    # always override LANG to 'C'
+    # See:  https://projects.puppetlabs.com/issues/4695
+    # We only drop the cluster if no databases have been created and if ctype
+    # on template 0 does not match specified locale
+    # Port numbers need to be dynamically detected in case of multple versions
+    # running at the same time and listening to different ports, especially
+    # during migrations
+    if $osfamily == 'Debian' {
+      exec { 'postgresql_drop_cluster':
+        command     => "pg_dropcluster --stop ${version} main",
+        unless      => "${psql_path} -qt -p $(grep '^port = ' ${postgresql_conf_path} | awk -F= '{print \$2}' | awk -F\\# '{print \$1}' | tr -d '[[:space:]]') -c '\\l' | grep template0 | awk -F\\| '{ print \$4 }' | tr -d '[[:space:]]' | grep -q '${postgres_cluster_locale_ctype}' > /dev/null",
+        onlyif      => "test \"$(${psql_path} -qt -p $(grep '^port = ' ${postgresql_conf_path} | awk -F= '{print \$2}' | awk -F\\# '{print \$1}' | tr -d '[[:space:]]') -c '\\l' | grep -v '^\\s*|' | grep -v '^\\w*$' | wc -l)\" = 3",
+        user        => $user,
+        group       => $group,
+        path        => [$bindir, "/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        before      => Exec['postgresql_initdb'],
+      }
+      $force_initdb = true
+    } else {
+      exec { 'postgresql_drop_cluster':
+        command     => "rm -Rf ${datadir}",
+        unless      => "${psql_path} -qt -p $(grep '^port = ' ${postgresql_conf_path} | awk -F= '{print \$2}' | awk -F\\# '{print \$1}' | tr -d '[[:space:]]') -c '\\l' | grep template0 | awk -F\\| '{ print \$4 }' | tr -d '[[:space:]]' | grep -q '${postgres_cluster_locale_ctype}'",
+        onlyif      => [ "test \"$(${psql_path} -qt -p $(grep '^port = ' ${postgresql_conf_path} | awk -F= '{print \$2}' | awk -F\\# '{print \$1}' | tr -d '[[:space:]]') -c '\\l' | grep -v '^\\s*|' | grep -v '^\\w*$' | wc -l)\" = 3",
+                         "${pg_ctl_path} -D ${datadir} -o ' -c config_file=${postgresql_conf_path}' -m fast -w stop"
+                       ],
+        user        => $user,
+        group       => $group,
+        path        => [$bindir, "/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        subscribe   => Package['postgresql-server'],
+        refreshonly => true,
+        before      => Exec['postgresql_initdb'],
+      }
+      $force_initdb = true
+    }
+  } else {
+    $force_initdb = false
+  }
+
+  if($needs_initdb) or ($force_initdb) {
     # Build up the initdb command.
     #
     # We optionally add the locale switch if specified. Older versions of the
     # initdb command don't accept this switch. So if the user didn't pass the
     # parameter, lets not pass the switch at all.
     $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
+    $pg_base = "pg_createcluster --start -e '${encoding}' -d '${datadir}'"
     $ic_xlog = $xlogdir ? {
       undef   => $ic_base,
       default => "${ic_base} --xlogdir '${xlogdir}'"
@@ -72,19 +119,31 @@ class postgresql::server::initdb {
       default => "${ic_xlog} --locale '${locale}'"
     }
 
-    # This runs the initdb command, we use the existance of the PG_VERSION
-    # file to ensure we don't keep running this command.
-    exec { 'postgresql_initdb':
-      command   => $initdb_command,
-      creates   => "${datadir}/PG_VERSION",
-      user      => $user,
-      group     => $group,
-      logoutput => on_failure,
-      require   => File[$require_before_initdb],
+    $pg_locale = $locale ? {
+      undef   => $pg_base,
+      default => "${pg_base} --locale '${locale}'"
     }
+
+    $pg_clustercreate_command = $xlogdir ? {
+      undef   => "$pg_locale ${version} main",
+      default => "${pg_locale} ${version} main -- --xlogdir '${xlogdir}'"
+    }
+
     # The package will take care of this for us the first time, but if we
     # ever need to init a new db we need to copy these files explicitly
     if $::operatingsystem == 'Debian' or $::operatingsystem == 'Ubuntu' {
+      # This runs the pg_createcluster command, we use the existance of the PG_VERSION
+      # file to ensure we don't keep running this command. Debian is special :)
+      exec { 'postgresql_initdb':
+        command   => $pg_clustercreate_command,
+        creates   => "${datadir}/PG_VERSION",
+        user      => $user,
+        group     => $group,
+        logoutput => on_failure,
+        path      => [$bindir, "/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        require   => File[$require_before_initdb],
+      }
+
       if $::operatingsystemrelease =~ /^6/ or $::operatingsystemrelease =~ /^7/ or $::operatingsystemrelease =~ /^10\.04/ or $::operatingsystemrelease =~ /^12\.04/ {
         file { 'server.crt':
           ensure  => file,
@@ -105,12 +164,25 @@ class postgresql::server::initdb {
           require => Exec['postgresql_initdb'],
         }
       }
+    } else {
+      # This runs the initdb command, we use the existance of the PG_VERSION
+      # file to ensure we don't keep running this command.
+      exec { 'postgresql_initdb':
+        command   => $initdb_command,
+        creates   => "${datadir}/PG_VERSION",
+        user      => $user,
+        group     => $group,
+        logoutput => on_failure,
+        require   => File[$require_before_initdb],
+      }
     }
   } elsif $encoding != undef {
     # [workaround]
-    # by default pg_createcluster encoding derived from locale
+    # by default pg_createcluster encoding/locale derived from locale
     # but it do does not work by installing postgresql via puppet because puppet
     # always override LANG to 'C'
+    # See:  https://projects.puppetlabs.com/issues/4695
+
     postgresql_psql { "Set template1 encoding to ${encoding}":
       command => "UPDATE pg_database
         SET datistemplate = FALSE

--- a/manifests/server/migrate.pp
+++ b/manifests/server/migrate.pp
@@ -1,0 +1,97 @@
+# PRIVATE CLASS: do not use directly
+class postgresql::server::migrate {
+  $pg_upgrade_path           = $postgresql::server::pg_upgrade_path
+  $pg_ctl_path               = $postgresql::server::pg_ctl_path
+  $psql_path                 = $postgresql::server::psql_path
+  $new_datadir               = $postgresql::server::datadir
+  $old_datadir               = pick($postgres_most_current_data_dir, $postgresql::server::datadir )
+  $new_bindir                = $postgresql::server::bindir
+  $old_bindir                = pick($postgres_most_current_bin_dir, $postgresql::server::bindir )
+  $new_postgresql_conf_path  = $postgresql::server::postgresql_conf_path
+  $user                      = $postgresql::server::user
+  $group                     = $postgresql::server::group
+  $old_confdir               = undef
+  $old_postgresql_confpath   = undef
+  $old_start_confpath        = undef
+
+  include postgresql::server::contrib
+  if ! defined(Class[postgresql::server::contrib]) {
+    include postgresql::server::database
+  }
+  $old_version = regsubst($old_datadir, '.*/([0-9]\.[0-9])/.*', '\1', 'G')
+  $new_version = $postgresql::server::_version
+  $old_conf_dir = $osfamily ? {
+      'Debian'  => pick($old_confdir, "/etc/postgresql/${old_version}/main" ),
+      default   => pick($old_confdir, $postgres_most_current_data_dir, false ),
+  }
+  $old_postgresql_conf_path  = pick($old_postgresql_confpath, "${old_conf_dir}/postgresql.conf")
+  $old_start_conf_path       = pick($old_start_confpath, "${old_conf_dir}/start.conf")
+
+  # We only migrate data if we can find distinct directories for the old and
+  # new version and we are using postgres versions from the postres repository
+  # since these don't automaticaly migrate data like the versions from the OS
+  # repos usually do.
+  if ($new_datadir != $old_datadir) and ($new_bindir != $old_bindir) and ($postgresql::globals::manage_package_repo == true) and ($postgresql::server::migrate_data == true) {
+    if ( $osfamily == 'Debian') {
+      exec { 'postgresql_disable_startup':
+        command     => "/bin/sed -i 's/^auto$/manual/g' ${old_start_conf_path}",
+        refreshonly => true,
+        subscribe   => Package['postgresql-server'],
+        user        => $user,
+        group       => $group,
+        before      => Service['postgresqld'],
+      }
+    } else {
+      exec { 'postgresql_disable_startup':
+        command     => "/sbin/chkconfig ${postgres_latest_service_name} off",
+        refreshonly => true,
+        subscribe   => Package['postgresql-server'],
+        before      => Service['postgresqld'],
+      }
+    }
+    exec { 'postgresql_change_port':
+      command     => "/bin/sed -ri \'s/(port = )([0-9]+)(.*)/echo \\1\$((\\2+1))\\3/ge\' ${old_postgresql_conf_path}",
+      refreshonly => true,
+      subscribe   => Package['postgresql-server'],
+      user        => $user,
+      group       => $group,
+      before      => Service['postgresqld'],
+    } ->
+    exec { 'postgresql_stop_old':
+      command     => "${pg_ctl_path} -D ${old_datadir} -o ' -c config_file=${old_postgresql_conf_path}' -m fast -w stop",
+      refreshonly => true,
+      subscribe   => Package['postgresql-server'],
+      user        => $user,
+      group       => $group,
+      returns     => [0,1],
+    } ->
+    exec { 'postgresql_stop_new':
+      command     => "${pg_ctl_path} -D ${new_datadir} -o ' -c config_file=${new_postgresql_conf_path}' -m fast -w stop",
+      refreshonly => true,
+      subscribe   => Package['postgresql-server'],
+      user        => $user,
+      group       => $group,
+      returns     => [0,1],
+    } ->
+    exec { 'postgresql_migrate':
+      command     => "$pg_upgrade_path -d ${old_datadir} -D ${new_datadir} -b ${old_bindir} -B ${new_bindir} -o ' -c config_file=${old_postgresql_conf_path}' -O ' -c config_file=${new_postgresql_conf_path}' ",
+      refreshonly => true,
+      subscribe   => Package['postgresql-server'],
+      require     => Package['postgresql-contrib'],
+      user        => $user,
+      group       => $group,
+      cwd         => '/tmp',
+    } ->
+    exec { 'postgresql_start_new':
+      command     => "${pg_ctl_path} -D ${new_datadir} -o ' -c config_file=${new_postgresql_conf_path}' start",
+      refreshonly => true,
+      subscribe   => Package['postgresql-server'],
+      user        => $user,
+      group       => $group,
+    }
+
+    debug("Migrated data from ${old_data_path} to ${new_data_path}")
+  } else {
+    debug('Postgres migrations selected but we were not able to migrate anything')
+  }
+}


### PR DESCRIPTION
If the migrate_data option is selected we will attempt to migrate data over
from the old DB to the new DB. If the old database uses a different locale
or encoding than the one specified the migration code will pick the same
encoding/locale as the old DB has in order to be able to migrate.