### PR TITLE
Change - Ensure that the postgres data dir has proper selinux context

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -22,30 +22,43 @@ class postgresql::server::initdb {
     cwd        => $module_workdir,
   }
 
+  if $::osfamily == 'RedHat' and $::selinux == true {
+    $seltype = 'postgresql_db_t'
+    $logdir_type = 'postgresql_log_t'
+  }
+
+  else {
+    $seltype = undef
+    $logdir_type = undef
+  }
+
   # Make sure the data directory exists, and has the correct permissions.
   file { $datadir:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
-    mode   => '0700',
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    mode    => '0700',
+    seltype => $seltype,
   }
 
   if($xlogdir) {
     # Make sure the xlog directory exists, and has the correct permissions.
     file { $xlogdir:
-      ensure => directory,
-      owner  => $user,
-      group  => $group,
-      mode   => '0700',
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      mode    => '0700',
+      seltype => $seltype,
     }
   }
 
   if($logdir) {
     # Make sure the log directory exists, and has the correct permissions.
     file { $logdir:
-      ensure => directory,
-      owner  => $user,
-      group  => $group,
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      seltype => $logdir_type,
     }
   }
 

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -15,6 +15,7 @@ describe 'postgresql::server::config', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     it 'should have the correct systemd-override file' do
@@ -62,6 +63,7 @@ describe 'postgresql::server::config', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     it 'should have the correct systemd-override file' do
@@ -117,6 +119,7 @@ describe 'postgresql::server::config', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => false,
       }
     end
     it 'should have the correct systemd-override file' do

--- a/spec/unit/classes/server/initdb_spec.rb
+++ b/spec/unit/classes/server/initdb_spec.rb
@@ -14,6 +14,7 @@ describe 'postgresql::server::initdb', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
@@ -28,6 +29,7 @@ describe 'postgresql::server::initdb', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     it { is_expected.to contain_file('/var/lib/pgsql92/data').with_ensure('directory') }
@@ -43,6 +45,7 @@ describe 'postgresql::server::initdb', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     let (:pre_condition) do
@@ -71,6 +74,7 @@ describe 'postgresql::server::initdb', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
     let (:pre_condition) do
@@ -99,6 +103,7 @@ describe 'postgresql::server::initdb', :type => :class do
         :kernel => 'Linux',
         :id => 'root',
         :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
       }
     end
 

--- a/spec/unit/classes/server/plpython_spec.rb
+++ b/spec/unit/classes/server/plpython_spec.rb
@@ -10,6 +10,7 @@ describe 'postgresql::server::plpython', :type => :class do
       :kernel => 'Linux',
       :id => 'root',
       :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :selinux => true,
     }
   end
 

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -10,6 +10,7 @@ describe 'postgresql::server::config_entry', :type => :define do
       :concat_basedir => tmpfilename('contrib'),
       :id => 'root',
       :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :selinux => true,
     }
   end
 
@@ -39,6 +40,7 @@ describe 'postgresql::server::config_entry', :type => :define do
           :concat_basedir => tmpfilename('contrib'),
           :id => 'root',
           :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :selinux => true,
         }
       end
       let(:params) {{ :ensure => 'present', :name => 'port_spec', :value => '5432' }}
@@ -58,6 +60,7 @@ describe 'postgresql::server::config_entry', :type => :define do
           :concat_basedir => tmpfilename('contrib'),
           :id => 'root',
           :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :selinux => true,
         }
       end
       let(:params) {{ :ensure => 'present', :name => 'port_spec', :value => '5432' }}
@@ -77,6 +80,7 @@ describe 'postgresql::server::config_entry', :type => :define do
           :concat_basedir => tmpfilename('contrib'),
           :id => 'root',
           :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :selinux => true,
         }
       end
       let(:params) {{ :ensure => 'present', :name => 'port_spec', :value => '5432' }}


### PR DESCRIPTION
The postgresql data directory needs to be set to the postgresql_db_t
type.  The selinux context was being set to 'etc_t' by default.