### PR TITLE
syntax error near UTF8

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -60,7 +60,7 @@ define postgresql::server::database(
 
   $encoding_option = $encoding ? {
     undef   => '',
-    default => "ENCODING=${encoding}",
+    default => "ENCODING='${encoding}'",
   }
 
   $tablespace_option = $tablespace ? {


### PR DESCRIPTION
Missing single quotes.


Error: Error executing SQL; psql returned pid 4487 exit 1: 'ERROR:  syntax error at or near "UTF8"
LINE 1: ... WITH OWNER=dbowner TEMPLATE=template0 ENCODING=UTF8  
                                                                 ^
'
Error: /Stage[main]/Postgresql_wrapper::Config/Postgresql::Server::Db[mydb]/Postgresql::Server::Database[mydb]/Postgresql_psql[Create db 'mydb']/command: change from notrun to CREATE DATABASE dbowner WITH OWNER=postgres TEMPLATE=template0 ENCODING=UTF8   failed: Error executing SQL; psql returned pid 4487 exit 1: 'ERROR:  syntax error at or near "UTF8"
LINE 1: ...proxy WITH OWNER=postgres TEMPLATE=template0 ENCODING=UTF8  
                                                                 ^
'
