### PR TITLE
Support postgres-9.5

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -134,6 +134,7 @@ class postgresql::globals (
     '9.3'   => '2.1',
     '9.4'   => '2.1',
     '93'    => '2.1',
+    '9.5'   => '2.1',
     default => undef,
   }
   $globals_postgis_version = $postgis_version ? {


### PR DESCRIPTION
Fixes the following error:
```
Evaluation Error: Error while evaluating a Function Call, pick(): must receive at least one non empty value at /etc/puppetlabs/code/environments/testing/modules/postgresql/manifests/globals.pp:126:30 on node localhost.ts.sv
```