### PR TITLE
(MODULES-4558) Add support for --data-checksums on initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,12 @@ Overrides the default PostgreSQL data directory for the target platform. Default
 
 **Warning:** If datadir is changed from the default, Puppet does not manage purging of the original data directory, which causes it to fail if the data directory is changed back to the original.
 
+##### `data_checksums`
+
+Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent. Valid values: 'true' or 'false'. Default: initdb's default ('false').
+
+**Warning:** This option is used during initialization by initdb, and cannot be changed later. If set, checksums are calculated for all objects, in all databases.
+
 ##### `default_database`
 
 Specifies the name of the default database to connect with. On most systems, this is 'postgres'.
@@ -618,6 +624,12 @@ The name of the PostgreSQL Python package.
 ##### `createdb_path`
 
 **Deprecated.** Specifies the path to the `createdb` command. Default: "${bindir}/createdb".
+
+##### `data_checksums`
+
+Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent. Valid values: 'true' or 'false'. Default: initdb's default ('false').
+
+**Warning:** This option is used during initialization by initdb, and cannot be changed later. If set, checksums are calculated for all objects, in all databases.
 
 ##### `default_database`
 

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -47,6 +47,7 @@ class postgresql::globals (
   $repo_baseurl             = undef,
 
   $needs_initdb             = undef,
+  $data_checksums           = undef,
 
   $encoding                 = undef,
   $locale                   = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class postgresql::params inherits postgresql::globals {
   $encoding                   = $postgresql::globals::encoding
   $locale                     = $postgresql::globals::locale
   $timezone                   = $postgresql::globals::timezone
+  $data_checksums             = $postgresql::globals::data_checksums
   $service_ensure             = 'running'
   $service_enable             = true
   $service_manage             = true
@@ -306,6 +307,10 @@ class postgresql::params inherits postgresql::globals {
       if ($datadir == undef) { fail("${err_prefix}datadir") }
       if ($confdir == undef) { fail("${err_prefix}confdir") }
     }
+  }
+
+  if($data_checksums and versioncmp($version, '9.3') < 0) {
+    fail('data_checksums require version 9.3 or greater')
   }
 
   $validcon_script_path = pick($validcon_script_path, '/usr/local/bin/validate_postgresql_connection.sh')

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,6 +45,7 @@ class postgresql::server (
   $group                      = $postgresql::params::group,
 
   $needs_initdb               = $postgresql::params::needs_initdb,
+  $data_checksums             = $postgresql::params::data_checksums,
 
   $encoding                   = $postgresql::params::encoding,
   $locale                     = $postgresql::params::locale,

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -1,6 +1,7 @@
 # PRIVATE CLASS: do not call directly
 class postgresql::server::initdb {
   $needs_initdb   = $postgresql::server::needs_initdb
+  $data_checksums = $postgresql::server::data_checksums
   $initdb_path    = $postgresql::server::initdb_path
   $datadir        = $postgresql::server::datadir
   $xlogdir        = $postgresql::server::xlogdir
@@ -74,6 +75,11 @@ class postgresql::server::initdb {
       default => "${ic_base} --xlogdir '${xlogdir}'"
     }
 
+    $ic_checksums = $data_checksums ? {
+      true    => "${ic_xlog} --data-checksums",
+      default => $ic_xlog,
+    }
+
     # The xlogdir need to be present before initdb runs.
     # If xlogdir is default it's created by package installer
     if($xlogdir) {
@@ -83,8 +89,8 @@ class postgresql::server::initdb {
     }
 
     $initdb_command = $locale ? {
-      undef   => $ic_xlog,
-      default => "${ic_xlog} --locale '${locale}'"
+      undef   => $ic_checksums,
+      default => "${ic_checksums} --locale '${locale}'"
     }
 
     # This runs the initdb command, we use the existance of the PG_VERSION


### PR DESCRIPTION
> We want to use checksums on data pages. This has to be enabled when running initdb. Currently, the puppetlabs/postgresql module does not seem to support this.

https://tickets.puppetlabs.com/browse/MODULES-4558