### PR TITLE
Grant role with unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,10 @@ Specifies the group role to which you are assigning a role.
 
 Specifies the role you want to assign to a group.
 
+##### `ensure`
+
+Specifies whether to grant ('present') or revoke ('absent') the membership. Default: 'present'.
+
 ##### `port`
 
 Port to use when connecting. Default: undef, which generally defaults to port 5432 depending on your PostgreSQL packaging.

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ The postgresql module comes with many options for configuring the server. While 
 * [postgresql::server::database_grant](#postgresqlserverdatabase_grant)
 * [postgresql::server::db](#postgresqlserverdb)
 * [postgresql::server::extension](#postgresqlserverextension)
+* [postgresql::server::grant_role](#postgresqlservergrant_role)
 * [postgresql::server::pg_hba_rule](#postgresqlserverpg_hba_rule)
 * [postgresql::server::pg_ident_rule](#postgresqlserverpg_ident_rule)
 * [postgresql::server::recovery](#postgresqlserverrecovery)
@@ -961,6 +962,30 @@ Sets the OS user to run `psql`. Default: the default user for the module, usuall
 ##### `role`
 
 Specifies the role or user whom you are granting access to.
+
+#### postgresql::server::grant_role
+
+Allows you to assign a role to a (group) role. See [PostgreSQL documentation for `Role Membership`](http://www.postgresql.org/docs/current/static/role-membership.html) for more information.
+
+##### `group`
+
+Specifies the group role to which you are assigning a role.
+
+##### `role`
+
+Specifies the role you want to assign to a group.
+
+##### `port`
+
+Port to use when connecting. Default: undef, which generally defaults to port 5432 depending on your PostgreSQL packaging.
+
+##### `psql_db`
+
+Specifies the database to execute the grant against. _This should not ordinarily be changed from the default_, which is `postgres`.
+
+##### `psql_user`
+
+Sets the OS user to run `psql`. Default: the default user for the module, usually `postgres`.
 
 #### postgresql::server::pg_hba_rule
 

--- a/README.md
+++ b/README.md
@@ -987,6 +987,10 @@ Specifies the database to execute the grant against. _This should not ordinarily
 
 Sets the OS user to run `psql`. Default: the default user for the module, usually `postgres`.
 
+##### `connect_settings`
+
+Specifies a hash of environment variables used when connecting to a remote server. Default: Connects to the local Postgres instance.
+
 #### postgresql::server::pg_hba_rule
 
 Allows you to create an access rule for `pg_hba.conf`. For more details see the [usage example](#create-an-access-rule-for-pghba.conf) and the [PostgreSQL documentation](http://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html).

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -13,4 +13,11 @@ define postgresql::server::grant_role (
     unless    => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='${group}' and pg_user.usename = '${role}'",
     require   => Class['postgresql::server'],
   }
+
+  if defined(Postgresql::Server::Role[$role]) {
+    Postgresql::Server::Role[$role]->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+  }
+  if defined(Postgresql::Server::Role[$group]) {
+    Postgresql::Server::Role[$group]->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+  }
 }

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -8,6 +8,14 @@ define postgresql::server::grant_role (
   $port             = $postgresql::server::port,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
+  validate_string($group)
+  validate_string($role)
+  if empty($group) {
+    fail('$group must be set')
+  }
+  if empty($role) {
+    fail('$role must be set')
+  }
   case $ensure {
     'present': {
       $command = "GRANT \"${group}\" TO \"${role}\""

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -1,0 +1,16 @@
+define postgresql::server::grant_role (
+  $group,
+  $role,
+  $psql_db          = $postgresql::server::default_database,
+  $psql_user        = $postgresql::server::user,
+  $port             = $postgresql::server::port,
+) {
+
+  postgresql_psql {"GRANT '${group}' TO '${role}'":
+    db        => $psql_db,
+    psql_user => $psql_user,
+    port      => $port,
+    unless    => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='${group}' and pg_user.usename = '${role}'",
+    require   => Class['postgresql::server'],
+  }
+}

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -4,16 +4,20 @@ define postgresql::server::grant_role (
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
+  $connect_settings = $postgresql::server::default_connect_settings,
 ) {
 
   postgresql_psql {"GRANT '${group}' TO '${role}'":
-    db        => $psql_db,
-    psql_user => $psql_user,
-    port      => $port,
-    unless    => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='${group}' and pg_user.usename = '${role}'",
-    require   => Class['postgresql::server'],
+    db               => $psql_db,
+    psql_user        => $psql_user,
+    port             => $port,
+    unless           => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='${group}' and pg_user.usename = '${role}'",
+    connect_settings => $connect_settings,
   }
 
+  if ! $connect_settings or empty($connect_settings) {
+    Class['postgresql::server']->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+  }
   if defined(Postgresql::Server::Role[$role]) {
     Postgresql::Server::Role[$role]->Postgresql_psql["GRANT '${group}' TO '${role}'"]
   }

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -24,7 +24,7 @@ define postgresql::server::grant_role (
 
   postgresql_psql { "grant_role:${name}":
     command          => $command,
-    unless           => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '${group}' AND u.usename = '${user}') AS t WHERE t.count ${unless_comp} 1",
+    unless           => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '${group}' AND u.usename = '${role}') AS t WHERE t.count ${unless_comp} 1",
     db               => $psql_db,
     psql_user        => $psql_user,
     port             => $port,

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -10,11 +10,11 @@ define postgresql::server::grant_role (
 ) {
   case $ensure {
     'present': {
-      $command = "GRANT '${group}' TO '${role}'"
+      $command = "GRANT \"${group}\" TO \"${role}\""
       $unless_comp = '='
     }
     'absent': {
-      $command = "REVOKE '${group}' FROM '${role}'"
+      $command = "REVOKE \"${group}\" FROM \"${role}\""
       $unless_comp = '!='
     }
     default: {

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -1,3 +1,4 @@
+# Define for granting membership to a role. See README.md for more information
 define postgresql::server::grant_role (
   $group,
   $role,

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -2,27 +2,42 @@
 define postgresql::server::grant_role (
   $group,
   $role,
+  $ensure           = 'present',
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
+  case $ensure {
+    'present': {
+      $command = "GRANT '${group}' TO '${role}'"
+      $unless_comp = '='
+    }
+    'absent': {
+      $command = "REVOKE '${group}' FROM '${role}'"
+      $unless_comp = '!='
+    }
+    default: {
+      fail("Unknown value for ensure '${ensure}'.")
+    }
+  }
 
-  postgresql_psql {"GRANT '${group}' TO '${role}'":
+  postgresql_psql { "grant_role:${name}":
+    command          => $command,
+    unless           => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '${group}' AND u.usename = '${user}') AS t WHERE t.count ${unless_comp} 1",
     db               => $psql_db,
     psql_user        => $psql_user,
     port             => $port,
-    unless           => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='${group}' and pg_user.usename = '${role}'",
     connect_settings => $connect_settings,
   }
 
   if ! $connect_settings or empty($connect_settings) {
-    Class['postgresql::server']->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+    Class['postgresql::server']->Postgresql_psql["grant_role:${name}"]
   }
   if defined(Postgresql::Server::Role[$role]) {
-    Postgresql::Server::Role[$role]->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+    Postgresql::Server::Role[$role]->Postgresql_psql["grant_role:${name}"]
   }
   if defined(Postgresql::Server::Role[$group]) {
-    Postgresql::Server::Role[$group]->Postgresql_psql["GRANT '${group}' TO '${role}'"]
+    Postgresql::Server::Role[$group]->Postgresql_psql["grant_role:${name}"]
   }
 }

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'postgresql::server::grant_role', :type => :define do
+  let :pre_condition do
+    "class { 'postgresql::server': }"
+  end
+
+  let :facts do
+    {:osfamily => 'Debian',
+     :operatingsystem => 'Debian',
+     :operatingsystemrelease => '6.0',
+     :kernel => 'Linux', :concat_basedir => tmpfilename('postgis'),
+     :id => 'root',
+     :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let (:title) { 'test' }
+
+  let (:params) { {
+    :group => 'my_group',
+    :role => 'my_role'
+  } }
+
+  context "with mandatory arguments only" do
+    it {
+      is_expected.to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").with({
+        :unless  => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='#{params[:group]}' and pg_user.usename = '#{params[:role]}'",
+      }).that_requires('Class[postgresql::server]')
+    }
+  end
+
+  context "with db arguments" do
+    let (:params) { super().merge({
+      :psql_db   => 'postgres',
+      :psql_user => 'postgres',
+      :port      => '5432',
+    }) }
+
+    it {
+      is_expected.to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").with({
+        :unless    => "select pg_roles.rolname,usename from pg_user join pg_auth_members on (pg_user.usesysid = pg_auth_members.member) join pg_roles on (pg_roles.oid = pg_auth_members.roleid) where pg_roles.rolname ='#{params[:group]}' and pg_user.usename = '#{params[:role]}'",
+        :db        => params[:psql_db],
+        :psql_user => params[:psql_user],
+        :port      => params[:port],
+      }).that_requires('Class[postgresql::server]')
+    }
+  end
+end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -25,7 +25,7 @@ describe 'postgresql::server::grant_role', :type => :define do
   context "with mandatory arguments only" do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
-        :command => "GRANT '#{params[:group]}' TO '#{params[:role]}'",
+        :command => "GRANT \"#{params[:group]}\" TO \"#{params[:role]}\"",
         :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
       }).that_requires('Class[postgresql::server]')
     }
@@ -40,7 +40,7 @@ describe 'postgresql::server::grant_role', :type => :define do
 
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
-        :command => "GRANT '#{params[:group]}' TO '#{params[:role]}'",
+        :command => "GRANT \"#{params[:group]}\" TO \"#{params[:role]}\"",
         :unless    => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
         :db        => params[:psql_db],
         :psql_user => params[:psql_user],
@@ -56,7 +56,7 @@ describe 'postgresql::server::grant_role', :type => :define do
 
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
-        :command => "REVOKE '#{params[:group]}' FROM '#{params[:role]}'",
+        :command => "REVOKE \"#{params[:group]}\" FROM \"#{params[:role]}\"",
         :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count != 1",
       }).that_requires('Class[postgresql::server]')
     }

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -46,4 +46,32 @@ describe 'postgresql::server::grant_role', :type => :define do
       }).that_requires('Class[postgresql::server]')
     }
   end
+
+  context "with user defined" do
+    let :pre_condition do
+      "class { 'postgresql::server': }
+postgresql::server::role { '#{params[:role]}': }"
+    end
+
+    it {
+      is_expected.to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires("Postgresql::Server::Role[#{params[:role]}]")
+    }
+    it {
+      is_expected.not_to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires("Postgresql::Server::Role[#{params[:group]}]")
+    }
+  end
+
+  context "with group defined" do
+    let :pre_condition do
+      "class { 'postgresql::server': }
+postgresql::server::role { '#{params[:group]}': }"
+    end
+
+    it {
+      is_expected.to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires("Postgresql::Server::Role[#{params[:group]}]")
+    }
+    it {
+      is_expected.not_to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires("Postgresql::Server::Role[#{params[:role]}]")
+    }
+  end
 end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -26,7 +26,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "GRANT '#{params[:group]}' TO '#{params[:role]}'",
-        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:user]}') AS t WHERE t.count = 1",
+        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
       }).that_requires('Class[postgresql::server]')
     }
   end
@@ -41,7 +41,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "GRANT '#{params[:group]}' TO '#{params[:role]}'",
-        :unless    => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:user]}') AS t WHERE t.count = 1",
+        :unless    => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
         :db        => params[:psql_db],
         :psql_user => params[:psql_user],
         :port      => params[:port],
@@ -57,7 +57,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "REVOKE '#{params[:group]}' FROM '#{params[:role]}'",
-        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:user]}') AS t WHERE t.count != 1",
+        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count != 1",
       }).that_requires('Class[postgresql::server]')
     }
   end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -74,4 +74,17 @@ postgresql::server::role { '#{params[:group]}': }"
       is_expected.not_to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires("Postgresql::Server::Role[#{params[:role]}]")
     }
   end
+
+  context "with connect_settings" do
+    let (:params) { super().merge({
+      :connect_settings => { 'PGHOST' => 'postgres-db-server' },
+    }) }
+
+    it {
+      is_expected.to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").with_connect_settings( { 'PGHOST' => 'postgres-db-server' } )
+    }
+    it {
+      is_expected.not_to contain_postgresql_psql("GRANT '#{params[:group]}' TO '#{params[:role]}'").that_requires('Class[postgresql::server]')
+    }
+  end
 end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -31,6 +31,52 @@ describe 'postgresql::server::grant_role', :type => :define do
     }
   end
 
+  context "validation" do
+    context "group invalid type" do
+      let (:params) { {
+        :group => ['a', 'b'],
+        :role  => 'r',
+      } }
+
+      it {
+        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+      }
+    end
+
+    context "role invalid type" do
+      let (:params) { {
+          :group => 'g',
+          :role  => 1,
+      } }
+
+      it {
+        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+      }
+    end
+
+    context "group empty" do
+      let (:params) { {
+          :group => '',
+          :role  => 'r',
+      } }
+
+      it {
+        expect { catalogue }.to raise_error(/\$group must be set/)
+      }
+    end
+
+    context "role empty" do
+      let (:params) { {
+          :group => 'g',
+          :role  => :undef,
+      } }
+
+      it {
+        expect { catalogue }.to raise_error(/\$role must be set/)
+      }
+    end
+  end
+
   context "with db arguments" do
     let (:params) { super().merge({
       :psql_db   => 'postgres',

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -46,7 +46,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     context "role invalid type" do
       let (:params) { {
           :group => 'g',
-          :role  => 1,
+          :role  => true,
       } }
 
       it {


### PR DESCRIPTION
Added unit tests to `grant_role`, created in #756.

This is the first time I wrote tests for a Puppet module, so all feedback welcome (including on code style). Do you need higher level tests as well?

Further enhancements I want to add to this branch:
 
 - [x] support `ensure => present/absent`, so they can be removed as well (similar to `postgresql::server::extension`)
 - [x] support `$connect_environment`