### PR TITLE
(#3858) Fix unless check in grant_role to work with roles as well as users

### DIFF
--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -32,7 +32,7 @@ define postgresql::server::grant_role (
 
   postgresql_psql { "grant_role:${name}":
     command          => $command,
-    unless           => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '${group}' AND u.usename = '${role}') AS t WHERE t.count ${unless_comp} 1",
+    unless           => "SELECT 1 WHERE pg_has_role('${role}', '${group}', 'MEMBER') ${unless_comp} true",
     db               => $psql_db,
     psql_user        => $psql_user,
     port             => $port,

--- a/spec/acceptance/server/grant_role_spec.rb
+++ b/spec/acceptance/server/grant_role_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper_acceptance'
+
+describe 'postgresql::server::grant_role:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  it 'should grant a role to a user' do
+    begin
+      pp = <<-EOS.unindent
+        $db = 'grant_role_test'
+        $user = 'psql_grant_role_tester'
+        $group = 'test_group'
+        $password = 'psql_grant_role_pw'
+
+        class { 'postgresql::server': }
+
+        # Since we are not testing pg_hba or any of that, make a local user for ident auth
+        user { $user:
+          ensure => present,
+        }
+
+        postgresql::server::role { $user:
+          password_hash => postgresql_password($user, $password),
+        }
+
+        postgresql::server::database { $db:
+          owner   => $user,
+          require => Postgresql::Server::Role[$user],
+        }
+
+        # Create a rule for the user
+        postgresql::server::pg_hba_rule { "allow ${user}":
+          type        => 'local',
+          database    => $db,
+          user        => $user,
+          auth_method => 'ident',
+          order       => 1,
+        }
+
+        # Create a role to grant to the user
+        postgresql::server::role { $group:
+          db      => $db,
+          login   => false,
+          require => Postgresql::Server::Database[$db],
+        }
+
+        # Grant the role to the user
+        postgresql::server::grant_role { "grant_role ${group} to ${user}":
+          role  => $user,
+          group => $group,
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+      ## Check that the role was granted to the user
+      psql('--command="SELECT 1 WHERE pg_has_role(\'psql_grant_role_tester\', \'test_group\', \'MEMBER\') = true" grant_role_test', 'psql_grant_role_tester') do |r|
+        expect(r.stdout).to match(/\(1 row\)/)
+        expect(r.stderr).to eq('')
+      end
+    end
+  end
+
+end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -26,7 +26,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "GRANT \"#{params[:group]}\" TO \"#{params[:role]}\"",
-        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
+        :unless  => "SELECT 1 WHERE pg_has_role('#{params[:role]}', '#{params[:group]}', 'MEMBER') = true",
       }).that_requires('Class[postgresql::server]')
     }
   end
@@ -87,7 +87,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "GRANT \"#{params[:group]}\" TO \"#{params[:role]}\"",
-        :unless    => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count = 1",
+        :unless  => "SELECT 1 WHERE pg_has_role('#{params[:role]}', '#{params[:group]}', 'MEMBER') = true",
         :db        => params[:psql_db],
         :psql_user => params[:psql_user],
         :port      => params[:port],
@@ -103,7 +103,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     it {
       is_expected.to contain_postgresql_psql("grant_role:#{title}").with({
         :command => "REVOKE \"#{params[:group]}\" FROM \"#{params[:role]}\"",
-        :unless  => "SELECT t.count FROM (SELECT count(*) FROM pg_user AS u JOIN pg_auth_members AS am ON (u.usesysid = am.member) JOIN pg_roles AS r ON (r.oid = am.roleid) WHERE r.rolname = '#{params[:group]}' AND u.usename = '#{params[:role]}') AS t WHERE t.count != 1",
+        :unless  => "SELECT 1 WHERE pg_has_role('#{params[:role]}', '#{params[:group]}', 'MEMBER') != true",
       }).that_requires('Class[postgresql::server]')
     }
   end


### PR DESCRIPTION
This PR corrects the unless check for postgresql::server::grant_role as well as adding acceptance tests.  Documented originally in https://tickets.puppetlabs.com/browse/MODULES-3858

Please let me know if you have any questions.