### PR TITLE
(maint) Fix CI issue where acceptance tests fail on SLES

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,7 +278,7 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, "/usr/lib/postgresql${version}/bin")
       $datadir              = pick($datadir, '/var/lib/pgsql/data')
       $confdir              = pick($confdir, $datadir)
-      if $::operatingsystem == 'SLES' and versioncmp($::operatingsystemrelease, 11.4) <= 0 {
+      if $::operatingsystem == 'SLES' and versioncmp($::operatingsystemrelease, '11.4') <= 0 {
         $service_status     = pick($service_status, "/etc/init.d/${service_name} status")
         $service_reload     = "/etc/init.d/${service_name} reload"
       } else {


### PR DESCRIPTION
Caused by float passed to versioncmp function which expects a string, which is only executed when OS == SLES

Introduced by PR #851 which only surfaced when running against SLES.