### PR TITLE
Migrate to puppet4 datatypes

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,9 +1,9 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
-  Enum['file', 'absent'] $file_ensure                 = 'file',
-  Stdlib::Absolutepath $validcon_script_path          = $postgresql::params::validcon_script_path,
-  String[1] $package_name                             = $postgresql::params::client_package_name,
-  Enum['present', 'absent', 'latest'] $package_ensure = 'present'
+  Enum['file', 'absent'] $file_ensure        = 'file',
+  Stdlib::Absolutepath $validcon_script_path = $postgresql::params::validcon_script_path,
+  String[1] $package_name                    = $postgresql::params::client_package_name,
+  String[1] $package_ensure                  = 'present'
 ) inherits postgresql::params {
 
   if $package_name != 'UNSET' {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,9 +1,9 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
-  $file_ensure                               = 'file',
-  Stdlib::Absolutepath $validcon_script_path = $postgresql::params::validcon_script_path,
-  String $package_name                       = $postgresql::params::client_package_name,
-  $package_ensure                            = 'present'
+  Enum['file', 'absent'] $file_ensure                 = 'file',
+  Stdlib::Absolutepath $validcon_script_path          = $postgresql::params::validcon_script_path,
+  String[1] $package_name                             = $postgresql::params::client_package_name,
+  Enum['present', 'absent', 'latest'] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   if $package_name != 'UNSET' {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,12 +1,10 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
-  $file_ensure    = 'file',
-  $validcon_script_path  = $postgresql::params::validcon_script_path,
-  $package_name   = $postgresql::params::client_package_name,
-  $package_ensure = 'present'
+  $file_ensure                               = 'file',
+  Stdlib::Absolutepath $validcon_script_path = $postgresql::params::validcon_script_path,
+  String $package_name                       = $postgresql::params::client_package_name,
+  $package_ensure                            = 'present'
 ) inherits postgresql::params {
-  validate_absolute_path($validcon_script_path)
-  validate_string($package_name)
 
   if $package_name != 'UNSET' {
     package { 'postgresql-client':

--- a/manifests/lib/devel.pp
+++ b/manifests/lib/devel.pp
@@ -1,9 +1,9 @@
 # This class installs postgresql development libraries. See README.md for more
 # details.
 class postgresql::lib::devel(
-  String $package_name                                             = $postgresql::params::devel_package_name,
-  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present',
-  Boolean $link_pg_config                                          = $postgresql::params::link_pg_config
+  String $package_name      = $postgresql::params::devel_package_name,
+  String[1] $package_ensure = 'present',
+  Boolean $link_pg_config   = $postgresql::params::link_pg_config
 ) inherits postgresql::params {
 
   if $::osfamily == 'Gentoo' {

--- a/manifests/lib/devel.pp
+++ b/manifests/lib/devel.pp
@@ -1,12 +1,10 @@
 # This class installs postgresql development libraries. See README.md for more
 # details.
 class postgresql::lib::devel(
-  $package_name   = $postgresql::params::devel_package_name,
+  String $package_name   = $postgresql::params::devel_package_name,
   $package_ensure = 'present',
   $link_pg_config = $postgresql::params::link_pg_config
 ) inherits postgresql::params {
-
-  validate_string($package_name)
 
   if $::osfamily == 'Gentoo' {
     fail('osfamily Gentoo does not have a separate "devel" package, postgresql::lib::devel is not supported')

--- a/manifests/lib/devel.pp
+++ b/manifests/lib/devel.pp
@@ -1,9 +1,9 @@
 # This class installs postgresql development libraries. See README.md for more
 # details.
 class postgresql::lib::devel(
-  String $package_name   = $postgresql::params::devel_package_name,
-  $package_ensure = 'present',
-  $link_pg_config = $postgresql::params::link_pg_config
+  String $package_name                                             = $postgresql::params::devel_package_name,
+  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present',
+  Boolean $link_pg_config                                          = $postgresql::params::link_pg_config
 ) inherits postgresql::params {
 
   if $::osfamily == 'Gentoo' {

--- a/manifests/lib/docs.pp
+++ b/manifests/lib/docs.pp
@@ -1,8 +1,8 @@
 # This class installs the postgresql-docs See README.md for more
 # details.
 class postgresql::lib::docs (
-  String $package_name   = $postgresql::params::docs_package_name,
-  $package_ensure = 'present',
+  String $package_name                                             = $postgresql::params::docs_package_name,
+  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present',
 ) inherits postgresql::params {
 
   package { 'postgresql-docs':

--- a/manifests/lib/docs.pp
+++ b/manifests/lib/docs.pp
@@ -1,11 +1,9 @@
 # This class installs the postgresql-docs See README.md for more
 # details.
 class postgresql::lib::docs (
-  $package_name   = $postgresql::params::docs_package_name,
+  String $package_name   = $postgresql::params::docs_package_name,
   $package_ensure = 'present',
 ) inherits postgresql::params {
-
-  validate_string($package_name)
 
   package { 'postgresql-docs':
     ensure => $package_ensure,

--- a/manifests/lib/docs.pp
+++ b/manifests/lib/docs.pp
@@ -1,8 +1,8 @@
 # This class installs the postgresql-docs See README.md for more
 # details.
 class postgresql::lib::docs (
-  String $package_name                                             = $postgresql::params::docs_package_name,
-  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present',
+  String $package_name      = $postgresql::params::docs_package_name,
+  String[1] $package_ensure = 'present',
 ) inherits postgresql::params {
 
   package { 'postgresql-docs':

--- a/manifests/lib/java.pp
+++ b/manifests/lib/java.pp
@@ -1,11 +1,9 @@
 # This class installs the postgresql jdbc connector. See README.md for more
 # details.
 class postgresql::lib::java (
-  $package_name   = $postgresql::params::java_package_name,
-  $package_ensure = 'present'
+  String $package_name = $postgresql::params::java_package_name,
+  $package_ensure      = 'present'
 ) inherits postgresql::params {
-
-  validate_string($package_name)
 
   package { 'postgresql-jdbc':
     ensure => $package_ensure,

--- a/manifests/lib/java.pp
+++ b/manifests/lib/java.pp
@@ -1,8 +1,8 @@
 # This class installs the postgresql jdbc connector. See README.md for more
 # details.
 class postgresql::lib::java (
-  String $package_name                                             = $postgresql::params::java_package_name,
-  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
+  String $package_name      = $postgresql::params::java_package_name,
+  String[1] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'postgresql-jdbc':

--- a/manifests/lib/java.pp
+++ b/manifests/lib/java.pp
@@ -1,8 +1,8 @@
 # This class installs the postgresql jdbc connector. See README.md for more
 # details.
 class postgresql::lib::java (
-  String $package_name = $postgresql::params::java_package_name,
-  $package_ensure      = 'present'
+  String $package_name                                             = $postgresql::params::java_package_name,
+  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'postgresql-jdbc':

--- a/manifests/lib/perl.pp
+++ b/manifests/lib/perl.pp
@@ -1,8 +1,8 @@
 # This class installs the perl libs for postgresql. See README.md for more
 # details.
 class postgresql::lib::perl(
-  $package_name   = $postgresql::params::perl_package_name,
-  $package_ensure = 'present'
+  String $package_name      = $postgresql::params::perl_package_name,
+  String[1] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'perl-DBD-Pg':

--- a/manifests/lib/python.pp
+++ b/manifests/lib/python.pp
@@ -1,8 +1,8 @@
 # This class installs the python libs for postgresql. See README.md for more
 # details.
 class postgresql::lib::python(
-  $package_name   = $postgresql::params::python_package_name,
-  $package_ensure = 'present'
+  String[1] $package_name   = $postgresql::params::python_package_name,
+  String[1] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'python-psycopg2':

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -49,27 +49,27 @@ class postgresql::server::config {
         user        => $user,
         auth_method => 'ident',
         auth_option => $local_auth_option,
-        order       => 001,
+        order       => 1,
       }
       postgresql::server::pg_hba_rule { 'local access to database with same name':
         type        => 'local',
         auth_method => 'ident',
         auth_option => $local_auth_option,
-        order       => 002,
+        order       => 2,
       }
       postgresql::server::pg_hba_rule { 'allow localhost TCP access to postgresql user':
         type        => 'host',
         user        => $user,
         address     => '127.0.0.1/32',
         auth_method => 'md5',
-        order       => 003,
+        order       => 3,
       }
       postgresql::server::pg_hba_rule { 'deny access to postgresql user':
         type        => 'host',
         user        => $user,
         address     => $ip_mask_deny_postgres_user,
         auth_method => 'reject',
-        order       => 004,
+        order       => 4,
       }
 
       postgresql::server::pg_hba_rule { 'allow access to all users':

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -30,6 +30,7 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
+      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
 
@@ -157,6 +158,7 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
+      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
   }
@@ -167,6 +169,7 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
+      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -49,40 +49,40 @@ class postgresql::server::config {
         user        => $user,
         auth_method => 'ident',
         auth_option => $local_auth_option,
-        order       => '001',
+        order       => 001,
       }
       postgresql::server::pg_hba_rule { 'local access to database with same name':
         type        => 'local',
         auth_method => 'ident',
         auth_option => $local_auth_option,
-        order       => '002',
+        order       => 002,
       }
       postgresql::server::pg_hba_rule { 'allow localhost TCP access to postgresql user':
         type        => 'host',
         user        => $user,
         address     => '127.0.0.1/32',
         auth_method => 'md5',
-        order       => '003',
+        order       => 003,
       }
       postgresql::server::pg_hba_rule { 'deny access to postgresql user':
         type        => 'host',
         user        => $user,
         address     => $ip_mask_deny_postgres_user,
         auth_method => 'reject',
-        order       => '004',
+        order       => 004,
       }
 
       postgresql::server::pg_hba_rule { 'allow access to all users':
         type        => 'host',
         address     => $ip_mask_allow_all_users,
         auth_method => 'md5',
-        order       => '100',
+        order       => 100,
       }
       postgresql::server::pg_hba_rule { 'allow access to ipv6 localhost':
         type        => 'host',
         address     => '::1/128',
         auth_method => 'md5',
-        order       => '101',
+        order       => 101,
       }
     }
 

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -1,7 +1,7 @@
 # Install the contrib postgresql packaging. See README.md for more details.
 class postgresql::server::contrib (
-  String $package_name                                = $postgresql::params::contrib_package_name,
-  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
+  String $package_name      = $postgresql::params::contrib_package_name,
+  String[1] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   if $::osfamily == 'Gentoo' {

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -1,7 +1,7 @@
 # Install the contrib postgresql packaging. See README.md for more details.
 class postgresql::server::contrib (
-  String $package_name = $postgresql::params::contrib_package_name,
-  $package_ensure      = 'present'
+  String $package_name                                = $postgresql::params::contrib_package_name,
+  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   if $::osfamily == 'Gentoo' {

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -1,9 +1,8 @@
 # Install the contrib postgresql packaging. See README.md for more details.
 class postgresql::server::contrib (
-  $package_name   = $postgresql::params::contrib_package_name,
-  $package_ensure = 'present'
+  String $package_name = $postgresql::params::contrib_package_name,
+  $package_ensure      = 'present'
 ) inherits postgresql::params {
-  validate_string($package_name)
 
   if $::osfamily == 'Gentoo' {
     fail('osfamily Gentoo does not have a separate "contrib" package, postgresql::server::contrib is not supported.')

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,15 +1,15 @@
 # Activate an extension on a postgresql database
 define postgresql::server::extension (
   $database,
-  $extension = $name,
-  $ensure = 'present',
-  $package_name = undef,
-  $package_ensure = undef,
+  $extension        = $name,
+  String[1] $ensure = 'present',
+  $package_name     = undef,
+  $package_ensure   = undef,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
-  $user          = $postgresql::server::user
-  $group         = $postgresql::server::group
-  $psql_path     = $postgresql::server::psql_path
+  $user             = $postgresql::server::user
+  $group            = $postgresql::server::group
+  $psql_path        = $postgresql::server::psql_path
 
   case $ensure {
     'present': {

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -1,18 +1,19 @@
 # Define for granting permissions to roles. See README.md for more details.
 define postgresql::server::grant (
-  $role,
-  $db,
-  $privilege             = undef,
-  $object_type           = 'database',
-  $object_name           = undef,
-  $psql_db               = $postgresql::server::default_database,
-  $psql_user             = $postgresql::server::user,
-  $port                  = $postgresql::server::port,
-  Boolean $onlyif_exists = false,
-  $connect_settings      = $postgresql::server::default_connect_settings,
+  String $role,
+  String $db,
+  Optional[String] $privilege      = undef,
+  String $object_type              = 'database',
+  Optional[String[1]] $object_name = undef,
+  String $psql_db                  = $postgresql::server::default_database,
+  String $psql_user                = $postgresql::server::user,
+  Integer $port                    = $postgresql::server::port,
+  Boolean $onlyif_exists           = false,
+  Hash $connect_settings           = $postgresql::server::default_connect_settings,
 ) {
-  $group                 = $postgresql::server::group
-  $psql_path             = $postgresql::server::psql_path
+
+  $group     = $postgresql::server::group
+  $psql_path = $postgresql::server::psql_path
 
   if ! $object_name {
     $_object_name = $db

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -2,17 +2,17 @@
 define postgresql::server::grant (
   $role,
   $db,
-  $privilege        = undef,
-  $object_type      = 'database',
-  $object_name      = undef,
-  $psql_db          = $postgresql::server::default_database,
-  $psql_user        = $postgresql::server::user,
-  $port             = $postgresql::server::port,
-  $onlyif_exists    = false,
-  $connect_settings = $postgresql::server::default_connect_settings,
+  $privilege             = undef,
+  $object_type           = 'database',
+  $object_name           = undef,
+  $psql_db               = $postgresql::server::default_database,
+  $psql_user             = $postgresql::server::user,
+  $port                  = $postgresql::server::port,
+  Boolean $onlyif_exists = false,
+  $connect_settings      = $postgresql::server::default_connect_settings,
 ) {
-  $group     = $postgresql::server::group
-  $psql_path = $postgresql::server::psql_path
+  $group                 = $postgresql::server::group
+  $psql_path             = $postgresql::server::psql_path
 
   if ! $object_name {
     $_object_name = $db
@@ -20,7 +20,6 @@ define postgresql::server::grant (
     $_object_name = $object_name
   }
 
-  validate_bool($onlyif_exists)
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
   #

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -1,21 +1,13 @@
 # Define for granting membership to a role. See README.md for more information
 define postgresql::server::grant_role (
-  $group,
-  $role             = $name,
+  String $group,
+  String $role      = $name,
   $ensure           = 'present',
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
-  validate_string($group)
-  validate_string($role)
-  if empty($group) {
-    fail('$group must be set')
-  }
-  if empty($role) {
-    fail('$role must be set')
-  }
   case $ensure {
     'present': {
       $command = "GRANT \"${group}\" TO \"${role}\""

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -2,7 +2,7 @@
 define postgresql::server::grant_role (
   String $group,
   String $role      = $name,
-  $ensure           = 'present',
+  Enum['present', 'absent'] $ensure           = 'present',
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -1,12 +1,12 @@
 # Define for granting membership to a role. See README.md for more information
 define postgresql::server::grant_role (
-  String $group,
-  String $role      = $name,
-  Enum['present', 'absent'] $ensure           = 'present',
-  $psql_db          = $postgresql::server::default_database,
-  $psql_user        = $postgresql::server::user,
-  $port             = $postgresql::server::port,
-  $connect_settings = $postgresql::server::default_connect_settings,
+  String[1] $group,
+  String[1] $role                   = $name,
+  Enum['present', 'absent'] $ensure = 'present',
+  $psql_db                          = $postgresql::server::default_database,
+  $psql_user                        = $postgresql::server::user,
+  $port                             = $postgresql::server::port,
+  $connect_settings                 = $postgresql::server::default_connect_settings,
 ) {
   case $ensure {
     'present': {

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -1,7 +1,8 @@
 # This resource manages an individual rule that applies to the file defined in
 # $target. See README.md for more details.
 define postgresql::server::pg_hba_rule(
-  $type,
+
+  Enum['local', 'host', 'hostssl', 'hostnossl'] $type,
   $database,
   $user,
   $auth_method,
@@ -27,8 +28,6 @@ define postgresql::server::pg_hba_rule(
   if $manage_pg_hba_conf == false {
       fail('postgresql::server::manage_pg_hba_conf has been disabled, so this resource is now unused and redundant, either enable that option or remove this resource from your manifests')
   } else {
-    validate_re($type, '^(local|host|hostssl|hostnossl)$',
-    "The type you specified [${type}] must be one of: local, host, hostssl, hostnossl")
 
     if($type =~ /^host/ and $address == undef) {
       fail('You must specify an address property when type is host based')

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -6,10 +6,10 @@ define postgresql::server::pg_hba_rule(
   $database,
   $user,
   $auth_method,
-  $address     = undef,
-  $description = 'none',
-  $auth_option = undef,
-  $order       = '150',
+  $address       = undef,
+  $description   = 'none',
+  $auth_option   = undef,
+  Integer $order = 150,
 
   # Needed for testing primarily, support for multiple files is not really
   # working.

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -1,20 +1,19 @@
 # This resource manages an individual rule that applies to the file defined in
 # $target. See README.md for more details.
 define postgresql::server::pg_hba_rule(
-
   Enum['local', 'host', 'hostssl', 'hostnossl'] $type,
-  $database,
-  $user,
-  $auth_method,
-  $address       = undef,
-  $description   = 'none',
-  $auth_option   = undef,
-  Integer $order = 150,
+  String $database,
+  String $user,
+  String $auth_method,
+  Optional[String] $address     = undef,
+  String $description           = 'none',
+  Optional[String] $auth_option = undef,
+  Integer $order                = 150,
 
   # Needed for testing primarily, support for multiple files is not really
   # working.
-  $target             = $postgresql::server::pg_hba_conf_path,
-  $postgresql_version = $postgresql::server::_version
+  Stdlib::Absolutepath $target  = $postgresql::server::pg_hba_conf_path,
+  String $postgresql_version    = $postgresql::server::_version
 ) {
 
   #Allow users to manage pg_hba.conf even if they are not managing the whole PostgreSQL instance

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -47,9 +47,7 @@ define postgresql::server::pg_hba_rule(
       default => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'crypt', 'bsd']
     }
 
-    $auth_method_regex = join(['^(', join($allowed_auth_methods, '|'), ')$'],'')
-    validate_re($auth_method, $auth_method_regex,
-    join(["The auth_method you specified [${auth_method}] must be one of: ", join($allowed_auth_methods, ', ')],''))
+    assert_type(Enum[$allowed_auth_methods], $auth_method)
 
     # Create a rule fragment
     $fragname = "pg_hba_rule_${name}"

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -1,9 +1,8 @@
 # Install the postgis postgresql packaging. See README.md for more details.
 class postgresql::server::postgis (
-  $package_name   = $postgresql::params::postgis_package_name,
+  String $package_name   = $postgresql::params::postgis_package_name,
   $package_ensure = 'present'
 ) inherits postgresql::params {
-  validate_string($package_name)
 
   package { 'postgresql-postgis':
     ensure => $package_ensure,

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -1,7 +1,7 @@
 # Install the postgis postgresql packaging. See README.md for more details.
 class postgresql::server::postgis (
-  String $package_name   = $postgresql::params::postgis_package_name,
-  $package_ensure = 'present'
+  String $package_name                                             = $postgresql::params::postgis_package_name,
+  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'postgresql-postgis':

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -1,7 +1,7 @@
 # Install the postgis postgresql packaging. See README.md for more details.
 class postgresql::server::postgis (
-  String $package_name                                             = $postgresql::params::postgis_package_name,
-  Enum['present', 'absent', 'latest', 'installed'] $package_ensure = 'present'
+  String $package_name      = $postgresql::params::postgis_package_name,
+  String[1] $package_ensure = 'present'
 ) inherits postgresql::params {
 
   package { 'postgresql-postgis':

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-postgresql",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 2.0.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 5.0.0"}
   ],

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -31,52 +31,6 @@ describe 'postgresql::server::grant_role', :type => :define do
     }
   end
 
-  context "validation" do
-    context "group invalid type" do
-      let (:params) { {
-        :group => ['a', 'b'],
-        :role  => 'r',
-      } }
-
-      it {
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
-      }
-    end
-
-    context "role invalid type" do
-      let (:params) { {
-          :group => 'g',
-          :role  => true,
-      } }
-
-      it {
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
-      }
-    end
-
-    context "group empty" do
-      let (:params) { {
-          :group => '',
-          :role  => 'r',
-      } }
-
-      it {
-        expect { catalogue }.to raise_error(/\$group must be set/)
-      }
-    end
-
-    context "role empty" do
-      let (:params) { {
-          :group => 'g',
-          :role  => '',
-      } }
-
-      it {
-        expect { catalogue }.to raise_error(/\$role must be set/)
-      }
-    end
-  end
-
   context "with db arguments" do
     let (:params) { super().merge({
       :psql_db   => 'postgres',
@@ -105,16 +59,6 @@ describe 'postgresql::server::grant_role', :type => :define do
         :command => "REVOKE \"#{params[:group]}\" FROM \"#{params[:role]}\"",
         :unless  => "SELECT 1 WHERE EXISTS (SELECT 1 FROM pg_roles AS r_role JOIN pg_auth_members AS am ON r_role.oid = am.member JOIN pg_roles AS r_group ON r_group.oid = am.roleid WHERE r_group.rolname = '#{params[:group]}' AND r_role.rolname = '#{params[:role]}') != true",
       }).that_requires('Class[postgresql::server]')
-    }
-  end
-
-  context "with ensure => invalid" do
-    let (:params) { super().merge({
-      :ensure   => 'invalid',
-    }) }
-
-    it {
-      expect { catalogue }.to raise_error(Puppet::Error, /Unknown value for ensure/)
     }
   end
 

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -124,7 +124,7 @@ describe 'postgresql::server::grant', :type => :define do
         :connect_settings => { 'PGHOST'    => 'postgres-db-server',
                                'DBVERSION' => '9.1',
              'PGPORT'    => '1234', },
-        :port => '5678',
+        :port => 5678,
       }
     end
 

--- a/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -92,80 +92,6 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
   end
 
   context 'validation' do
-    context 'validate type test 1' do
-      let :pre_condition do
-        <<-EOS
-          class { 'postgresql::server': }
-        EOS
-      end
-
-      let :params do
-        {
-          :type => 'invalid',
-          :database => 'all',
-          :user => 'all',
-          :address => '0.0.0.0/0',
-          :auth_method => 'ldap',
-          :target => target,
-        }
-      end
-      it 'should fail parsing when type is not valid' do
-        expect { catalogue }.to raise_error(Puppet::Error,
-          /The type you specified \[invalid\] must be one of/)
-      end
-    end
-
-    context 'validate auth_method' do
-      let :pre_condition do
-        <<-EOS
-          class { 'postgresql::server': }
-        EOS
-      end
-
-      let :params do
-        {
-          :type => 'local',
-          :database => 'all',
-          :user => 'all',
-          :address => '0.0.0.0/0',
-          :auth_method => 'invalid',
-          :target => target,
-        }
-      end
-
-      it 'should fail parsing when auth_method is not valid' do
-        expect { catalogue }.to raise_error(Puppet::Error,
-          /The auth_method you specified \[invalid\] must be one of/)
-      end
-    end
-
-    context 'validate unsupported auth_method' do
-      let :pre_condition do
-        <<-EOS
-          class { 'postgresql::globals':
-            version => '9.0',
-          }
-          class { 'postgresql::server': }
-        EOS
-      end
-
-      let :params do
-        {
-          :type => 'local',
-          :database => 'all',
-          :user => 'all',
-          :address => '0.0.0.0/0',
-          :auth_method => 'peer',
-          :target => target,
-        }
-      end
-
-      it 'should fail parsing when auth_method is not valid' do
-        expect { catalogue }.to raise_error(Puppet::Error,
-          /The auth_method you specified \[peer\] must be one of: trust, reject, md5, password, gss, sspi, krb5, ident, ldap, radius, cert, pam/)
-      end
-    end
-
     context 'validate supported auth_method' do
       let :pre_condition do
         <<-EOS
@@ -188,9 +114,11 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
       end
 
       it do
-        is_expected.to contain_concat__fragment('pg_hba_rule_test').with({
-          :content => /local\s+all\s+all\s+0\.0\.0\.0\/0\s+peer/
-  })
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(
+          {
+           :content => /local\s+all\s+all\s+0\.0\.0\.0\/0\s+peer/
+          }
+        )
       end
     end
 

--- a/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -190,7 +190,7 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
       it do
         is_expected.to contain_concat__fragment('pg_hba_rule_test').with({
           :content => /local\s+all\s+all\s+0\.0\.0\.0\/0\s+peer/
-	})
+  })
       end
     end
 


### PR DESCRIPTION
The goal of this is to get rid of most of the validate_* calls, not to introduce datatypes to _all_ params.