### PR TITLE
(maint) fix for connection validator

### DIFF
--- a/lib/puppet/util/postgresql_validator.rb
+++ b/lib/puppet/util/postgresql_validator.rb
@@ -15,14 +15,12 @@ module Puppet
         final_cmd.push cmd_init
 
         cmd_parts = {
-          :host => "--host=#{@resource[:host]}",
-          :port => "--port=#{@resource[:port]}",
-          :db_username => "--username=#{@resource[:db_username]}",
-          :db_name => "--dbname=#{@resource[:db_name]}",
-          :command => "--command='#{@resource[:command]}'"
+          :host => "--host #{@resource[:host]}",
+          :port => "--port #{@resource[:port]}",
+          :db_username => "--username #{@resource[:db_username]}",
+          :db_name => "--dbname #{@resource[:db_name]}",
+          :command => "--command '#{@resource[:command]}'"
         }
-
-        cmd_parts[:db_password] = "--no-password " if @resource[:db_password]
 
         cmd_parts.each do |k,v|
           final_cmd.push v if @resource[k]
@@ -40,8 +38,10 @@ module Puppet
       def attempt_connection(sleep_length, tries)
         (0..tries-1).each do |try|
           Puppet.debug "PostgresqlValidator.attempt_connection: Attempting connection to #{@resource[:db_name]}"
-          if execute_command =~ /1/
-            Puppet.debug "PostgresqlValidator.attempt_connection: Connection to #{@resource[:db_name]} successful!"
+          Puppet.debug "PostgresqlValidator.attempt_connection: #{build_validate_cmd}"
+          result = execute_command
+          if result && result.length > 0
+            Puppet.debug "PostgresqlValidator.attempt_connection: Connection to #{@resource[:db_name] || parse_connect_settings.select { |elem| elem.match /PGDATABASE/ }} successful!"
             return true
           else
             Puppet.warning "PostgresqlValidator.attempt_connection: Sleeping for #{sleep_length} seconds"

--- a/spec/acceptance/postgresql_conn_validator_spec.rb
+++ b/spec/acceptance/postgresql_conn_validator_spec.rb
@@ -14,7 +14,7 @@ describe 'postgresql_conn_validator', :unless => UNSUPPORTED_PLATFORMS.include?(
       require => Postgresql::Server::Role['testuser']
     }->
     postgresql::server::database_grant { 'allow connect for testuser':
-      privilege => 'CONNECT',
+      privilege => 'ALL',
       db        => 'testdb',
       role      => 'testuser',
     }

--- a/spec/unit/puppet/provider/postgresql_conn_validator/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_conn_validator/ruby_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:postgresql_conn_validator).provider(:ruby) do
 
   describe '#build_psql_cmd' do
     it 'contains expected commandline options' do
-      expect(provider.validator.build_psql_cmd).to match /\/usr\/bin\/psql.*--host=.*--port=.*--username=.*/
+      expect(provider.validator.build_psql_cmd).to match /\/usr\/bin\/psql.*--host.*--port.*--username.*/
     end
   end
 


### PR DESCRIPTION
last fix for postgres 8 ever. postgres 8 does not support the CONNECT privilege or equals signs in the command. --no-password doesn't seem to be required.  Also cleaned up conditional in the util script.