### PR TITLE
MODULES-3107 fail when datadir is mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,13 @@ Overrides the default PostgreSQL data directory for the target platform. Default
 
 **Warning:** If datadir is changed from the default, Puppet does not manage purging of the original data directory, which causes it to fail if the data directory is changed back to the original.
 
+##### `manage_datadir`
+
+Manage datadir as file resource by this module, default true.
+If false, it will not create the folder, and expect 'datadir' exists and own by the 'user'.
+
+**Warning** If manage_datadir is false, Puppet will still initialize database.
+
 ##### `default_database`
 
 Specifies the name of the default database to connect with. On most systems, this is 'postgres'.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -55,7 +55,7 @@ class postgresql::globals (
   $manage_recovery_conf     = undef,
 
   $manage_package_repo      = undef,
-  $ismount                  = false,
+  $manage_datadir           = true,
 ) {
   # We are determining this here, because it is needed by the package repo
   # class.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -55,6 +55,7 @@ class postgresql::globals (
   $manage_recovery_conf     = undef,
 
   $manage_package_repo      = undef,
+  $ismount                  = false,
 ) {
   # We are determining this here, because it is needed by the package repo
   # class.

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,6 +53,7 @@ class postgresql::server (
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
+  $ismount                    = $postgresql::params::ismount,
 
   #Deprecated
   $version                    = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,7 +53,7 @@ class postgresql::server (
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
-  $ismount                    = $postgresql::params::ismount,
+  $manage_datadir             = $postgresql::params::manage_datadir,
 
   #Deprecated
   $version                    = undef,

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -11,6 +11,7 @@ class postgresql::server::initdb {
   $user         = $postgresql::server::user
   $psql_path    = $postgresql::server::psql_path
   $port         = $postgresql::server::port
+  $ismount      = $postgresql::server::ismount
 
   # Set the defaults for the postgresql_psql resource
   Postgresql_psql {
@@ -21,11 +22,13 @@ class postgresql::server::initdb {
   }
 
   # Make sure the data directory exists, and has the correct permissions.
-  file { $datadir:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
-    mode   => '0700',
+  if(!$ismount) {
+    file { $datadir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => '0700',
+    }
   }
 
   if($xlogdir) {

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -1,17 +1,17 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::initdb {
-  $needs_initdb = $postgresql::server::needs_initdb
-  $initdb_path  = $postgresql::server::initdb_path
-  $datadir      = $postgresql::server::datadir
-  $xlogdir      = $postgresql::server::xlogdir
-  $logdir       = $postgresql::server::logdir
-  $encoding     = $postgresql::server::encoding
-  $locale       = $postgresql::server::locale
-  $group        = $postgresql::server::group
-  $user         = $postgresql::server::user
-  $psql_path    = $postgresql::server::psql_path
-  $port         = $postgresql::server::port
-  $ismount      = $postgresql::server::ismount
+  $needs_initdb     = $postgresql::server::needs_initdb
+  $initdb_path      = $postgresql::server::initdb_path
+  $datadir          = $postgresql::server::datadir
+  $xlogdir          = $postgresql::server::xlogdir
+  $logdir           = $postgresql::server::logdir
+  $encoding         = $postgresql::server::encoding
+  $locale           = $postgresql::server::locale
+  $group            = $postgresql::server::group
+  $user             = $postgresql::server::user
+  $psql_path        = $postgresql::server::psql_path
+  $port             = $postgresql::server::port
+  $manage_datadir   = $postgresql::server::manage_datadir
 
   # Set the defaults for the postgresql_psql resource
   Postgresql_psql {
@@ -22,7 +22,7 @@ class postgresql::server::initdb {
   }
 
   # Make sure the data directory exists, and has the correct permissions.
-  if(!$ismount) {
+  if($manage_datadir) {
     file { $datadir:
       ensure => directory,
       owner  => $user,


### PR DESCRIPTION
If datadir is a mount point ( in my case NFS ), module fails during manifests/server/initdb.pp.
Why
it try to create datadir – which already exists because it's mount point.