### PR TITLE
Let listen_addresses be defined independently

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@
 class postgresql::params inherits postgresql::globals {
   $version                    = $postgresql::globals::globals_version
   $postgis_version            = $postgresql::globals::globals_postgis_version
-  $listen_addresses           = 'localhost'
+  $listen_addresses           = undef
   $port                       = 5432
   $log_line_prefix            = '%t '
   $ip_mask_deny_postgres_user = '0.0.0.0/0'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -100,11 +100,12 @@ class postgresql::server::config {
     create_resources('postgresql::server::pg_hba_rule', $ipv6acl_resources)
   }
 
-  # We must set a "listen_addresses" line in the postgresql.conf if we
-  # want to allow any connections from remote hosts.
-  postgresql::server::config_entry { 'listen_addresses':
-    value => $listen_addresses,
+  if $listen_addresses {
+    postgresql::server::config_entry { 'listen_addresses':
+      value => $listen_addresses,
+    }
   }
+
   postgresql::server::config_entry { 'port':
     value => $port,
   }


### PR DESCRIPTION
Postgresql module is often extended by other shared modules.  Shared modules should not use resource-like class definitions to let the callers use them when necessary.  It is still a reasonable behaviour for the shared module to set max_connections.  Making it optional would allow this to happen.

Removing the default value "localhost" should not break anything as it is already the default of PostgreSQL and on every distribution I know of.
