### PR TITLE
Support granting SELECT and UPDATE permission on sequences (MODULES-4158)

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -143,8 +143,8 @@ define postgresql::server::grant (
               SELECT DISTINCT
                      object_schema,
                      object_name,
-                     (regexp_split_to_array(regexp_replace(privs,E'\/.*',''),'='))[1] AS grantee,
-                     regexp_split_to_table((regexp_split_to_array(regexp_replace(privs,E'\/.*',''),'='))[2],E'\\s*') AS privs_split
+                     (regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[1] AS grantee,
+                     regexp_split_to_table((regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[2],E'\\s*') AS privs_split
                 FROM (
                  SELECT n.nspname as object_schema,
                          c.relname as object_name,

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -82,6 +82,40 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
         end
       end
     end
+
+    it 'should grant update on a sequence to a user' do
+      begin
+        pp = pp_setup + <<-EOS.unindent
+
+          postgresql_psql { 'create test sequence':
+            command   => 'CREATE SEQUENCE test_seq',
+            db        => $db,
+            psql_user => $owner,
+            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq'",
+            require   => Postgresql::Server::Database[$db],
+          }
+
+          postgresql::server::grant { 'grant update on test_seq':
+            privilege   => 'UPDATE',
+            object_type => 'SEQUENCE',
+            object_name => 'test_seq',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql_psql['create test sequence'],
+                             Postgresql::Server::Role[$user], ]
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+
+        ## Check that the privilege was granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_sequence_privilege('#{user}', 'test_seq', 'UPDATE')\"", user) do |r|
+          expect(r.stdout).to match(/\(1 row\)/)
+          expect(r.stderr).to eq('')
+        end
+      end
+    end
   end
 
   context 'all sequences' do
@@ -113,6 +147,40 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
 
         ## Check that the privileges were granted to the user
         psql("-d #{db} --command=\"SELECT 1 WHERE has_sequence_privilege('#{user}', 'test_seq2', 'USAGE') AND has_sequence_privilege('#{user}', 'test_seq3', 'USAGE')\"", user) do |r|
+          expect(r.stdout).to match(/\(1 row\)/)
+          expect(r.stderr).to eq('')
+        end
+      end
+    end
+
+    it 'should grant update on all sequences to a user' do
+      begin
+        pp = pp_setup + <<-EOS.unindent
+
+          postgresql_psql { 'create test sequences':
+            command   => 'CREATE SEQUENCE test_seq2; CREATE SEQUENCE test_seq3;',
+            db        => $db,
+            psql_user => $owner,
+            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq2'",
+            require   => Postgresql::Server::Database[$db],
+          }
+
+          postgresql::server::grant { 'grant usage on all sequences':
+            privilege   => 'UPDATE',
+            object_type => 'ALL SEQUENCES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql_psql['create test sequences'],
+                             Postgresql::Server::Role[$user], ]
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+
+        ## Check that the privileges were granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_sequence_privilege('#{user}', 'test_seq2', 'UPDATE') AND has_sequence_privilege('#{user}', 'test_seq3', 'UPDATE')\"", user) do |r|
           expect(r.stdout).to match(/\(1 row\)/)
           expect(r.stderr).to eq('')
         end

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper_acceptance'
+
+describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  db = 'grant_priv_test'
+  owner = 'psql_grant_priv_owner'
+  user = 'psql_grant_priv_tester'
+  password = 'psql_grant_role_pw'
+
+  pp_setup = <<-EOS.unindent
+    $db = #{db}
+    $owner = #{owner}
+    $user = #{user}
+    $password = #{password}
+
+    class { 'postgresql::server': }
+
+    postgresql::server::role { $owner:
+      password_hash => postgresql_password($owner, $password),
+    }
+
+    # Since we are not testing pg_hba or any of that, make a local user for ident auth
+    user { $owner:
+      ensure => present,
+    }
+
+    postgresql::server::database { $db:
+      owner   => $owner,
+      require => Postgresql::Server::Role[$owner],
+    }
+
+    # Create a user to grant privileges to
+    postgresql::server::role { $user:
+      db      => $db,
+      require => Postgresql::Server::Database[$db],
+    }
+
+    # Make a local user for ident auth
+    user { $user:
+      ensure => present,
+    }
+
+    # Grant them connect to the database
+    postgresql::server::database_grant { "allow connect for ${user}":
+      privilege => 'CONNECT',
+      db        => $db,
+      role      => $user,
+    }
+  EOS
+
+  context 'sequence' do
+    it 'should grant usage on a sequence to a user' do
+      begin
+        pp = pp_setup + <<-EOS.unindent
+
+          postgresql_psql { 'create test sequence':
+            command   => 'CREATE SEQUENCE test_seq',
+            db        => $db,
+            psql_user => $owner,
+            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq'",
+            require   => Postgresql::Server::Database[$db],
+          }
+
+          postgresql::server::grant { 'grant usage on test_seq':
+            privilege   => 'USAGE',
+            object_type => 'SEQUENCE',
+            object_name => 'test_seq',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql_psql['create test sequence'],
+                             Postgresql::Server::Role[$user], ]
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+
+        ## Check that the privilege was granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_sequence_privilege('#{user}', 'test_seq', 'USAGE')\"", user) do |r|
+          expect(r.stdout).to match(/\(1 row\)/)
+          expect(r.stderr).to eq('')
+        end
+      end
+    end
+  end
+
+  context 'all sequences' do
+    it 'should grant usage on all sequences to a user' do
+      begin
+        pp = pp_setup + <<-EOS.unindent
+
+          postgresql_psql { 'create test sequences':
+            command   => 'CREATE SEQUENCE test_seq2; CREATE SEQUENCE test_seq3;',
+            db        => $db,
+            psql_user => $owner,
+            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq2'",
+            require   => Postgresql::Server::Database[$db],
+          }
+
+          postgresql::server::grant { 'grant usage on all sequences':
+            privilege   => 'USAGE',
+            object_type => 'ALL SEQUENCES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql_psql['create test sequences'],
+                             Postgresql::Server::Role[$user], ]
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+
+        ## Check that the privileges were granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_sequence_privilege('#{user}', 'test_seq2', 'USAGE') AND has_sequence_privilege('#{user}', 'test_seq3', 'USAGE')\"", user) do |r|
+          expect(r.stdout).to match(/\(1 row\)/)
+          expect(r.stderr).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -48,10 +48,11 @@ describe 'postgresql::server::grant', :type => :define do
 
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('grant:test').with(
-                          {
-                            'command' => "GRANT USAGE ON SEQUENCE \"test\" TO\n      \"test\"",
-                            'unless' => "SELECT 1 WHERE has_sequence_privilege('test',\n                  'test', 'USAGE')",
-                          }) }
+      {
+        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* "test"/m,
+        'unless'  => /SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)/m,
+      }
+    ) }
   end
 
   context 'all sequences' do
@@ -71,10 +72,11 @@ describe 'postgresql::server::grant', :type => :define do
 
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('grant:test').with(
-                          {
-                            'command' => "GRANT USAGE ON ALL SEQUENCES IN SCHEMA \"public\" TO\n      \"test\"",
-                            'unless' => "SELECT 1 FROM (\n        SELECT sequence_name\n        FROM information_schema.sequences\n        WHERE sequence_schema='public'\n          EXCEPT DISTINCT\n        SELECT object_name as sequence_name\n        FROM information_schema.role_usage_grants\n        WHERE object_type='SEQUENCE'\n        AND grantee='test'\n        AND object_schema='public'\n        AND privilege_type='USAGE'\n        ) P\n        HAVING count(P.sequence_name) = 0",
-                          }) }
+      {
+        'command' => /GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* "test"/m,
+        'unless'  => /SELECT 1 FROM \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\) P\s* HAVING count\(P\.sequence_name\) = 0/m,
+      }
+    ) }
   end
 
   context "with specific db connection settings - default port" do


### PR DESCRIPTION
Add support for granting SELECT and UPDATE permissions on sequences (MODULES-4158).
    
This requires a significant change to the unless statement used to determine whether the permission has already been granted. The previous statement used the standard SQL information_schema tables, however these provide limited information on sequence permissions. In order to retrieve the current permission set with the necessary level of detail we must query the pg_class system catalog and parse out the permissions from there.

As part of this PR, I've added additional acceptance tests to verify both old and new functionality. All tests pass on my local system (using supplied Gemfile).