### PR TITLE
(maint) fix grant_spec test

### DIFF
--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -57,7 +57,7 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
       let(:pp_lang) { pp_setup + <<-EOS.unindent
 
           postgresql_psql { 'make sure plpgsql exists':
-            command   => 'CREATE OR REPLACE LANGUAGE plpgsql',
+            command   => 'CREATE LANGUAGE plpgsql',
             db        => $db,
             psql_user => $superuser,
             unless    => "SELECT 1 from pg_language where lanname = 'plpgsql'",


### PR DESCRIPTION
Tests from #838 broke because the CREATE AND REPLACE LANGUAGE command is not available until postgresql 9. I originally thought that using only CREATE LANGUAGE would not be idempotent, but it turns out it is. This commit changes CREATE AND REPLACE LANGUAGE to CREATE LANGUAGE.

This change has been verified on the failing platform (Redhat 7) with an acceptance test run on vmpooler.

Commands can also be compared on postgresql docs:
8.4: https://www.postgresql.org/docs/8.4/static/sql-createlanguage.html
9.0: https://www.postgresql.org/docs/9.0/static/sql-createlanguage.html