### PR TITLE
Add missing onlyif_function to sequence grant code

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -96,11 +96,13 @@ define postgresql::server::grant (
       validate_string($unless_privilege,'USAGE','ALL','ALL PRIVILEGES')
       $unless_function = 'has_sequence_privilege'
       $on_db = $db
+      $onlyif_function = undef
     }
     'ALL SEQUENCES IN SCHEMA': {
       validate_string($_privilege,'USAGE','ALL','ALL PRIVILEGES')
       $unless_function = 'custom'
       $on_db = $db
+      $onlyif_function = undef
 
       $schema = $object_name
 


### PR DESCRIPTION
Fix the following error when trying to grant privileges on a sequence:

Error 400 on SERVER: Undefined variable "onlyif_function" at /etc/puppet/environments/ida/modules/postgresql/manifests/server/grant.pp:223