### PR TITLE
(maint) fix grant_spec test

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -227,7 +227,7 @@ define postgresql::server::grant (
       }
       validate_re($unless_privilege, [ '^$','^CREATE$','^USAGE$','^ALL$','^ALL PRIVILEGES$' ])
       $unless_function = 'has_language_privilege'
-      $on_db = $psql_db
+      $on_db = $db
       $onlyif_function = $onlyif_exists ? {
         true    => 'language_exists',
         default => undef,

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -5,8 +5,6 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
   let(:db) { 'grant_priv_test' }
   let(:owner) { 'psql_grant_priv_owner' }
   let(:user) { 'psql_grant_priv_tester' }
-  #testing grants on language requires a superuser
-  let(:superuser) { 'postgres' }
   let(:password) { 'psql_grant_role_pw' }
   let(:pp_install) { "class {'postgresql::server': }"}
 
@@ -54,12 +52,14 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
 
   context 'LANGUAGE' do
     describe 'GRANT * ON LANGUAGE' do
+      #testing grants on language requires a superuser
+      let(:superuser) { 'postgres' }
       let(:pp_lang) { pp_setup + <<-EOS.unindent
 
           postgresql_psql { 'make sure plpgsql exists':
-            command   => 'CREATE OR REPLACE LANGUAGE plpgsql',
+            command   => 'CREATE LANGUAGE plpgsql',
             db        => $db,
-            psql_user => $superuser,
+            psql_user => '#{superuser}',
             unless    => "SELECT 1 from pg_language where lanname = 'plpgsql'",
             require   => Postgresql::Server::Database[$db],
           }


### PR DESCRIPTION
Tests from #838 broke because the CREATE AND REPLACE LANGUAGE command is not available until postgresql 9. I originally thought that using only CREATE LANGUAGE would not be idempotent, but it turns out it is. This commit changes CREATE AND REPLACE LANGUAGE to CREATE LANGUAGE.

In addition, operations on LANGUAGE were set to use $psql_db and not the $db parameter value, which had to be fixed because the unless function was being continually run on a db that did not have privileges. 

also, i moved the superuser variable inside the test as it's not used anywhere else.

passed redhat-6 and ubuntu-1404 acceptance tests on vmpooler.