### PR TITLE
add ensure=>absent to postgresql::server::role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,7 +1444,16 @@ Provides the target for the rule, and is generally an internal only property.
 **Use with caution.**
 
 #### postgresql::server::role
-Creates a role or user in PostgreSQL.
+Creates or drops a role or user in PostgreSQL.
+
+##### `ensure`
+
+Specify whether to create or drop the role.
+
+Specifying `present` will create the role.
+Specifying `absent` will drop the role.
+
+Default value: `present`.
 
 ##### `connection_limit`
 Specifies how many concurrent connections the role can make.

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -149,4 +149,20 @@ describe 'postgresql::server::role', :type => :define do
     end
   end
 
+  context 'with ensure set to absent' do
+    let :params do
+      {
+          :ensure => 'absent',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it 'should have drop role for "test" user if ensure absent' do
+      is_expected.to contain_postgresql_psql('DROP ROLE "test"')
+    end
+  end
+
 end


### PR DESCRIPTION
[MODULES-5636](https://tickets.puppetlabs.com/browse/MODULES-5636)
This change introduces the parameter 'ensure' to the defined type postgresql::server::role

ensure => present (default) leaves the current behaviour unchanged.

ensure => absent invokes `DROP ROLE...` instead of `CREATE ROLE...`
