### PR TITLE
Correctly set $service_provider

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class postgresql::params inherits postgresql::globals {
   $service_enable             = true
   $service_manage             = true
   $service_restart_on_change  = true
-  $service_provider           = $service_provider
+  $service_provider           = $postgresql::globals::service_provider
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
   $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
   $manage_recovery_conf       = pick($manage_recovery_conf, false)


### PR DESCRIPTION
The `$service_provider` variable in params.pp is user-definable via `postgresql::globals::service_provider`. Thus params.pp should reference that variable correctly, like other variables from globals.pp.