### PR TITLE
add parameter "version" to postgresql::server::extension to update the extension version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,6 +1177,21 @@ Valid options: 'present' or 'absent'.
 
 Specifies the extension to activate. If left blank, uses the name of the resource.
 
+#### `version`
+
+Specifies the version of the extension which the database uses.
+When an extension package is updated, this does not automatically change the effective version in each database.
+
+This needs be updated using the PostgreSQL-specific SQL `ALTER EXTENSION...`
+
+`version` may be set to `latest`, in which case the SQL `ALTER EXTENSION "extension" UPDATE` is applied to this database (only).
+
+`version` may be set to a specific version, in which case the extension is updated using `ALTER EXTENSION "extension" UPDATE TO 'version'`
+
+eg. If extension is set to `postgis` and version is set to `2.3.3`, this will apply the SQL `ALTER EXTENSION "postgis" UPDATE TO '2.3.3'` to this database only.
+
+`version` may be omitted, in which case no `ALTER EXTENSION...` SQL is applied, and the version will be left unchanged.
+
 ##### `package_name`
 
 Specifies a package to install prior to activating the extension.

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -1,11 +1,12 @@
 # Activate an extension on a postgresql database
 define postgresql::server::extension (
   $database,
-  $extension        = $name,
-  String[1] $ensure = 'present',
-  $package_name     = undef,
-  $package_ensure   = undef,
-  $connect_settings = $postgresql::server::default_connect_settings,
+  $extension                   = $name,
+  Optional[String[1]] $version = undef,
+  String[1] $ensure            = 'present',
+  $package_name                = undef,
+  $package_ensure              = undef,
+  $connect_settings            = $postgresql::server::default_connect_settings,
 ) {
   $user             = $postgresql::server::user
   $group            = $postgresql::server::group
@@ -42,7 +43,10 @@ define postgresql::server::extension (
     db               => $database,
     command          => $command,
     unless           => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${extension}') as t WHERE t.count ${unless_comp} 1",
-    require          => Postgresql::Server::Database[$database],
+  }
+
+  if($database != undef and defined(Postgresql::Server::Database[$database])) {
+    Postgresql::Server::Database[$database]->Postgresql_psql["Add ${extension} extension to ${database}"]
   }
 
   if $package_name {
@@ -57,5 +61,26 @@ define postgresql::server::extension (
       require => $package_require,
       before  => $package_before,
     })
+  }
+  if $version {
+    if $version == 'latest' {
+      $alter_extension_sql = "ALTER EXTENSION \"${extension}\" UPDATE"
+      $update_unless = "SELECT 1 FROM pg_available_extensions WHERE name = '${extension}' AND default_version = installed_version"
+    } else {
+      $alter_extension_sql = "ALTER EXTENSION \"${extension}\" UPDATE TO '${version}'"
+      $update_unless = "SELECT 1 FROM pg_extension WHERE extname='${extension}' AND extversion='${version}'"
+    }
+    postgresql_psql { "${database}: ${alter_extension_sql}":
+      db               => $database,
+      psql_user        => $user,
+      psql_group       => $group,
+      psql_path        => $psql_path,
+      connect_settings => $connect_settings,
+      command          => $alter_extension_sql,
+      unless           => $update_unless,
+    }
+    if($database != undef and defined(Postgresql::Server::Database[$database])) {
+      Postgresql::Server::Database[$database]->Postgresql_psql["${database}: ${alter_extension_sql}"]
+    }
   }
 }

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -90,6 +90,36 @@ describe 'postgresql::server::extension', :type => :define do
       }
     end
   end
+
+  context "when extension version is specified" do
+    let (:params) { super().merge({
+      :ensure       => 'absent',
+      :package_name => 'postgis',
+      :version      => '99.99.99',
+    }) }
+
+    it {
+      is_expected.to contain_postgresql_psql('template_postgis: ALTER EXTENSION "postgis" UPDATE TO \'99.99.99\'').with({
+        :db      => 'template_postgis',
+        :unless  => "SELECT 1 FROM pg_extension WHERE extname='postgis' AND extversion='99.99.99'",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
+    }
+  end
+
+  context "when extension version is latest" do
+    let (:params) { super().merge({
+      :ensure       => 'absent',
+      :package_name => 'postgis',
+      :version      => 'latest',
+    }) }
+
+    it {
+      is_expected.to contain_postgresql_psql('template_postgis: ALTER EXTENSION "postgis" UPDATE').with({
+        :db      => 'template_postgis',
+        :unless  => "SELECT 1 FROM pg_available_extensions WHERE name = 'postgis' AND default_version = installed_version",
+      }).that_requires('Postgresql::Server::Database[template_postgis]')
+    }
+  end
 end
 
 describe 'postgresql::server::extension', :type => :define do


### PR DESCRIPTION
 [MODULES-5635](https://tickets.puppetlabs.com/browse/MODULES-5635)
This change adds the parameter "version" to the defined type postgresql::server::extension

If unspecified, the module behaviour is unchanged.

If specified, the module will invoke the PostgreSQL-specific `ALTER EXTENSION...`

`version` may be set to `latest`, in which case the SQL `ALTER EXTENSION "extension" UPDATE` is applied to this database (only).

`version` may be set to a specific version, in which case the extension is updated using `ALTER EXTENSION "extension" UPDATE TO 'version'`

When an extension package is updated, this does not automatically change the effective version in each database. The `ALTER EXTENSION...` takes care of this on a per-database basis.