### PR TITLE
OpenBSD version is now 9.4

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -102,7 +102,10 @@ class postgresql::globals (
       default => '9.2',
     },
     'FreeBSD' => '93',
-    'OpenBSD' => '9.3',
+    'OpenBSD' => $::operatingsystemrelease ? {
+      /5\.6/ => '9.3',
+      /5\.[7-8]/ => '9.4',
+    },
     'Suse' => $::operatingsystem ? {
       'SLES' => $::operatingsystemrelease ? {
         /11\.[0-4]/ => '91',


### PR DESCRIPTION
The default version for PostgreSQL in 5.7 and 5.8 is 9.4. 5.6 is still supported, so leaving there 9.3