### PR TITLE
Added parameter to disable automatic service restarts on config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,9 @@ This setting can be used to override the default postgresql service provider. If
 ####`service_reload`
 This setting can be used to override the default reload command for your PostgreSQL service. If not specified, the module will the default reload command for your OS distro.
 
+####`service_restart_on_change`
+This setting can be used to override the default behaviour to restart your Postgresql service when a config entry has been changed that requires a service restart to become active. Defaults to `true`.
+
 ####`service_status`
 This setting can be used to override the default status check command for your PostgreSQL service. If not specified, the module will use whatever service name is the default for your OS distro.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class postgresql::params inherits postgresql::globals {
   $service_ensure             = 'running'
   $service_enable             = true
   $service_manage             = true
+  $service_restart_on_change  = true
   $service_provider           = $service_provider
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
   $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,6 +13,7 @@ class postgresql::server (
   $service_enable             = $postgresql::params::service_enable,
   $service_manage             = $postgresql::params::service_manage,
   $service_name               = $postgresql::params::service_name,
+  $service_restart_on_change  = $postgresql::params::service_restart_on_change,
   $service_provider           = $postgresql::params::service_provider,
   $service_reload             = $postgresql::params::service_reload,
   $service_status             = $postgresql::params::service_status,

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -17,9 +17,11 @@ define postgresql::server::config_entry (
 
   case $name {
     /data_directory|hba_file|ident_file|include|listen_addresses|port|max_connections|superuser_reserved_connections|unix_socket_directory|unix_socket_group|unix_socket_permissions|bonjour|bonjour_name|ssl|ssl_ciphers|shared_buffers|max_prepared_transactions|max_files_per_process|shared_preload_libraries|wal_level|wal_buffers|archive_mode|max_wal_senders|hot_standby|logging_collector|silent_mode|track_activity_query_size|autovacuum_max_workers|autovacuum_freeze_max_age|max_locks_per_transaction|max_pred_locks_per_transaction|restart_after_crash|lc_messages|lc_monetary|lc_numeric|lc_time/: {
-      Postgresql_conf {
-        notify => Class['postgresql::server::service'],
-        before => Class['postgresql::server::reload'],
+      if $postgresql::server::service_restart_on_change {
+        Postgresql_conf {
+          notify => Class['postgresql::server::service'],
+          before => Class['postgresql::server::reload'],
+        }
       }
     }
 

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -23,7 +23,12 @@ define postgresql::server::config_entry (
           before => Class['postgresql::server::reload'],
         }
       } else {
-        Postgresql_conf {}
+        Postgresql_conf {
+            before => [
+                Class['postgresql::server::service'],
+                Class['postgresql::server::reload'],
+            ],
+        }
       }
     }
 

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -22,6 +22,8 @@ define postgresql::server::config_entry (
           notify => Class['postgresql::server::service'],
           before => Class['postgresql::server::reload'],
         }
+      } else {
+        Postgresql_conf {}
       }
     }
 

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -60,6 +60,28 @@ describe 'postgresql::server', :type => :class do
     end
   end
 
+  describe 'service_restart_on_change => false' do
+    let(:params) {{ :service_restart_on_change => false }}
+    it { is_expected.to contain_class("postgresql::params") }
+    it { is_expected.to contain_class("postgresql::server") }
+    it { is_expected.to_not contain_Postgresql_conf('data_directory').that_notifies('Class[postgresql::server::service]')
+    }
+    it 'should validate connection' do
+      is_expected.to contain_postgresql__validate_db_connection('validate_service_is_running')
+    end
+  end
+
+  describe 'service_restart_on_change => true' do
+    let(:params) {{ :service_restart_on_change => true }}
+    it { is_expected.to contain_class("postgresql::params") }
+    it { is_expected.to contain_class("postgresql::server") }
+    it { is_expected.to contain_Postgresql_conf('data_directory').that_notifies('Class[postgresql::server::service]')
+    }
+    it 'should validate connection' do
+      is_expected.to contain_postgresql__validate_db_connection('validate_service_is_running')
+    end
+  end
+
   describe 'service_reload => /bin/true' do
     let(:params) {{ :service_reload => '/bin/true' }}
     it { is_expected.to contain_class("postgresql::params") }


### PR DESCRIPTION
If you run Postgresql on production servers, you might want Puppet not to automatically restart Postgresql service when a config entry change has been applied that requires a restart rather than a reload to become active. This way, Puppet just applies the new config and Ops can restart the service during a scheduled maintenance window.