### PR TITLE
(MODULES-1127) allow LANGUAGE as valid object_type

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -49,6 +49,7 @@ define postgresql::server::grant (
     '^ALL SEQUENCES IN SCHEMA$',
     '^TABLE$',
     '^ALL TABLES IN SCHEMA$',
+    '^LANGUAGE$',
     #'^TABLESPACE$',
     #'^VIEW$',
     ]

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -228,7 +228,10 @@ define postgresql::server::grant (
       validate_re($unless_privilege, [ '^$','^CREATE$','^USAGE$','^ALL$','^ALL PRIVILEGES$' ])
       $unless_function = 'has_language_privilege'
       $on_db = $psql_db
-      $onlyif_function = undef
+      $onlyif_function = $onlyif_exists ? {
+        true    => 'language_exists',
+        default => undef,
+      }
     }
 
     default: {

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -52,40 +52,61 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
     EOS
   }
 
-  context 'GRANT * on LANGUAGE' do
-    let(:pp_lang) { pp_setup + <<-EOS.unindent
+  context 'LANGUAGE' do
+    describe 'GRANT * ON LANGUAGE' do
+      let(:pp_lang) { pp_setup + <<-EOS.unindent
 
-        postgresql_psql { 'make sure plpgsql exists':
-          command   => 'CREATE OR REPLACE LANGUAGE plpgsql',
-          db        => $db,
-          psql_user => $superuser,
-          unless    => "SELECT 1 from pg_language where lanname = 'plpgsql'",
-          require   => Postgresql::Server::Database[$db],
+          postgresql_psql { 'make sure plpgsql exists':
+            command   => 'CREATE OR REPLACE LANGUAGE plpgsql',
+            db        => $db,
+            psql_user => $superuser,
+            unless    => "SELECT 1 from pg_language where lanname = 'plpgsql'",
+            require   => Postgresql::Server::Database[$db],
+          }
+
+          postgresql::server::grant { 'grant usage on plpgsql':
+            psql_user     => '#{superuser}',
+            privilege     => 'USAGE',
+            object_type   => 'LANGUAGE',
+            object_name   => 'plpgsql',
+            role          => $user,
+            db            => $db,
+            require       => [ Postgresql_psql['make sure plpgsql exists'],
+                               Postgresql::Server::Role[$user], ]
         }
+        EOS
+      }
 
-        postgresql::server::grant { 'grant usage on plpgsql':
-          psql_user   => '#{superuser}',
-          privilege   => 'USAGE',
-          object_type => 'LANGUAGE',
-          object_name => 'plpgsql',
-          role        => $user,
-          db          => $db,
-          require     => [ Postgresql_psql['make sure plpgsql exists'],
-                           Postgresql::Server::Role[$user], ]
-       }
-      EOS
-    }
+      it 'is expected to run idempotently' do
+        apply_manifest(pp_lang, :catch_failures => true)
+        apply_manifest(pp_lang, :catch_changes => true)
+      end
 
-    it 'is expected to run idempotently' do
-      apply_manifest(pp_lang, :catch_failures => true)
-      apply_manifest(pp_lang, :catch_changes => true)
-    end
+      it 'is expected to GRANT USAGE ON LANGUAGE plpgsql to ROLE' do
+        ## Check that the privilege was granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_language_privilege('#{user}', 'plpgsql', 'USAGE')\"", superuser) do |r|
+          expect(r.stdout).to match(/\(1 row\)/)
+          expect(r.stderr).to eq('')
+        end
+      end
 
-    it 'is expected to GRANT USAGE ON LANGUAGE plpgsql to ROLE' do
-      ## Check that the privilege was granted to the user
-      psql("-d #{db} --command=\"SELECT 1 WHERE has_language_privilege('#{user}', 'plpgsql', 'USAGE')\"", superuser) do |r|
-        expect(r.stdout).to match(/\(1 row\)/)
-        expect(r.stderr).to eq('')
+      let(:pp_onlyif) { pp_setup + <<-EOS.unindent
+          postgresql::server::grant { 'grant usage on BSql':
+            psql_user     => '#{superuser}',
+            privilege     => 'USAGE',
+            object_type   => 'LANGUAGE',
+            object_name   => 'bsql',
+            role          => $user,
+            db            => $db,
+            onlyif_exists => true,
+        }
+        EOS
+      }
+
+      #test onlyif_exists function
+      it 'is expected to not GRANT USAGE ON (dummy)LANGUAGE BSql to ROLE' do
+        apply_manifest(pp_onlyif, :catch_failures => true)
+        apply_manifest(pp_onlyif, :catch_changes => true)
       end
     end
   end


### PR DESCRIPTION
A community request came in from someone wanting to be able to grant usage on language and it was being blocked by `validate_re` in ::server::grant. This commit adds LANGUAGE to the allowed list of object types.

Adding LANGUAGE to the initial validation list was not enough, some additional params needed to be defined. Acceptance tests were also added to verify USAGE could be granted on the plpgsql language, which ships with postgres