### PR TITLE
Change - Remove deprecated force parameter on concat resources

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -154,7 +154,6 @@ class postgresql::server::config {
     concat { $pg_ident_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no pg_ident_rules
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],
@@ -165,7 +164,6 @@ class postgresql::server::config {
     concat { $recovery_conf_path:
       owner  => $user,
       group  => $group,
-      force  => true, # do not crash if there is no recovery conf file
       mode   => '0640',
       warn   => true,
       notify => Class['postgresql::server::reload'],


### PR DESCRIPTION
The $force parameter to concat is deprecated and has no effect.  This commit silences warning messages in the puppet server logs.  For example:

> 2017-02-13 08:32:21,798 WARN  [qtp1532802229-36820] [puppetserver] Scope(Concat[/var/lib/pgsql/data/pg_ident.conf]) The $force parameter to concat is deprecated and has no effect.
