### PR TITLE
Remove deprecated force parameter from concat

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -154,7 +154,6 @@ class postgresql::server::config {
     concat { $pg_ident_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no pg_ident_rules
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],
@@ -165,7 +164,6 @@ class postgresql::server::config {
     concat { $recovery_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no recovery conf file
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],


### PR DESCRIPTION
Prevents warnings like:

Scope(Concat[/var/lib/pgsql/data/pg_ident.conf]): The $force parameter to concat is deprecated and has no effect