### PR TITLE
Let the module handle OpenBSD 6.x versions 

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -106,6 +106,7 @@ class postgresql::globals (
     'OpenBSD' => $::operatingsystemrelease ? {
       /5\.6/ => '9.3',
       /5\.[7-9]/ => '9.4',
+      /6\.[0-9]/ => '9.5',
     },
     'Suse' => $::operatingsystem ? {
       'SLES' => $::operatingsystemrelease ? {


### PR DESCRIPTION
and bump default postgresql version for OpenBSD 6.0 to 9.5.

Currently OpenBSD is at 6.0-beta, and release freeze is rather soon. Currently there is PostgreSQL 9.5.3 available as package, which will likely make it into the 6.0 release.

