### PR TITLE
Change apt::pin to apt_postgresql_org to prevent error message

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -5,7 +5,7 @@ include ::apt
   #
   # http://www.postgresql.org/download/linux/debian/
   #
-  apt::pin { 'apt.postgresql.org':
+  apt::pin { 'apt_postgresql_org':
     originator => 'apt.postgresql.org',
     priority   => 500,
   }->


### PR DESCRIPTION
If manage_package_repo = true the repo.pp will call apt::pin and a file 50apt.postgresql.org will be created. But this causes the error message "wrong file extension in ..." if run apt-get or apt-cache.