### PR TITLE
Update systemd-override.erb

### DIFF
--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -32,8 +32,7 @@ describe 'postgresql::server::config', :type => :class do
       let (:pre_condition) do
         <<-EOS
           class { 'postgresql::globals':
-            manage_package_repo => true,
-            version => '9.4',
+            version => '9.0',
           }->
           class { 'postgresql::server': }
         EOS

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -28,11 +28,11 @@ describe 'postgresql::server::config', :type => :class do
         .with_content(/postgresql.service/)
     end
 
-    describe 'with manage_package_repo => true and a version' do
+    describe 'with a version >= 9.1' do
       let (:pre_condition) do
         <<-EOS
           class { 'postgresql::globals':
-            version => '9.0',
+            version => '9.1',
           }->
           class { 'postgresql::server': }
         EOS

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,4 +1,4 @@
-<% if @manage_package_repo or (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
+<% if scope.function_versioncmp([@version.to_s, '9.1']) >= 0 -%>
 .include /lib/systemd/system/postgresql-<%= @version %>.service
 <% else -%>
 .include /lib/systemd/system/postgresql.service

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,4 +1,4 @@
-<% if @manage_package_repo and (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
+<% if @manage_package_repo or (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
 .include /lib/systemd/system/postgresql-<%= @version %>.service
 <% else -%>
 .include /lib/systemd/system/postgresql.service


### PR DESCRIPTION
We are mirroring all external repos so I need to keep `manage_package_repo` to false.

On the other hand, I do have a version >= 9.1 and the service won't start if it doesn't go inside the if.