### PR TITLE
Remove unnecessary `client_package_name` parameter from server.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,7 +3,6 @@ class postgresql::server (
   $postgres_password          = undef,
 
   $package_name               = $postgresql::params::server_package_name,
-  $client_package_name        = $postgresql::params::client_package_name,
   $package_ensure             = $postgresql::params::package_ensure,
 
   $plperl_package_name        = $postgresql::params::plperl_package_name,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -2,7 +2,6 @@
 class postgresql::server::install {
   $package_ensure      = $postgresql::server::package_ensure
   $package_name        = $postgresql::server::package_name
-  $client_package_name = $postgresql::server::client_package_name
 
   $_package_ensure = $package_ensure ? {
     true     => 'present',


### PR DESCRIPTION
This was missed during some re-factor a long time back.