### PR TITLE
Escape case where password ends with '$'.

### DIFF
--- a/lib/puppet/parser/functions/postgresql_escape.rb
+++ b/lib/puppet/parser/functions/postgresql_escape.rb
@@ -11,7 +11,7 @@ module Puppet::Parser::Functions
 
     password = args[0]
 
-    if password !~ /\$\$/ 
+    if password !~ /\$\$/ and password[-1] != '$'
       retval = "$$#{password}$$"
     else
       escape = Digest::MD5.hexdigest(password)[0..5].gsub(/\d/,'')
@@ -20,6 +20,6 @@ module Puppet::Parser::Functions
       end
       retval = "$#{escape}$#{password}$#{escape}$"
     end
-    retval 
+    retval
   end
 end

--- a/spec/unit/functions/postgresql_escape_spec.rb
+++ b/spec/unit/functions/postgresql_escape_spec.rb
@@ -8,3 +8,7 @@ describe 'postgresql_escape', :type => :puppet_function do
   it { is_expected.to run.with_params('fo$$o').
     and_return('$ed$fo$$o$ed$') }
 end
+describe 'postgresql_escape', :type => :puppet_function do
+  it { is_expected.to run.with_params('foo$').
+    and_return('$a$foo$$a$') }
+end


### PR DESCRIPTION
postgresql_escape returns an invalid string if the password end in '$'.

    postgres=# alter role "postgres" password $$foo$$$;   
    ERROR:  syntax error at or near "$"
    LINE 1: alter role "postgres" password $$foo$$$;

