### PR TITLE
Archlinux service reload parameter is incorrect.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,7 +112,7 @@ class postgresql::params inherits postgresql::globals {
       $psql_path              = pick($psql_path, "${bindir}/psql")
 
       $service_status         = $service_status
-      $service_reload         = "service ${service_name} reload"
+      $service_reload         = "systemctl reload ${service_name}"
       $python_package_name    = pick($python_package_name, 'python-psycopg2')
       # Archlinux does not have a perl::DBD::Pg package
       $perl_package_name      = pick($perl_package_name, 'undef')


### PR DESCRIPTION
I first noticed that the initial postgresql used 'service postgresql reload' to reload itself, which caused an error as I'm using systemd.
However, nowhere in postgresql there's a reference to the 'service' command.

I haven't tested wheter deploying postgresql now works without manual intervention, but I have at least verified that the $service_provider value is not Undef.