### PR TITLE
Allow order parameter to be string value

### DIFF
--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -5,10 +5,10 @@ define postgresql::server::pg_hba_rule(
   String $database,
   String $user,
   String $auth_method,
-  Optional[String] $address     = undef,
-  String $description           = 'none',
-  Optional[String] $auth_option = undef,
-  Integer $order                = 150,
+  Optional[String] $address       = undef,
+  String $description             = 'none',
+  Optional[String] $auth_option   = undef,
+  Variant[String, Integer] $order = 150,
 
   # Needed for testing primarily, support for multiple files is not really
   # working.

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -133,4 +133,39 @@ describe 'postgresql::server::config', :type => :class do
         .with_content(/.include \/usr\/lib64\/systemd\/system\/postgresql-9.5.service/)
     end
   end
+
+  describe 'with managed pg_hba_conf and ipv4acls' do
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          version => '9.5',
+        }->
+        class { 'postgresql::server':
+          manage_pg_hba_conf => true,
+          ipv4acls => [
+            'hostnossl all all 0.0.0.0/0 reject',
+            'hostssl all all 0.0.0.0/0 md5'
+          ]
+        }
+      EOS
+    end
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '7.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
+      }
+    end
+    it 'should have hba rule default' do
+      is_expected.to contain_postgresql__server__pg_hba_rule('local access as postgres user')
+    end
+    it 'should have hba rule ipv4acls' do
+      is_expected.to contain_postgresql__server__pg_hba_rule('postgresql class generated rule ipv4acls 0')
+    end
+  end
 end


### PR DESCRIPTION
concat::fragment accepts either a string or integer as order parameter value.
Numeric ordering doesn't work once converted to string filenames:

20 sequential fragments for example

| Numeric (no padding) | String (0 Zero Padded) |
|----------------------|------------------------|
| 10_fragment          | 001_fragment           |
| 11_fragment          | 002_fragment           |
| ...                  |                        |
| 19_fragment          | 010_fragment           |
| 1_fragment           | 011_fragment           |
| 20_fragment          | 012_fragment           |
| 2_fragment           | 013_fragment           |
| 3_fragment           | 014_fragment           |

Order has gone to pot...