### PR TITLE
(MODULES-1508) add support for unix_socket_directories

### DIFF
--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -16,7 +16,7 @@ define postgresql::server::config_entry (
   }
 
   case $name {
-    /data_directory|timezone|hba_file|ident_file|include|listen_addresses|port|max_connections|superuser_reserved_connections|unix_socket_directory|unix_socket_group|unix_socket_permissions|bonjour|bonjour_name|ssl|ssl_ciphers|shared_buffers|max_prepared_transactions|max_files_per_process|shared_preload_libraries|wal_level|wal_buffers|archive_mode|max_wal_senders|hot_standby|logging_collector|silent_mode|track_activity_query_size|autovacuum_max_workers|autovacuum_freeze_max_age|max_locks_per_transaction|max_pred_locks_per_transaction|restart_after_crash|lc_messages|lc_monetary|lc_numeric|lc_time/: {
+    /data_directory|timezone|hba_file|ident_file|include|listen_addresses|port|max_connections|superuser_reserved_connections|unix_socket_director(y|ies)|unix_socket_group|unix_socket_permissions|bonjour|bonjour_name|ssl|ssl_ciphers|shared_buffers|max_prepared_transactions|max_files_per_process|shared_preload_libraries|wal_level|wal_buffers|archive_mode|max_wal_senders|hot_standby|logging_collector|silent_mode|track_activity_query_size|autovacuum_max_workers|autovacuum_freeze_max_age|max_locks_per_transaction|max_pred_locks_per_transaction|restart_after_crash|lc_messages|lc_monetary|lc_numeric|lc_time/: {
       if $postgresql::server::service_restart_on_change {
         Postgresql_conf {
           notify => Class['postgresql::server::service'],

--- a/spec/acceptance/server/config_entry_spec.rb
+++ b/spec/acceptance/server/config_entry_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper_acceptance'
+
+describe 'postgresql::server::config_entry' do
+
+  let(:pp_setup) { <<-EOS
+    class { 'postgresql::server':
+      postgresql_conf_path => '/tmp/postgresql.conf',
+      }
+    EOS
+  }
+
+  context 'unix_socket_directories' do
+    let(:pp_test) { pp_setup + <<-EOS
+      postgresql::server::config_entry { 'unix_socket_directories':
+        value => '/var/socket/, /root/'
+      }
+      EOS
+    }
+
+    #get postgresql version
+    apply_manifest("class { 'postgresql::server': }")
+    result = shell('psql --version')
+    version = result.stdout.match(%r{\s(\d\.\d)})[1]
+
+    if version >= '9.3'
+      it 'is expected to run idempotently' do
+        apply_manifest(pp_test, :catch_failures => true)
+        apply_manifest(pp_test, :catch_changes => true)
+      end
+
+      it 'is expected to contain directories' do
+        shell('cat /tmp/postgresql.conf') do |output|
+          expect(output.stdout).to contain("unix_socket_directories = '/var/socket/, /root/'")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -110,4 +110,27 @@ describe 'postgresql::server::config_entry', :type => :define do
         :value => 'off' })
     end
   end
+
+  context 'unix_socket_directories' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :operatingsystemrelease => '7.0',
+        :kernel => 'Linux',
+        :concat_basedir => tmpfilename('contrib'),
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
+      }
+    end
+    let(:params) {{ :ensure => 'present', :name => 'unix_socket_directories', :value => '/var/pgsql, /opt/postgresql, /root/' }}
+
+    it 'should restart the server and change unix_socket_directories to the provided list' do
+      is_expected.to contain_postgresql_conf('unix_socket_directories')
+                      .with({ :name => 'unix_socket_directories',
+                              :value => '/var/pgsql, /opt/postgresql, /root/'})
+                      .that_notifies('Class[postgresql::server::service]')
+    end
+  end
 end


### PR DESCRIPTION
unix_socket_directories, new in 9.3, requires a server restart for changes. Only recognized config attributes trigger a restart, so this adds it to the list to be recognized.

This adds a unit test to make sure that unix_socket_directories notifies a service restart

This is an acceptance test to test config entries in general, specifically unix_socket_directories. The manifest should run without failures and the provided list of socket dirs should be present in the config file.