### PR TITLE
Default role of grant_role to namevar

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ Specifies the group role to which you are assigning a role.
 
 ##### `role`
 
-Specifies the role you want to assign to a group.
+Specifies the role you want to assign to a group.  If left blank, uses the name of the resource.
 
 ##### `ensure`
 

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -1,7 +1,7 @@
 # Define for granting membership to a role. See README.md for more information
 define postgresql::server::grant_role (
   $group,
-  $role,
+  $role             = $name,
   $ensure           = 'present',
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -68,7 +68,7 @@ describe 'postgresql::server::grant_role', :type => :define do
     context "role empty" do
       let (:params) { {
           :group => 'g',
-          :role  => :undef,
+          :role  => '',
       } }
 
       it {


### PR DESCRIPTION
Most of the times users are part of a single group.  This change make it
easier to grant a role to an array of roles.
