### PR TITLE
Replace depecrated apt::source parameters

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -10,12 +10,16 @@ include ::apt
     priority   => 500,
   }->
   apt::source { 'apt.postgresql.org':
-    location    => 'http://apt.postgresql.org/pub/repos/apt/',
-    release     => "${::lsbdistcodename}-pgdg",
-    repos       => "main ${postgresql::repo::version}",
-    key         => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
-    key_source  => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-    include_src => false,
+    location => 'http://apt.postgresql.org/pub/repos/apt/',
+    release  => "${::lsbdistcodename}-pgdg",
+    repos    => "main ${postgresql::repo::version}",
+    key      => {
+      'id'     => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+      'source' => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
+    },
+    include  => {
+      'src' => false,
+    },
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>


### PR DESCRIPTION
include_src and key_source parameters are deprecated in favour of
include and key hash parameters