### PR TITLE
Add support for Gentoo-based operatingsystems

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -8,10 +8,12 @@ class postgresql::client (
   validate_absolute_path($validcon_script_path)
   validate_string($package_name)
 
-  package { 'postgresql-client':
-    ensure => $package_ensure,
-    name   => $package_name,
-    tag    => 'postgresql',
+  if $package_name != 'UNSET' {
+    package { 'postgresql-client':
+      ensure => $package_ensure,
+      name   => $package_name,
+      tag    => 'postgresql',
+    }
   }
 
   file { $validcon_script_path:

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -104,6 +104,7 @@ class postgresql::globals (
       /Archlinux/ => '9.2',
       default => '9.2',
     },
+    'Gentoo' => '9.5',
     'FreeBSD' => '93',
     'OpenBSD' => $::operatingsystemrelease ? {
       /5\.6/ => '9.3',

--- a/manifests/lib/devel.pp
+++ b/manifests/lib/devel.pp
@@ -8,6 +8,10 @@ class postgresql::lib::devel(
 
   validate_string($package_name)
 
+  if $::osfamily == 'Gentoo' {
+    fail('osfamily Gentoo does not have a separate "devel" package, postgresql::lib::devel is not supported')
+  }
+
   package { 'postgresql-devel':
     ensure => $package_ensure,
     name   => $package_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,6 +171,30 @@ class postgresql::params inherits postgresql::globals {
       $psql_path              = pick($psql_path, '/usr/bin/psql')
     }
 
+    'Gentoo': {
+      $user                = pick($user, 'postgres')
+      $group               = pick($group, 'postgres')
+
+      $client_package_name  = pick($client_package_name, 'UNSET')
+      $server_package_name  = pick($server_package_name, 'postgresql')
+      $contrib_package_name = pick_default($contrib_package_name, undef)
+      $devel_package_name   = pick_default($devel_package_name, undef)
+      $java_package_name    = pick($java_package_name, 'jdbc-postgresql')
+      $perl_package_name    = pick($perl_package_name, 'DBD-Pg')
+      $plperl_package_name  = undef
+      $python_package_name  = pick($python_package_name, 'psycopg')
+
+      $service_name         = pick($service_name, "postgresql-${version}")
+      $bindir               = pick($bindir, "/usr/lib/postgresql-${version}/bin")
+      $datadir              = pick($datadir, "/var/lib/postgresql/${version}_data")
+      $confdir              = pick($confdir, "/etc/postgresql-${version}")
+      $service_status       = pick($service_status, "systemctl status ${service_name}")
+      $service_reload       = "systemctl reload ${service_name}"
+      $psql_path            = pick($psql_path, "${bindir}/psql")
+
+      $needs_initdb         = pick($needs_initdb, true)
+    }
+
     'FreeBSD': {
       $link_pg_config       = true
       $user                 = pick($user, 'pgsql')

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -166,27 +166,28 @@ class postgresql::server::config {
     }
   }
 
-  if $::osfamily == 'RedHat' {
-    if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
-      # Template uses:
-      # - $::operatingsystem
-      # - $service_name
-      # - $port
-      # - $datadir
-      file { 'systemd-override':
-        ensure  => present,
-        path    => "/etc/systemd/system/${service_name}.service",
-        owner   => root,
-        group   => root,
-        content => template('postgresql/systemd-override.erb'),
-        notify  => [ Exec['restart-systemd'], Class['postgresql::server::service'] ],
-        before  => Class['postgresql::server::reload'],
-      }
-      exec { 'restart-systemd':
-        command     => 'systemctl daemon-reload',
-        refreshonly => true,
-        path        => '/bin:/usr/bin:/usr/local/bin'
-      }
+  if $::osfamily == 'Gentoo' or
+    ($::osfamily == 'RedHat' and
+      ($::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora')) {
+
+    # Template uses:
+    # - $::operatingsystem
+    # - $service_name
+    # - $port
+    # - $datadir
+    file { 'systemd-override':
+      ensure  => present,
+      path    => "/etc/systemd/system/${service_name}.service",
+      owner   => root,
+      group   => root,
+      content => template('postgresql/systemd-override.erb'),
+      notify  => [ Exec['restart-systemd'], Class['postgresql::server::service'] ],
+      before  => Class['postgresql::server::reload'],
+    }
+    exec { 'restart-systemd':
+      command     => 'systemctl daemon-reload',
+      refreshonly => true,
+      path        => '/bin:/usr/bin:/usr/local/bin'
     }
   }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -166,10 +166,30 @@ class postgresql::server::config {
     }
   }
 
-  if $::osfamily == 'Gentoo' or
-    ($::osfamily == 'RedHat' and
-      ($::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora')) {
-
+  if $::osfamily == 'RedHat' {
+    if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
+      # Template uses:
+      # - $::operatingsystem
+      # - $service_name
+      # - $port
+      # - $datadir
+      file { 'systemd-override':
+        ensure  => present,
+        path    => "/etc/systemd/system/${service_name}.service",
+        owner   => root,
+        group   => root,
+        content => template('postgresql/systemd-override.erb'),
+        notify  => [ Exec['restart-systemd'], Class['postgresql::server::service'] ],
+        before  => Class['postgresql::server::reload'],
+      }
+      exec { 'restart-systemd':
+        command     => 'systemctl daemon-reload',
+        refreshonly => true,
+        path        => '/bin:/usr/bin:/usr/local/bin'
+      }
+    }
+  }
+  elsif $::osfamily == 'Gentoo' {
     # Template uses:
     # - $::operatingsystem
     # - $service_name

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -5,6 +5,10 @@ class postgresql::server::contrib (
 ) inherits postgresql::params {
   validate_string($package_name)
 
+  if $::osfamily == 'Gentoo' {
+    fail('osfamily Gentoo does not have a separate "contrib" package, postgresql::server::contrib is not supported.')
+  }
+
   package { 'postgresql-contrib':
     ensure => $package_ensure,
     name   => $package_name,

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -44,4 +44,15 @@ describe 'postgresql::client', :type => :class do
       })
     end
   end
+
+  describe 'with client package name explicitly set undef' do
+    let :params do
+      {
+        :package_name => 'UNSET'
+      }
+    end
+    it 'should not manage postgresql-client package' do
+      is_expected.not_to contain_package('postgresql-client')
+    end
+  end
 end

--- a/spec/unit/classes/lib/devel_spec.rb
+++ b/spec/unit/classes/lib/devel_spec.rb
@@ -51,4 +51,23 @@ describe 'postgresql::lib::devel', :type => :class do
     }
   end
 
+  describe 'on Gentoo' do
+    let :facts do
+      {
+        :osfamily => 'Gentoo',
+        :operatingsystem => 'Gentoo',
+      }
+    end
+    let :params do
+      {
+        :link_pg_config => false,
+      }
+    end
+
+    it 'should fail to compile' do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/is not supported/)
+    end
+  end
 end

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -98,4 +98,36 @@ describe 'postgresql::server::config', :type => :class do
       end
     end
   end
+
+  describe 'on Gentoo' do
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          version => '9.5',
+        }->
+        class { 'postgresql::server': }
+      EOS
+    end
+    let :facts do
+      {
+        :osfamily => 'Gentoo',
+        :operatingsystem => 'Gentoo',
+        :operatingsystemrelease => 'unused',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it 'should have the correct systemd-override file' do
+      is_expected.to contain_file('systemd-override').with ({
+        :ensure => 'present',
+        :path => '/etc/systemd/system/postgresql-9.5.service',
+        :owner => 'root',
+        :group => 'root',
+      })
+      is_expected.to contain_file('systemd-override') \
+        .with_content(/.include \/usr\/lib64\/systemd\/system\/postgresql-9.5.service/)
+    end
+  end
 end

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -41,4 +41,19 @@ describe 'postgresql::server::contrib', :type => :class do
       })
     end
   end
+
+  describe 'on Gentoo' do
+    let :facts do
+      {
+        :osfamily => 'Gentoo',
+        :operatingsystem => 'Gentoo',
+      }
+    end
+
+    it 'should fail to compile' do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/is not supported/)
+    end
+  end
 end

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -2,7 +2,7 @@
 .include /usr/lib64/systemd/system/<%= @service_name %>.service
 <%- elsif scope.lookupvar('::operatingsystem') == 'Fedora' -%>
 .include /lib/systemd/system/<%= @service_name %>.service
-<% else %>
+<% else -%>
 .include /usr/lib/systemd/system/<%= @service_name %>.service
 <% end -%>
 [Service]

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,8 +1,14 @@
-<%- if scope.lookupvar('::operatingsystem') == 'Fedora' -%>
+<%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
+.include /usr/lib64/systemd/system/<%= @service_name %>.service
+<%- elsif scope.lookupvar('::operatingsystem') == 'Fedora' -%>
 .include /lib/systemd/system/<%= @service_name %>.service
-<% else -%>
+<% else %>
 .include /usr/lib/systemd/system/<%= @service_name %>.service
 <% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>
+<%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
+Environment=DATA_DIR=<%= @datadir %>
+<%- else -%>
 Environment=PGDATA=<%= @datadir %>
+<%- end -%>


### PR DESCRIPTION
- Add params.pp support for osfamily=Gentoo
- Make `postgresql::client` management of `postgresql-client` package
  optional. (Gentoo does not split client/server/devel/contrib packages).
  Add spec test for this new behaviour
- Ensure ::server::contrib and ::lib::devel fail on gentoo for same reason
- Extend the systemd-override to Gentoo to propagate port and datadir changes

Fixes https://tickets.puppetlabs.com/browse/MODULES-4011
