### PR TITLE
Fix password change failing

### DIFF
--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -22,6 +22,7 @@ class postgresql::server::passwd {
       cwd         => '/tmp',
       environment => [
         "PGPASSWORD=${postgres_password}",
+        "PGPORT=${port}",
         "NEWPASSWD_ESCAPED=${escaped}",
       ],
       # With this command we're passing -h to force TCP authentication, which

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -45,6 +45,7 @@ describe 'postgresql::server', :type => :class do
         'user'        => 'postgres',
         'environment' => [
           "PGPASSWORD=new-p@s$word-to-set",
+          "PGPORT=5432",
           "NEWPASSWD_ESCAPED=$$new-p@s$word-to-set$$"
         ],
         'unless'      => "/usr/bin/psql -h localhost -p 5432 -c 'select 1' > /dev/null",


### PR DESCRIPTION
postgres db user password change failing when postgres is listening on non standard port number.