### PR TITLE
Remove duplicate RedHat default section

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -76,12 +76,6 @@ class postgresql::globals (
         /^5\./ => '8.1',
         default => undef,
       },
-      default => $::operatingsystemrelease ? {
-        /^7\./ => '9.2',
-        /^6\./ => '8.4',
-        /^5\./ => '8.1',
-        default => undef,
-      },
     },
     'Debian' => $::operatingsystem ? {
       'Debian' => $::operatingsystemrelease ? {


### PR DESCRIPTION
A duplicate default_version default section was added in
https://github.com/puppetlabs/puppetlabs-postgresql/commit/1eb45d07f163ab3e3fd117d9de4bc4351b228853.

This removes the duplicate default section.
