### PR TITLE
Fix creation of recovery.conf file when recovery configuration is not specified

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -161,17 +161,6 @@ class postgresql::server::config {
     }
   }
 
-  if ($manage_recovery_conf == true) {
-    concat { $recovery_conf_path:
-      owner  => $user,
-      group  => $group,
-      force  => true, # do not crash if there is no recovery conf file
-      mode   => '0640',
-      warn   => true,
-      notify => Class['postgresql::server::reload'],
-    }
-  }
-
   if $::osfamily == 'RedHat' {
     if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       # Template uses:

--- a/manifests/server/recovery.pp
+++ b/manifests/server/recovery.pp
@@ -29,6 +29,15 @@ define postgresql::server::recovery(
       fail('postgresql::server::recovery use this resource but do not pass a parameter will avoid creating the recovery.conf, because it makes no sense.')
     }
 
+    concat { $target:
+      owner  => $::postgresql::server::config::user,
+      group  => $::postgresql::server::config::group,
+      force  => true, # do not crash if there is no recovery conf file
+      mode   => '0640',
+      warn   => true,
+      notify => Class['postgresql::server::reload'],
+    }
+
     # Create the recovery.conf content
     concat::fragment { 'recovery.conf':
       target  => $target,

--- a/spec/acceptance/server/recovery_spec.rb
+++ b/spec/acceptance/server/recovery_spec.rb
@@ -39,6 +39,36 @@ describe 'postgresql::server::recovery', :unless => UNSUPPORTED_PLATFORMS.includ
     end
   end
 
+  describe 'should not create recovery if recovery config not specified' do
+    after(:all) do
+      pp = <<-EOS.unindent
+        file { '/tmp/recovery.conf':
+          ensure => absent,
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'does not add conf file' do
+      pp = <<-EOS.unindent
+        class { 'postgresql::globals':
+          recovery_conf_path => '/tmp/recovery.conf',
+          manage_recovery_conf => true,
+        }
+
+        class { 'postgresql::server': }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file('/tmp/recovery.conf') do
+      it { is_expected.not_to be_file }
+    end
+  end
+
   describe 'should not manage recovery' do
     it 'does not add conf file' do
       pp = <<-EOS.unindent


### PR DESCRIPTION
Fixes https://tickets.puppetlabs.com/browse/MODULES-4276

See also https://github.com/puppetlabs/puppetlabs-postgresql/pull/603#issuecomment-272190972