### PR TITLE
Add default postgis version for 9.5

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -132,8 +132,9 @@ class postgresql::globals (
     '91'    => '1.5',
     '9.2'   => '2.0',
     '9.3'   => '2.1',
-    '9.4'   => '2.1',
     '93'    => '2.1',
+    '9.4'   => '2.1',
+    '9.5'   => '2.2',
     default => undef,
   }
   $globals_postgis_version = $postgis_version ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,15 +76,15 @@ class postgresql::params inherits postgresql::globals {
       $perl_package_name   = pick($perl_package_name, 'perl-DBD-Pg')
       $python_package_name = pick($python_package_name, 'python-psycopg2')
 
-      $postgis_package_name = pick(
-        $postgis_package_name,
-        $::operatingsystemrelease ? {
-          /^5\./     => 'postgis',
-          default => versioncmp($postgis_version, '2') ? {
-            '-1'    => "postgis${package_version}",
-            default => "postgis2_${package_version}",}
-        }
-      )
+      if $postgresql::globals::postgis_package_name {
+        $postgis_package_name = $postgresql::globals::postgis_package_name
+      } elsif $::operatingsystemrelease =~ /^5\./ {
+        $postgis_package_name = 'postgis'
+      } elsif $postgis_version and versioncmp($postgis_version, '2') < 0 {
+        $postgis_package_name = "postgis${package_version}"
+      } else {
+        $postgis_package_name = "postgis2_${package_version}"
+      }
     }
 
     'Archlinux': {
@@ -141,7 +141,7 @@ class postgresql::params inherits postgresql::globals {
       $client_package_name    = pick($client_package_name, "postgresql-client-${version}")
       $server_package_name    = pick($server_package_name, "postgresql-${version}")
       $contrib_package_name   = pick($contrib_package_name, "postgresql-contrib-${version}")
-      if versioncmp($postgis_version, '2') < 0 {
+      if $postgis_version and versioncmp($postgis_version, '2') < 0 {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis")
       } else {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis-${postgis_version}")

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -5,6 +5,7 @@ describe 'postgresql::server', :type => :class do
     {
       :osfamily => 'Debian',
       :operatingsystem => 'Debian',
+      :lsbdistid => 'Debian',
       :operatingsystemrelease => '6.0',
       :concat_basedir => tmpfilename('server'),
       :kernel => 'Linux',
@@ -137,6 +138,21 @@ describe 'postgresql::server', :type => :class do
 
     it 'should contain proper initdb exec' do
       is_expected.to contain_exec('postgresql_initdb')
+    end
+  end
+
+  describe 'postgresql_version' do
+    let(:pre_condition) do
+      <<-EOS
+      class { 'postgresql::globals':
+        manage_package_repo => true,
+        version             => '99.5',
+        before              => Class['postgresql::server'],
+      }
+      EOS
+    end
+    it 'contains the correct package version' do
+      is_expected.to contain_class('postgresql::repo').with_version('99.5')
     end
   end
 end


### PR DESCRIPTION
This commit also updates the logic that determines the postgis version
so that if version association is missing in the future, it will still
compile.