### PR TITLE
Silence unnecessary warning messages.

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -37,13 +37,6 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
         if setting =~ /^(\w+)=((.|\n)+)$/
           env_name = $1
           value = $2
-          if environment.include?(env_name) || environment.include?(env_name.to_sym)
-            if env_name == 'NEWPGPASSWD'
-              warning "Overriding environment setting '#{env_name}' with '****'"
-            else
-              warning "Overriding environment setting '#{env_name}' with '#{value}'"
-            end
-          end
           environment[env_name] = value
         else
           warning "Cannot understand environment setting #{setting.inspect}"


### PR DESCRIPTION
These warnings cause puppet agents to send out a report every time
that puppet runs.  Removed warning messages in order to silence
these reports.