### PR TITLE
(MODULES-4682) Pass default_connect_settings to validate service

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,6 +10,7 @@ class postgresql::server::service {
   $port             = $postgresql::server::port
   $default_database = $postgresql::server::default_database
   $psql_path        = $postgresql::params::psql_path
+  $connect_settings = $postgresql::server::default_connect_settings
 
   anchor { 'postgresql::server::service::begin': }
 
@@ -34,6 +35,7 @@ class postgresql::server::service {
         run_as    => $user,
         db_name   => $default_database,
         port      => $port,
+        connect_settings => $connect_settings,
         sleep     => 1,
         tries     => 60,
         psql_path => $psql_path,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -32,15 +32,15 @@ class postgresql::server::service {
       # Without it, we may continue doing more work before the database is
       # prepared leading to a nasty race condition.
       postgresql_conn_validator{ 'validate_service_is_running':
-        run_as    => $user,
-        db_name   => $default_database,
-        port      => $port,
+        run_as           => $user,
+        db_name          => $default_database,
+        port             => $port,
         connect_settings => $connect_settings,
-        sleep     => 1,
-        tries     => 60,
-        psql_path => $psql_path,
-        require   => Service['postgresqld'],
-        before    => Anchor['postgresql::server::service::end']
+        sleep            => 1,
+        tries            => 60,
+        psql_path        => $psql_path,
+        require          => Service['postgresqld'],
+        before           => Anchor['postgresql::server::service::end']
       }
       Postgresql::Server::Database <| title == $default_database |> -> Postgresql_conn_validator['validate_service_is_running']
     }


### PR DESCRIPTION
If using CentOS or RedHat Enterprise Linux with PostgreSQL from
SoftwareCollections the validation of the service fails because
it needs the `LD_LIBRARY_PATH` environment variable to work properly.

To pass the env for example for postgresql_psql one can only set

```
class {'postgresql::globals':
  default_connect_settings => {
    'LD_LIBRARY_PATH' => '/opt/rh/rh-postgresql95/root/usr/lib64',
}
```

This patch passes the default_connect_settings to the
`validate_db_connection` resource in `postgresql::service`