### PR TITLE
Unset default log_line_prefix

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class postgresql::params inherits postgresql::globals {
   $postgis_version            = $postgresql::globals::globals_postgis_version
   $listen_addresses           = 'localhost'
   $port                       = 5432
-  $log_line_prefix            = '%t '
+  $log_line_prefix            = undef
   $ip_mask_deny_postgres_user = '0.0.0.0/0'
   $ip_mask_allow_all_users    = '127.0.0.1/32'
   $ipv4acls                   = []


### PR DESCRIPTION
PostgreSQL 10 comes with "%m [%p] " [1] as the default.  Deb packages are defaulted to "%t [%p-%l] %q%u@%d ", RPM packages are defaulted to "< %m >" for some time.  I believe most distributions have something similar.  These are all better than what we are overriding the value by default.

Removing this default would allow people to specify the value from different classes.

[1] https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=7d3235ba42f8d5fc70c58e242702cc5e2e3549a6;hp=5ff4a67f63fd6d3eb01ff9707d4674ed54a89f3b
