### PR TITLE
Change - Add default postgres version for Fedora 24 to globals class

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -61,6 +61,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
+        /^(24)$/       => '9.5',
         /^(22|23)$/    => '9.4',
         /^(21)$/       => '9.3',
         /^(18|19|20)$/ => '9.2',


### PR DESCRIPTION
Fedora 24 provides postgresql 9.5 in the default yum repos.