### PR TITLE
Fix usage of deprecated apt::source parameters.

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -13,9 +13,13 @@ include ::apt
     location    => 'http://apt.postgresql.org/pub/repos/apt/',
     release     => "${::lsbdistcodename}-pgdg",
     repos       => "main ${postgresql::repo::version}",
-    key         => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
-    key_source  => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-    include_src => false,
+    key         => {
+      id     => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+      source => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
+    },
+    include => {
+      src => false,
+    },
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>


### PR DESCRIPTION
The latest puppetlabs-apt module deprecates key_source and include_src
parameters to apt::source which produces the following output on puppetmaster:

```
(Scope(Apt::Source[apt.postgresql.org])) $include_src is deprecated and will be
removed in the next major release, please use $include => { 'src' => false }
instead
(Scope(Apt::Source[apt.postgresql.org])) $key_source is deprecated and will be
removed in the next major release, please use $key => { 'source' =>
https://www.postgresql.org/media/keys/ACCC4CF8.asc } instead.
(Scope(Apt::Key[Add key: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 from
Apt::Source apt.postgresql.org])) $key_source is deprecated and will be removed
in the next major release. Please use $source instead.
```