### PR TITLE
Quote the encoding when creating a database, fixes error with

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -60,7 +60,7 @@ define postgresql::server::database(
 
   $encoding_option = $encoding ? {
     undef   => '',
-    default => "ENCODING=${encoding}",
+    default => "ENCODING='${encoding}'",
   }
 
   $tablespace_option = $tablespace ? {


### PR DESCRIPTION
PostgreSQL 9.4.4 seen on OpenBSD 5.8-snapshot.

Without the quoting, I got error like the following, using the puppetdb module:

Debug: Executing '/usr/local/bin/psql -d postgres -p 5432 -t -c "CREATE DATABASE puppetdb WITH OWNER=_postgresql TEMPLATE=template0 ENCODING=UTF-8  "'
Error: Error executing SQL; psql returned pid 29760 exit 1: 'ERROR:  syntax error at or near "UTF"
LINE 1: ...b WITH OWNER=_postgresql TEMPLATE=template0 ENCODING=UTF-8
                                                                ^
'
Error: /Stage[main]/Puppetdb::Database::Postgresql/Postgresql::Server::Db[puppetdb]/Postgresql::Server::Database[puppetdb]/Postgresql_psql[Create db 'puppetdb']/
command: change from notrun to CREATE DATABASE puppetdb WITH OWNER=_postgresql TEMPLATE=template0 ENCODING=UTF-8   failed: Error executing SQL; psql returned pid
 29760 exit 1: 'ERROR:  syntax error at or near "UTF"
LINE 1: ...b WITH OWNER=_postgresql TEMPLATE=template0 ENCODING=UTF-8