### PR TITLE
(maint) mock structured facts

### DIFF
--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -4,6 +4,13 @@ describe 'postgresql::globals', type: :class do
   context 'on a debian 6' do
     let (:facts) do
       {
+        :os => {
+          :family               => 'Debian',
+          :name                 => 'Debian',
+          :release => {
+            :full => '6.0'
+          }
+        },
         :osfamily               => 'Debian',
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '6.0',

--- a/spec/unit/classes/repo_spec.rb
+++ b/spec/unit/classes/repo_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe 'postgresql::repo', :type => :class do
   let :facts do
     {
+      :os => {
+        :name                 => 'Debian',
+        :family               => 'Debian',
+        :release => {
+          :full               => '6.0'
+        }
+      },
       :osfamily               => 'Debian',
       :operatingsystem        => 'Debian',
       :operatingsystemrelease => '6.0',

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe 'postgresql::server', :type => :class do
   let :facts do
     {
+      :os => {
+        :family  => 'Debian',
+        :name => 'Debian',
+        :release => {
+          :full => '6.0'
+        }
+      },
       :osfamily => 'Debian',
       :operatingsystem => 'Debian',
       :lsbdistid => 'Debian',


### PR DESCRIPTION
we recently switched apt back to the params pattern and it now uses structured facts. since postgres includes apt, some postgres tests needed to have structured facts mocked out because most of the tests still use legacy facts. the mocking gets redundant and we should make an effor to go in at some point and switch postgres to structured facts completely but this works for now.