### PR TITLE
(maint) removes spec.opts for 4.9.0 release

### DIFF
--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace


### PR DESCRIPTION
We are no longer using the spec.opts file and its causing conflicts with parallel spec runs so this removes it. It is removed farther along in master but the change that necessitated its removal is in this release.