### PR TITLE
Default contcat order

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -30,7 +30,6 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
-      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
 
@@ -158,7 +157,6 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
-      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
   }
@@ -169,7 +167,6 @@ class postgresql::server::config {
       group  => $group,
       mode   => '0640',
       warn   => true,
-      order  => 'numeric',
       notify => Class['postgresql::server::reload'],
     }
   }


### PR DESCRIPTION
Remove numeric order override from concat, use default alpha sort.