### PR TITLE
(maint) Add 'os' facts used by apt module

### DIFF
--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -4,11 +4,17 @@ describe 'postgresql::globals', type: :class do
   context 'on a debian 6' do
     let (:facts) do
       {
-        :osfamily               => 'Debian',
-        :operatingsystem        => 'Debian',
-        :operatingsystemrelease => '6.0',
-        :lsbdistid              => 'Debian',
-        :lsbdistcodename        => 'squeeze'
+        lsbdistid: 'Debian',
+        lsbdistcodename: 'squeeze',
+        operatingsystem: 'Debian',
+        operatingsystemrelease: '6.0',
+        os: {
+          family: 'Debian',
+          lsb: { distid: 'Debian', distcodename: 'squeeze' },
+          name: 'Debian',
+          release: { full: '6.0' },
+        },
+        osfamily: 'Debian',
       }
     end
 

--- a/spec/unit/classes/repo_spec.rb
+++ b/spec/unit/classes/repo_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe 'postgresql::repo', :type => :class do
   let :facts do
     {
-      :osfamily               => 'Debian',
-      :operatingsystem        => 'Debian',
-      :operatingsystemrelease => '6.0',
-      :lsbdistid              => 'Debian',
-      :lsbdistcodename        => 'squeeze',
+      lsbdistid: 'Debian',
+      lsbdistcodename: 'squeeze',
+      os: {
+        family: 'Debian',
+        lsb: { distid: 'Debian', distcodename: 'squeeze' },
+        name: 'Debian',
+        release: { full: '6.0' },
+      },
+      osfamily: 'Debian',
     }
   end
 

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -8,6 +8,12 @@ describe 'postgresql::server', :type => :class do
       :lsbdistid => 'Debian',
       :lsbdistcodename => 'jessie',
       :operatingsystemrelease => '8.0',
+      :os => {
+        family: 'Debian',
+        lsb: { distid: 'Debian', distcodename: 'squeeze' },
+        name: 'Debian',
+        release: { full: '6.0' },
+      },
       :concat_basedir => tmpfilename('server'),
       :kernel => 'Linux',
       :id => 'root',


### PR DESCRIPTION
The 'os' facts are used by puppetlabs/puppetlabs-apt@33d17cf in the apt
module, so need populating in addition to legacy facts.