### PR TITLE
MODULES-2989 parameter ensure of custom resource postgresql_replication_slot is not documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,7 +1640,7 @@ This is the namevar.
 
 ##### `ensure`
 
-Specifies the action to create or destroy named slot. Must be present
+Specifies the action to create or destroy named slot. Required.
 
 Valid values: 'present', 'absent'.
 

--- a/README.md
+++ b/README.md
@@ -1640,7 +1640,9 @@ This is the namevar.
 
 ##### `ensure`
 
-Specifies the action to create or destroy named slot. Required.
+Required.
+
+Specifies the action to create or destroy named slot. 
 
 Valid values: 'present', 'absent'.
 

--- a/README.md
+++ b/README.md
@@ -1642,9 +1642,9 @@ This is the namevar.
 
 Specifies the action to create or destroy named slot. Must be present
 
-Valid values: `present`, `absent`.
+Valid values: 'present', 'absent'.
 
-Default value: `present`.
+Default value: 'present'.
 
 #### postgresql_conn_validator
 

--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,14 @@ Specifies the name of the slot to create. Must be a valid replication slot name.
 
 This is the namevar.
 
+##### `ensure`
+
+Specifies the action to create or destroy named slot. Must be present
+
+Valid values: `present`, `absent`.
+
+Default value: `present`.
+
 #### postgresql_conn_validator
 
 Validate the connection to a local or remote PostgreSQL database using this type.


### PR DESCRIPTION
MODULES-2989 parameter ensure of custom resource postgresql_replication_slot is not documented

updated the README.md appropriately