### PR TITLE
Allow working directory to be configurable via globals (instead of always using /tmp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ Set a prefix for the server logs. Default: `'%t '`
 
 Sets up official PostgreSQL repositories on your host if set to true. Default: false.
 
+##### `module_workdir`
+
+Specifies working directory under which the psql command should be executed. May need to specify if /tmp is on volume mounted with noexec option. Default: /tmp 
+
 ##### `needs_initdb`
 
 Explicitly calls the initdb operation after the server package is installed and before the PostgreSQL service is started. Default: OS dependent.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -55,6 +55,7 @@ class postgresql::globals (
   $manage_recovery_conf     = undef,
 
   $manage_package_repo      = undef,
+  $module_workdir           = undef,
 ) {
   # We are determining this here, because it is needed by the package repo
   # class.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
   $manage_recovery_conf       = pick($manage_recovery_conf, false)
   $package_ensure             = 'present'
+  $module_workdir             = pick($module_workdir,'/tmp')
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,7 +53,7 @@ class postgresql::server (
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
-
+  $module_workdir             = $postgresql::params::module_workdir,
   #Deprecated
   $version                    = undef,
 ) inherits postgresql::params {

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -1,16 +1,17 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::initdb {
-  $needs_initdb = $postgresql::server::needs_initdb
-  $initdb_path  = $postgresql::server::initdb_path
-  $datadir      = $postgresql::server::datadir
-  $xlogdir      = $postgresql::server::xlogdir
-  $logdir       = $postgresql::server::logdir
-  $encoding     = $postgresql::server::encoding
-  $locale       = $postgresql::server::locale
-  $group        = $postgresql::server::group
-  $user         = $postgresql::server::user
-  $psql_path    = $postgresql::server::psql_path
-  $port         = $postgresql::server::port
+  $needs_initdb   = $postgresql::server::needs_initdb
+  $initdb_path    = $postgresql::server::initdb_path
+  $datadir        = $postgresql::server::datadir
+  $xlogdir        = $postgresql::server::xlogdir
+  $logdir         = $postgresql::server::logdir
+  $encoding       = $postgresql::server::encoding
+  $locale         = $postgresql::server::locale
+  $group          = $postgresql::server::group
+  $user           = $postgresql::server::user
+  $psql_path      = $postgresql::server::psql_path
+  $port           = $postgresql::server::port
+  $module_workdir = $postgresql::server::module_workdir
 
   # Set the defaults for the postgresql_psql resource
   Postgresql_psql {
@@ -18,6 +19,7 @@ class postgresql::server::initdb {
     psql_group => $group,
     psql_path  => $psql_path,
     port       => $port,
+    cwd        => $module_workdir,
   }
 
   # Make sure the data directory exists, and has the correct permissions.
@@ -81,6 +83,7 @@ class postgresql::server::initdb {
       group     => $group,
       logoutput => on_failure,
       require   => File[$require_before_initdb],
+      cwd       => $module_workdir,
     }
     # The package will take care of this for us the first time, but if we
     # ever need to init a new db we need to copy these files explicitly

--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -6,6 +6,7 @@ class postgresql::server::passwd {
   $psql_path         = $postgresql::server::psql_path
   $port              = $postgresql::server::port
   $database          = $postgresql::server::default_database
+  $module_workdir    = $postgresql::server::module_workdir
 
   # psql will default to connecting as $user if you don't specify name
   $_datbase_user_same = $database == $user
@@ -27,7 +28,7 @@ class postgresql::server::passwd {
       user        => $user,
       group       => $group,
       logoutput   => true,
-      cwd         => '/tmp',
+      cwd         => $module_workdir,
       environment => [
         "PGPASSWORD=${postgres_password}",
         "PGPORT=${port}",

--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -5,6 +5,14 @@ class postgresql::server::passwd {
   $group             = $postgresql::server::group
   $psql_path         = $postgresql::server::psql_path
   $port              = $postgresql::server::port
+  $database          = $postgresql::server::default_database
+
+  # psql will default to connecting as $user if you don't specify name
+  $_datbase_user_same = $database == $user
+  $_dboption = $_datbase_user_same ? {
+    false => " --dbname ${database}",
+    default => ''
+  }
 
   if ($postgres_password != undef) {
     # NOTE: this password-setting logic relies on the pg_hba.conf being
@@ -15,7 +23,7 @@ class postgresql::server::passwd {
     exec { 'set_postgres_postgrespw':
       # This command works w/no password because we run it as postgres system
       # user
-      command     => "${psql_path} -c \"ALTER ROLE \\\"${user}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"",
+      command     => "${psql_path}${_dboption} -c \"ALTER ROLE \\\"${user}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"",
       user        => $user,
       group       => $group,
       logoutput   => true,

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -13,9 +13,10 @@ define postgresql::server::role(
   $username         = $title,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
-  $psql_user  = $postgresql::server::user
-  $psql_group = $postgresql::server::group
-  $psql_path  = $postgresql::server::psql_path
+  $psql_user      = $postgresql::server::user
+  $psql_group     = $postgresql::server::group
+  $psql_path      = $postgresql::server::psql_path
+  $module_workdir = $postgresql::server::module_workdir
 
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
@@ -57,6 +58,7 @@ define postgresql::server::role(
     psql_group => $psql_group,
     psql_path  => $psql_path,
     connect_settings => $connect_settings,
+    cwd        => $module_workdir,
     require    => [
       Postgresql_psql["CREATE ROLE ${username} ENCRYPTED PASSWORD ****"],
       Class['postgresql::server'],

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -19,10 +19,11 @@ define postgresql::server::schema(
   $connect_settings = $postgresql::server::default_connect_settings,
   $change_ownership = false,
 ) {
-  $user      = $postgresql::server::user
-  $group     = $postgresql::server::group
-  $psql_path = $postgresql::server::psql_path
-  $version   = $postgresql::server::_version
+  $user           = $postgresql::server::user
+  $group          = $postgresql::server::group
+  $psql_path      = $postgresql::server::psql_path
+  $version        = $postgresql::server::_version
+  $module_workdir = $postgresql::server::module_workdir
 
   # If the connection settings do not contain a port, then use the local server port
   if $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
@@ -37,6 +38,7 @@ define postgresql::server::schema(
     psql_group => $group,
     psql_path  => $psql_path,
     port       => $port,
+    cwd        => $module_workdir,
     connect_settings => $connect_settings,
   }
 

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -5,9 +5,10 @@ define postgresql::server::tablespace(
   $spcname = $title,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
-  $user      = $postgresql::server::user
-  $group     = $postgresql::server::group
-  $psql_path = $postgresql::server::psql_path
+  $user           = $postgresql::server::user
+  $group          = $postgresql::server::group
+  $psql_path      = $postgresql::server::psql_path
+  $module_workdir = $postgresql::server::module_workdir
 
   # If the connection settings do not contain a port, then use the local server port
   if $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
@@ -22,6 +23,7 @@ define postgresql::server::tablespace(
     psql_path        => $psql_path,
     port             => $port,
     connect_settings => $connect_settings,
+    cwd              => $module_workdir,
   }
 
   if ($owner == undef) {

--- a/manifests/validate_db_connection.pp
+++ b/manifests/validate_db_connection.pp
@@ -19,6 +19,7 @@ define postgresql::validate_db_connection(
   include postgresql::params
 
   $psql_path = $postgresql::params::psql_path
+  $module_workdir = $postgresql::params::module_workdir
   $validcon_script_path = $postgresql::client::validcon_script_path
 
   $cmd_init = "${psql_path} --tuples-only --quiet "
@@ -67,7 +68,7 @@ define postgresql::validate_db_connection(
   exec { $exec_name:
     command     => "echo 'Unable to connect to defined database using: ${cmd}' && false",
     unless      => $validate_cmd,
-    cwd         => '/tmp',
+    cwd         => $module_workdir,
     environment => $env,
     logoutput   => 'on_failure',
     user        => $run_as,

--- a/spec/unit/classes/server/initdb_spec.rb
+++ b/spec/unit/classes/server/initdb_spec.rb
@@ -32,5 +32,91 @@ describe 'postgresql::server::initdb', :type => :class do
     end
     it { is_expected.to contain_file('/var/lib/pgsql92/data').with_ensure('directory') }
   end
+
+  describe 'exec with module_workdir => /var/tmp' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '6.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          module_workdir => '/var/tmp',
+        }->
+        class { 'postgresql::server': }
+      EOS
+    end
+
+    it 'should contain exec with specified working directory' do
+      is_expected.to contain_exec('postgresql_initdb').with ({
+        :cwd => '/var/tmp',
+      })
+    end
+  end
+
+  describe 'exec with module_workdir => undef' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '6.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+        }->
+        class { 'postgresql::server': }
+      EOS
+    end
+
+    it 'should contain exec with default working directory' do
+      is_expected.to contain_exec('postgresql_initdb').with ({
+        :cwd => '/tmp',
+      })
+    end
+  end
+
+
+  describe 'postgresql_psql with module_workdir => /var/tmp' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '6.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          module_workdir => '/var/tmp',
+          encoding       => 'test',
+          needs_initdb   => false,
+        }->
+        class { 'postgresql::server': }
+      EOS
+    end
+    it 'should contain postgresql_psql with specified working directory' do 
+      is_expected.to contain_postgresql_psql('Set template1 encoding to test').with({
+        :cwd => '/var/tmp',
+      })
+    end
+  end
 end
 

--- a/spec/unit/defines/validate_db_connection_spec.rb
+++ b/spec/unit/defines/validate_db_connection_spec.rb
@@ -52,12 +52,18 @@ describe 'postgresql::validate_db_connection', :type => :define do
     end
 
     let :pre_condition do
-      "class { 'postgresql::client': validcon_script_path => '/opt/something/validate.sh' }"
-    end
+      <<-EOS
+        class { 'postgresql::globals':
+          module_workdir => '/var/tmp',
+        } ->
+        class { 'postgresql::client': validcon_script_path => '/opt/something/validate.sh' }
+      EOS
+    end 
 
-    it 'should have proper path for validate command' do
+    it 'should have proper path for validate command and correct cwd' do
       is_expected.to contain_exec('validate postgres connection for test@test:5432/test').with({
-        :unless => %r'^/opt/something/validate.sh\s+\d+'
+        :unless => %r'^/opt/something/validate.sh\s+\d+',
+        :cwd    => '/var/tmp',
       })
     end
 


### PR DESCRIPTION
When running on a server with /tmp mounted with "noexec" option in fstab (to satisfy security) I was getting an error like: 

Error: Error executing SQL; psql returned 256: 'could not change directory to "/root"

which was resolved for most people back in version 2.2.1 by setting /tmp as the working directory for psql. I need to set the folder to something else now that /tmp is secure so this pull request makes /tmp configurable. 

This pull also has a commit from another pull request I have open that is waiting for 4.6.1 to come out so the tests will pass. 