### PR TITLE
OpenBSD 5.9 will also ship a PostgreSQL 9.4 version

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -105,7 +105,7 @@ class postgresql::globals (
     'FreeBSD' => '93',
     'OpenBSD' => $::operatingsystemrelease ? {
       /5\.6/ => '9.3',
-      /5\.[7-8]/ => '9.4',
+      /5\.[7-9]/ => '9.4',
     },
     'Suse' => $::operatingsystem ? {
       'SLES' => $::operatingsystemrelease ? {


### PR DESCRIPTION
Just two days ago, OpenBSD switched to 5.9-beta. Now the postgresql module breaks for me :(
Fix is easy, 5.9 will, as it is with 5.7 and 5.8 come with PostgreSQL 9.4.X.

