### PR TITLE
prevent information leak of database user password

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -38,7 +38,11 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
           env_name = $1
           value = $2
           if environment.include?(env_name) || environment.include?(env_name.to_sym)
-            warning "Overriding environment setting '#{env_name}' with '#{value}'"
+            if env_name == 'NEWPGPASSWD'
+              warning "Overriding environment setting '#{env_name}' with '****'"
+            else
+              warning "Overriding environment setting '#{env_name}' with '#{value}'"
+            end
           end
           environment[env_name] = value
         else


### PR DESCRIPTION
Do not leak the DB password when overriding environment variable NEWPGPASSWD, i.e.

before the patch:
Warning: Postgresql_psql[CREATE ROLE myuser ENCRYPTED PASSWORD ****](provider=ruby): Overriding environment setting 'NEWPGPASSWD' with 'mypassword'

with the patch:
Warning: Postgresql_psql[CREATE ROLE myuser ENCRYPTED PASSWORD ****](provider=ruby): Overriding environment setting 'NEWPGPASSWD' with '****'

