### PR TITLE
fix default params for SUSE family OSes

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -111,10 +111,10 @@ class postgresql::globals (
     'Suse' => $::operatingsystem ? {
       'SLES' => $::operatingsystemrelease ? {
         /11\.[0-4]/ => '91',
-        default => '93',
+        default => '94',
       },
       'OpenSuSE' => $::operatingsystemrelease ? {
-        '13.2' => '93',
+        default => '94',
       },
       default => undef,
     },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,8 +278,13 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, "/usr/lib/postgresql${version}/bin")
       $datadir              = pick($datadir, '/var/lib/pgsql/data')
       $confdir              = pick($confdir, $datadir)
-      $service_status       = pick($service_status, "/etc/init.d/${service_name} status")
-      $service_reload       = "/etc/init.d/${service_name} reload"
+      if $::operatingsystem == 'SLES' and versioncmp($::operatingsystemrelease, 11.4) <= 0 {
+        $service_status     = pick($service_status, "/etc/init.d/${service_name} status")
+        $service_reload     = "/etc/init.d/${service_name} reload"
+      } else {
+        $service_status     = pick($service_status, "systemctl status ${service_name}")
+        $service_reload     = "systemctl reload ${service_name}"
+      }
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $needs_initdb         = pick($needs_initdb, true)


### PR DESCRIPTION
- remove the old openSUSE 13.2
- add default value '94' to cover all the recent and supported openSUSE distros
- use the old initscript for SLE 11 SPx, systemd commands for anything else