### PR TITLE
(MODULES-3442) Use empty array for missing resource relationships

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -15,7 +15,7 @@ define postgresql::server::extension (
     'present': {
       $command = "CREATE EXTENSION \"${extension}\""
       $unless_comp = '='
-      $package_require = undef
+      $package_require = []
       $package_before = Postgresql_psql["Add ${extension} extension to ${database}"]
     }
 
@@ -23,7 +23,7 @@ define postgresql::server::extension (
       $command = "DROP EXTENSION \"${extension}\""
       $unless_comp = '!='
       $package_require = Postgresql_psql["Add ${extension} extension to ${database}"]
-      $package_before = undef
+      $package_before = []
     }
 
     default: {


### PR DESCRIPTION
Empty require/before relationships in the server extension package
resource are changed from undef to empty arrays to work around PUP-6385
in Puppet 4.5.x. Previously undef was passed literally through
create_resources() causing Puppet to fail to find the resource named
`undef`.