### PR TITLE
Fix markdown error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ Sets the hash to use during password creation. If the password is not already pr
 postgresql::server::role { "myusername":
 password_hash => postgresql_password('myusername', 'mypassword'),
 }
+```
 
 ##### `replication`
 


### PR DESCRIPTION
This fixes a small error in the README that messes up the markup.