### PR TITLE
MODULES-2525 - updated systemd-override to support fedora and CentOS paths for systemd

### DIFF
--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -25,7 +25,7 @@ describe 'postgresql::server::config', :type => :class do
         :group => 'root',
       })
       is_expected.to contain_file('systemd-override') \
-        .with_content(/postgresql.service/)
+        .with_content(/.include \/usr\/lib\/systemd\/system\/postgresql.service/)
     end
 
     describe 'with manage_package_repo => true and a version' do
@@ -47,9 +47,55 @@ describe 'postgresql::server::config', :type => :class do
           :group => 'root',
         })
         is_expected.to contain_file('systemd-override') \
-          .with_content(/postgresql-9.4.service/)
+          .with_content(/.include \/usr\/lib\/systemd\/system\/postgresql-9.4.service/)
+      end
+    end
+  end
+
+  describe 'on Fedora 21' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Fedora',
+        :operatingsystemrelease => '21',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it 'should have the correct systemd-override file' do
+      is_expected.to contain_file('systemd-override').with ({
+        :ensure => 'present',
+        :path => '/etc/systemd/system/postgresql.service',
+        :owner => 'root',
+        :group => 'root',
+      })
+      is_expected.to contain_file('systemd-override') \
+        .with_content(/.include \/lib\/systemd\/system\/postgresql.service/)
+    end
+
+    describe 'with manage_package_repo => true and a version' do
+      let (:pre_condition) do
+        <<-EOS
+          class { 'postgresql::globals':
+            manage_package_repo => true,
+            version => '9.4',
+          }->
+          class { 'postgresql::server': }
+        EOS
+      end
+
+      it 'should have the correct systemd-override file' do
+        is_expected.to contain_file('systemd-override').with ({
+          :ensure => 'present',
+          :path => '/etc/systemd/system/postgresql-9.4.service',
+          :owner => 'root',
+          :group => 'root',
+        })
+        is_expected.to contain_file('systemd-override') \
+          .with_content(/.include \/lib\/systemd\/system\/postgresql-9.4.service/)
       end
     end
   end
 end
-

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,4 +1,8 @@
+<%- if scope.lookupvar('::operatingsystem') == 'Fedora' -%>
 .include /lib/systemd/system/<%= @service_name %>.service
+<% else -%>
+.include /usr/lib/systemd/system/<%= @service_name %>.service
+<% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>
 Environment=PGDATA=<%= @datadir %>


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-2525

The path in the current file does not exist on CentOS 7.  Doing some research it seems this is a Fedora path.  So this PR will template the correct path for Fedora or CentOS/Redhat.  Please see the linked ticket for official documentation from RedHat and Fedora.