### PR TITLE
postgres server init script naming on amazon linux ami

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class postgresql::params inherits postgresql::globals {
         $plperl_package_name    = pick($plperl_package_name, "postgresql${package_version}-plperl")
         $plpython_package_name  = pick($plpython_package_name, "postgresql${package_version}-plpython")
         $service_name           = $::operatingsystem ? {
-          'Amazon' => pick($service_name, "postgresql${version}"),
+          'Amazon' => pick($service_name, "postgresql${version_parts[0]}${version_parts[1]}"),
           default  => pick($service_name, "postgresql-${version}"),
         }
         $bindir                 = $::operatingsystem ? {


### PR DESCRIPTION
On current amazon linux ami (details below), and open puppet (details below), the postgres module (installed as part of puppetlabs/puppetdb) currently, tries to start postgressql server with /etc/init.d/postgresql9.4 , while the init script doesn't have the dot in the version number, so it needs to use /etc/init.d/postgresql94

From what I see in all available postgresql server rpms, currently on amazon linux ami, seems all the init scripts of postgresql doesn't have a dot in the suffix version number.

Supporting info:

[root@puppet ~]# yum list postgres* | grep 'server\.'; 
postgresql94-server.x86_64            9.4.5-1.63.amzn1        @amzn-updates     
postgresql8-server.x86_64             8.4.20-4.51.amzn1       amzn-updates      
postgresql92-server.x86_64            9.2.14-1.56.amzn1       amzn-updates      
postgresql93-server.x86_64            9.3.10-1.60.amzn1       amzn-updates      

for i in postgresql8-server.x86_64 postgresql92-server.x86_64 postgresql93-server.x86_64 postgresql94-server.x86_64; do echo $i; repoquery -l $i | grep init.d; done

postgresql8-server.x86_64
/etc/rc.d/init.d/postgresql
postgresql92-server.x86_64
/etc/rc.d/init.d/postgresql92
postgresql93-server.x86_64
/etc/rc.d/init.d/postgresql93
postgresql94-server.x86_64

[root@puppet ~]# puppet --version
4.3.2
[root@puppet ~]# rpm -qa | grep puppet | grep server
puppetserver-2.2.1-1.el6.noarch
[root@puppet ~]# 
[root@puppet ~]# cat /etc/os-release 
NAME="Amazon Linux AMI"
VERSION="2015.09"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2015.09"
PRETTY_NAME="Amazon Linux AMI 2015.09"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2015.09:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
[root@puppet ~]# 
[root@puppet ~]# cat /etc/system-release
Amazon Linux AMI release 2015.09