### PR TITLE
Fix postgresql::server acceptance test descriptions

### DIFF
--- a/spec/acceptance/00-utf8_encoding_spec.rb
+++ b/spec/acceptance/00-utf8_encoding_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 # These tests are designed to ensure that the module, when ran with defaults,
 # sets up everything correctly and allows us to connect to Postgres.
-describe 'postgres::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'postgresql::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'with defaults' do
     pp = <<-EOS
       class { 'postgresql::globals':

--- a/spec/acceptance/alternative_port_spec.rb
+++ b/spec/acceptance/alternative_port_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 # These tests ensure that postgres can change itself to an alternative port
 # properly.
-describe 'postgres::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'postgresql::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'on an alternative port' do
     pp = <<-EOS
       class { 'postgresql::server': port => '55433' }

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 # These tests are designed to ensure that the module, when ran with defaults,
 # sets up everything correctly and allows us to connect to Postgres.
-describe 'postgres::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'postgresql::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'with defaults' do
     pp = <<-EOS
       class { 'postgresql::server': }

--- a/spec/acceptance/z_alternative_pgdata_spec.rb
+++ b/spec/acceptance/z_alternative_pgdata_spec.rb
@@ -8,7 +8,7 @@ if fact('osfamily') == 'RedHat' and fact('selinux') == 'true'
   shell 'setenforce 0'
 end
 
-describe 'postgres::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'postgresql::server', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'on an alternative pgdata location' do
     pp = <<-EOS
       #file { '/var/lib/pgsql': ensure => directory, } ->


### PR DESCRIPTION
The descriptions of the acceptance tests should match the class under
test, i.e. postgresql::server.

Analog example: [acceptance/db_spec.rb] (https://github.com/puppetlabs/puppetlabs-postgresql/blob/master/spec/acceptance/db_spec.rb#L3)