### PR TITLE
This addresses a deficiency in GH-720

### DIFF
--- a/lib/facter/postgresql_version.rb
+++ b/lib/facter/postgresql_version.rb
@@ -1,8 +1,8 @@
 Facter.add(:postgresql_version) do
   setcode do
-    if Facter::Util::Resolution.which('psql')
-      postgresql_version = Facter::Util::Resolution.exec('psql -V 2>&1')
-      %r{^psql \(PostgreSQL\) ([\w\.]+)}.match(postgresql_version)[1]
+    if Facter::Util::Resolution.which('postgres')
+      postgresql_version = Facter::Util::Resolution.exec('postgres -V 2>&1')
+      %r{^postgres \(PostgreSQL\) ([\w\.]+)}.match(postgresql_version)[1]
     end
   end
 end


### PR DESCRIPTION
GH-720 introduced a case where only the postgres client was installed on a system, and the fact was returning. This changes it to use the postgres binary instead of psql.