### PR TITLE
amazon linux defaults to postgresql92 now

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class postgresql::params inherits postgresql::globals {
       $version_parts      = split($version, '[.]')
       $package_version    = "${version_parts[0]}${version_parts[1]}"
 
-      if $version == $postgresql::globals::default_version {
+      if $version == $postgresql::globals::default_version and $::operatingsystem != 'Amazon' {
         $client_package_name    = pick($client_package_name, 'postgresql')
         $server_package_name    = pick($server_package_name, 'postgresql-server')
         $contrib_package_name   = pick($contrib_package_name,'postgresql-contrib')


### PR DESCRIPTION
module currently doesn't work with amazon linux

cat /etc/os-release 
NAME="Amazon Linux AMI"
VERSION="2015.09"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2015.09"
PRETTY_NAME="Amazon Linux AMI 2015.09"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2015.09:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"

yum install postgresql-X currently will install postgresql92-X

it might be better to check if the os[release][major] == 2015 and os[release][minor] >= 9, or a few other options; but I'm not sure when amazon moved to postgresql92 by default.

This works for me, but could break people running on older version of amazon linux.