### PR TITLE
handle case where default database name is not the same as user

### DIFF
--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -5,6 +5,14 @@ class postgresql::server::passwd {
   $group             = $postgresql::server::group
   $psql_path         = $postgresql::server::psql_path
   $port              = $postgresql::server::port
+  $database          = $postgresql::server::default_database
+
+  # psql will default to connecting as $user if you don't specify name
+  $_datbase_user_same = $database == $user
+  $_dboption = $_datbase_user_same ? {
+    false => " --dbname ${database}",
+    default => ''
+  }
 
   if ($postgres_password != undef) {
     # NOTE: this password-setting logic relies on the pg_hba.conf being
@@ -15,7 +23,7 @@ class postgresql::server::passwd {
     exec { 'set_postgres_postgrespw':
       # This command works w/no password because we run it as postgres system
       # user
-      command     => "${psql_path} -c \"ALTER ROLE \\\"${user}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"",
+      command     => "${psql_path}${_dboption} -c \"ALTER ROLE \\\"${user}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"",
       user        => $user,
       group       => $group,
       logoutput   => true,


### PR DESCRIPTION
This is to resolve issue: [MODULES-3739](https://tickets.puppetlabs.com/browse/MODULES-3739) 

Without this change you get an error if you override postgresql::globals::user with something other than the postgresql::globals::default_database value. 

