### PR TITLE
(MODULES-1707) add logic to params.pp for jdbc driver package on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,9 +150,9 @@ class postgresql::params inherits postgresql::globals {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis-${postgis_version}")
       }
       $devel_package_name     = pick($devel_package_name, 'libpq-dev')
-      $java_package_name      = $::operatingsystem ? {
-        'Debian' => $::lsbmajdistrelease ? {
-          /^6/    => pick($java_package_name, 'libjava'),
+      $java_package_name = $::operatingsystem ? {
+        'Debian' => $::operatingsystemrelease ? {
+          /^6/    => pick($java_package_name, 'libpg-java'),
           default => pick($java_package_name, 'libpostgresql-jdbc-java'),
         },
       default  => pick($java_package_name, 'libpostgresql-jdbc-java'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,7 +150,13 @@ class postgresql::params inherits postgresql::globals {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis-${postgis_version}")
       }
       $devel_package_name     = pick($devel_package_name, 'libpq-dev')
-      $java_package_name      = pick($java_package_name, 'libpostgresql-jdbc-java')
+      $java_package_name      = $::operatingsystem ? {
+        'Debian' => $::lsbmajdistrelease ? {
+          /^6/    => pick($java_package_name, 'libjava'),
+          default => pick($java_package_name, 'libpostgresql-jdbc-java'),
+        },
+      default  => pick($java_package_name, 'libpostgresql-jdbc-java'),
+      }
       $perl_package_name      = pick($perl_package_name, 'libdbd-pg-perl')
       $plperl_package_name    = pick($plperl_package_name, "postgresql-plperl-${version}")
       $plpython_package_name  = pick($plpython_package_name, "postgresql-plpython-${version}")

--- a/spec/unit/classes/lib/java_spec.rb
+++ b/spec/unit/classes/lib/java_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::lib::java', :type => :class do
     }
     end
     it { is_expected.to contain_package('postgresql-jdbc').with(
-      :name   => 'libpostgresql-jdbc-java',
+      :name   => 'libpg-java',
       :ensure => 'present',
       :tag    => 'postgresql'
     )}


### PR DESCRIPTION
the name of the jdbc driver package is different on Debian 6. This adds logic in params.pp to account for that.

lsbmajdistrelease was causing spec failures because it is not available for Debian, so this changes to operatingsystemrelease. also, the unit test for the postgresql::lib::java manifest needed to be updated.