### PR TITLE
(MODULES-4906) Add support for concat 3.0.0 and 4.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
     {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <3.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [


### PR DESCRIPTION
Prevent `puppet module list` and `puppet module install` from complaining about invalid installations of postgresql and concat due to dependency mismatch. Goal is to reduce confusion among users that may get confused by those messages.