### PR TITLE
(MODULES-4947) bump apt dependency in metadata + fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
-    apt:
-      repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      branch: "2.0.0"
+    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,8 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":"4.x"},
-    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <5.0.0"}
+    {"name":"puppetlabs/apt","version_requirement":">= 2.0.0 < 5.0.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 < 5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [


### PR DESCRIPTION
4.0.0 and 3.0.0 got released a few days ago. We need to bump it,
otherwise PMT is unable to resolve dependencies in certain situations.