### PR TITLE
Fixes MODULES_2059 - adds extension argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,10 @@ OS user for running `psql`. Defaults to the default user for the module, usually
 Hash of environment variable used when connecting to a remote server. Defaults to connecting to the local Postgres instance.
 
 ###Resource: postgresql::server::extension
-Manages a postgresql extension.
+This defined type manages a postgresql extension for a given database.
+
+####`extension`
+The extension to activate. If left blank, will use the name of the resource.
 
 ####`database`
 The database on which to activate the extension.


### PR DESCRIPTION
This adds the ability to define the extension name separately from the "title" of the resource, which allows you to add the extension to more than one database.

As per the original ticket, extensions in postgresql can be defined on a per database basis. By using the same name for both the extension and the instance of postgresql::server::extension, you're getting duplicates errors if you try to assign an extension to more than one database.

I tried to expand the current tests to verify we can actually instantiate postgresql::server::extension twice.

Welcoming comments on this as I've never had to do it before :)