### PR TITLE
(MODULES-3024) Quote database objects when creating databases

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -55,7 +55,7 @@ define postgresql::server::database(
 
   $template_option = $template ? {
     undef   => '',
-    default => "TEMPLATE=${template}",
+    default => "TEMPLATE=\"${template}\"",
   }
 
   $encoding_option = $encoding ? {
@@ -65,7 +65,7 @@ define postgresql::server::database(
 
   $tablespace_option = $tablespace ? {
     undef   => '',
-    default => "TABLESPACE=${tablespace}",
+    default => "TABLESPACE=\"${tablespace}\"",
   }
 
   if $createdb_path != undef{
@@ -73,7 +73,7 @@ define postgresql::server::database(
   }
 
   postgresql_psql { "Create db '${dbname}'":
-    command => "CREATE DATABASE \"${dbname}\" WITH OWNER=${owner} ${template_option} ${encoding_option} ${locale_option} ${tablespace_option}",
+    command => "CREATE DATABASE \"${dbname}\" WITH OWNER=\"${owner}\" ${template_option} ${encoding_option} ${locale_option} ${tablespace_option}",
     unless  => "SELECT datname FROM pg_database WHERE datname='${dbname}'",
     db      => $default_db,
     require => Class['postgresql::server::service']
@@ -99,7 +99,7 @@ define postgresql::server::database(
       default => 'shobj_description',
     }
     Postgresql_psql[ "Create db '${dbname}'" ]->
-    postgresql_psql {"COMMENT ON DATABASE ${dbname} IS '${comment}'":
+    postgresql_psql {"COMMENT ON DATABASE \"${dbname}\" IS '${comment}'":
       unless => "SELECT pg_catalog.${comment_information_function}(d.oid, 'pg_database') as \"Description\" FROM pg_catalog.pg_database d WHERE datname = '${dbname}' AND pg_catalog.${comment_information_function}(d.oid, 'pg_database') = '${comment}'",
       db     => $dbname,
     }

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -8,14 +8,14 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
         class { 'postgresql::server':
           postgres_password => 'space password',
         }
-        postgresql::server::tablespace { 'postgresql_test_db':
+        postgresql::server::tablespace { 'postgresql-test-db':
           location => '#{tmpdir}',
         } ->
-        postgresql::server::db { 'postgresql_test_db':
+        postgresql::server::db { 'postgresql-test-db':
           comment    => 'testcomment',
-          user       => 'test',
+          user       => 'test-user',
           password   => 'test1',
-          tablespace => 'postgresql_test_db',
+          tablespace => 'postgresql-test-db',
         }
       EOS
 
@@ -27,12 +27,12 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
       shell("chmod 600 /root/.pgpass")
       shell("psql -U postgres -h localhost --command='\\l'")
 
-      psql('--command="select datname from pg_database" postgresql_test_db') do |r|
-        expect(r.stdout).to match(/postgresql_test_db/)
+      psql('--command="select datname from pg_database" "postgresql-test-db"') do |r|
+        expect(r.stdout).to match(/postgresql-test-db/)
         expect(r.stderr).to eq('')
       end
 
-      psql('--command="SELECT 1 FROM pg_roles WHERE rolname=\'test\'"') do |r|
+      psql('--command="SELECT 1 FROM pg_roles WHERE rolname=\'test-user\'"') do |r|
         expect(r.stdout).to match(/\(1 row\)/)
       end
 
@@ -43,11 +43,11 @@ describe 'postgresql::server::db', :unless => UNSUPPORTED_PLATFORMS.include?(fac
       else
         comment_information_function = "obj_description"
       end
-      psql("--dbname postgresql_test_db --command=\"SELECT pg_catalog.#{comment_information_function}(d.oid, 'pg_database') FROM pg_catalog.pg_database d WHERE datname = 'postgresql_test_db' AND pg_catalog.#{comment_information_function}(d.oid, 'pg_database') = 'testcomment'\"") do |r|
+      psql("--dbname postgresql-test-db --command=\"SELECT pg_catalog.#{comment_information_function}(d.oid, 'pg_database') FROM pg_catalog.pg_database d WHERE datname = 'postgresql-test-db' AND pg_catalog.#{comment_information_function}(d.oid, 'pg_database') = 'testcomment'\"") do |r|
         expect(r.stdout).to match(/\(1 row\)/)
       end
     ensure
-      psql('--command="drop database postgresql_test_db" postgres')
+      psql('--command="drop database "postgresql-test-db" postgres')
       psql('--command="DROP USER test"')
     end
   end

--- a/spec/unit/defines/server/database_spec.rb
+++ b/spec/unit/defines/server/database_spec.rb
@@ -27,7 +27,7 @@ describe 'postgresql::server::database', :type => :define do
     let (:params) {{ :comment => 'test comment',
                      :connect_settings => {} }}
 
-    it { is_expected.to contain_postgresql_psql("COMMENT ON DATABASE test IS 'test comment'").with_connect_settings( {} ) }
+    it { is_expected.to contain_postgresql_psql("COMMENT ON DATABASE \"test\" IS 'test comment'").with_connect_settings( {} ) }
   end
 
   context "with specific db connection settings - default port" do


### PR DESCRIPTION
Prior to this commit, when creating databases with a name or owner that has
characters which must be quoted (e.g., "pe-postgres"), the postgresql::server::database define
fails due to a SQL syntax error.