### PR TITLE
Use double qoutes around database name.

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -73,7 +73,7 @@ define postgresql::server::database(
   }
 
   postgresql_psql { "Create db '${dbname}'":
-    command => "CREATE DATABASE ${dbname} WITH OWNER=${owner} ${template_option} ${encoding_option} ${locale_option} ${tablespace_option}",
+    command => "CREATE DATABASE \"${dbname}\" WITH OWNER=${owner} ${template_option} ${encoding_option} ${locale_option} ${tablespace_option}",
     unless  => "SELECT datname FROM pg_database WHERE datname='${dbname}'",
     db      => $default_db,
     require => Class['postgresql::server::service']


### PR DESCRIPTION
When using a database name that contains dashes or underscores, the
CREATE DATABASE statement fails with a syntax error. Use double quotes
around the database name to solve this.