### PR TITLE
The $force parameter is deprecated in concat. Remove it.

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -141,7 +141,6 @@ class postgresql::server::config {
     concat { $pg_ident_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no pg_ident_rules
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],
@@ -152,7 +151,6 @@ class postgresql::server::config {
     concat { $recovery_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no recovery conf file
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <3.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":"2.x"}
   ],
   "data_provider": null,
   "operatingsystem_support": [


### PR DESCRIPTION
Concat 2.x has deprecated <code>$force</code>, so I was seeing messages like this on my server:

```syslog
2016-03-29 16:36:45,946 WARN  [puppet-server] Scope(Concat[/var/lib/pgsql/9.3/data/pg_ident.conf]) The $force parameter to concat is deprecated and has no effect.
```