### PR TITLE
Always add version when >= 9.1

### DIFF
--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -17,22 +17,12 @@ describe 'postgresql::server::config', :type => :class do
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       }
     end
-    it 'should have the correct systemd-override file' do
-      is_expected.to contain_file('systemd-override').with ({
-        :ensure => 'present',
-        :path => '/etc/systemd/system/postgresql.service',
-        :owner => 'root',
-        :group => 'root',
-      })
-      is_expected.to contain_file('systemd-override') \
-        .with_content(/postgresql.service/)
-    end
 
-    describe 'with manage_package_repo => true and a version' do
+    describe 'with a version >= 9.1' do
       let (:pre_condition) do
         <<-EOS
           class { 'postgresql::globals':
-            manage_package_repo => true,
+            manage_package_repo => false,
             version => '9.4',
           }->
           class { 'postgresql::server': }
@@ -52,4 +42,3 @@ describe 'postgresql::server::config', :type => :class do
     end
   end
 end
-

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,4 +1,4 @@
-<% if @manage_package_repo and (scope.function_versioncmp([@version.to_s, '9.1']) >= 0) -%>
+<% if scope.function_versioncmp([@version.to_s, '9.1']) >= 0 -%>
 .include /lib/systemd/system/postgresql-<%= @version %>.service
 <% else -%>
 .include /lib/systemd/system/postgresql.service


### PR DESCRIPTION
Even in the case 'manage_package_repo' is false

By policy, we mirrored all external repos. Systemd won't start at all with a version >= 9.1 in this case.