### PR TITLE
Replace deprecated function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,7 +1203,10 @@ Valid options: 'DATABASE', 'SCHEMA', 'SEQUENCE', 'ALL SEQUENCES IN SCHEMA', 'TAB
 
 ##### `object_name`
 
-Specifies name of `object_type` to which to grant access.
+Specifies name of `object_type` to which to grant access, can be either a string or a two element array.
+
+String: 'object_name'
+Array:  ['schema_name', 'object_name']
 
 ##### `port`
 

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -3,8 +3,25 @@ define postgresql::server::grant (
   String $role,
   String $db,
   Optional[String] $privilege      = undef,
-  String $object_type              = 'database',
-  Optional[String[1]] $object_name = undef,
+  Pattern[#/(?i:^COLUMN$)/,
+    /(?i:^ALL SEQUENCES IN SCHEMA$)/,
+    /(?i:^ALL TABLES IN SCHEMA$)/,
+    /(?i:^DATABASE$)/,
+    #/(?i:^FOREIGN DATA WRAPPER$)/,
+    #/(?i:^FOREIGN SERVER$)/,
+    #/(?i:^FUNCTION$)/,
+    /(?i:^LANGUAGE$)/,
+    #/(?i:^PROCEDURAL LANGUAGE$)/,
+    /(?i:^TABLE$)/,
+    #/(?i:^TABLESPACE$)/,
+    /(?i:^SCHEMA$)/,
+    /(?i:^SEQUENCE$)/
+    #/(?i:^VIEW$)/
+  ] $object_type                   = 'database',
+  Optional[Variant[
+            Array[String,2,2],
+            String[1]]
+  ] $object_name                   = undef,
   String $psql_db                  = $postgresql::server::default_database,
   String $psql_user                = $postgresql::server::user,
   Integer $port                    = $postgresql::server::port,
@@ -36,24 +53,6 @@ define postgresql::server::grant (
   $_object_type = upcase($object_type)
   $_privilege   = upcase($privilege)
 
-  ## Validate that the object type is known
-  validate_re($_object_type,[
-    #'^COLUMN$',
-    '^DATABASE$',
-    #'^FOREIGN SERVER$',
-    #'^FOREIGN DATA WRAPPER$',
-    #'^FUNCTION$',
-    #'^PROCEDURAL LANGUAGE$',
-    '^SCHEMA$',
-    '^SEQUENCE$',
-    '^ALL SEQUENCES IN SCHEMA$',
-    '^TABLE$',
-    '^ALL TABLES IN SCHEMA$',
-    '^LANGUAGE$',
-    #'^TABLESPACE$',
-    #'^VIEW$',
-    ]
-  )
   # You can use ALL TABLES IN SCHEMA by passing schema_name to object_name
   # You can use ALL SEQUENCES IN SCHEMA by passing schema_name to object_name
 
@@ -71,10 +70,15 @@ define postgresql::server::grant (
       $unless_privilege = $_privilege ? {
         'ALL'            => 'CREATE',
         'ALL PRIVILEGES' => 'CREATE',
-        default          => $_privilege,
+        Pattern[
+          '^$',
+          '^CONNECT$',
+          '^CREATE$',
+          '^TEMP$',
+          '^TEMPORARY$'
+        ]                => $_privilege,
+        default          => fail('Illegal value for $privilege parameter'),
       }
-      validate_re($unless_privilege, [ '^$', '^CREATE$','^CONNECT$','^TEMPORARY$','^TEMP$',
-        '^ALL$','^ALL PRIVILEGES$' ])
       $unless_function = 'has_database_privilege'
       $on_db = $psql_db
       $onlyif_function = undef
@@ -83,9 +87,13 @@ define postgresql::server::grant (
       $unless_privilege = $_privilege ? {
         'ALL'            => 'CREATE',
         'ALL PRIVILEGES' => 'CREATE',
-        default          => $_privilege,
+        Pattern[
+          '^$',
+          '^CREATE$',
+          '^USAGE$'
+        ]                => $_privilege,
+        default          => fail('Illegal value for $privilege parameter'),
       }
-      validate_re($_privilege, [ '^$', '^CREATE$', '^USAGE$', '^ALL$', '^ALL PRIVILEGES$' ])
       $unless_function = 'has_schema_privilege'
       $on_db = $db
       $onlyif_function = undef
@@ -93,15 +101,31 @@ define postgresql::server::grant (
     'SEQUENCE': {
       $unless_privilege = $_privilege ? {
         'ALL'   => 'USAGE',
-        default => $_privilege,
+        Pattern[
+          '^$',
+          '^ALL PRIVILEGES$',
+          '^SELECT$',
+          '^UPDATE$',
+          '^USAGE$'
+        ]       => $_privilege,
+        default => fail('Illegal value for $privilege parameter'),
       }
-      validate_re($unless_privilege, [ '^$', '^USAGE$', '^SELECT$', '^UPDATE$', '^ALL$', '^ALL PRIVILEGES$' ])
       $unless_function = 'has_sequence_privilege'
       $on_db = $db
       $onlyif_function = undef
     }
     'ALL SEQUENCES IN SCHEMA': {
-      validate_re($_privilege, [ '^$', '^USAGE$', '^SELECT$', '^UPDATE$', '^ALL$', '^ALL PRIVILEGES$' ])
+      case $_privilege {
+        Pattern[
+          '^$',
+          '^ALL$',
+          '^ALL PRIVILEGES$',
+          '^SELECT$',
+          '^UPDATE$',
+          '^USAGE$'
+        ]:       { }
+        default: { fail('Illegal value for $privilege parameter') }
+      }
       $unless_function = 'custom'
       $on_db = $db
       $onlyif_function = undef
@@ -166,10 +190,19 @@ define postgresql::server::grant (
     'TABLE': {
       $unless_privilege = $_privilege ? {
         'ALL'   => 'INSERT',
-        default => $_privilege,
+        Pattern[
+          '^$',
+          '^ALL$',
+          '^ALL PRIVILEGES$',
+          '^DELETE$',
+          '^REFERENCES$',
+          '^SELECT$',
+          '^TRIGGER$',
+          '^TRUNCATE$',
+          '^UPDATE$'
+        ]       => $_privilege,
+        default => fail('Illegal value for $privilege parameter'),
       }
-      validate_re($unless_privilege,[ '^$', '^SELECT$','^INSERT$','^UPDATE$','^DELETE$',
-        '^TRUNCATE$','^REFERENCES$','^TRIGGER$','^ALL$','^ALL PRIVILEGES$' ])
       $unless_function = 'has_table_privilege'
       $on_db = $db
       $onlyif_function = $onlyif_exists ? {
@@ -178,8 +211,21 @@ define postgresql::server::grant (
       }
     }
     'ALL TABLES IN SCHEMA': {
-      validate_re($_privilege, [ '^$', '^SELECT$','^INSERT$','^UPDATE$','^DELETE$',
-        '^TRUNCATE$','^REFERENCES$','^TRIGGER$','^ALL$','^ALL PRIVILEGES$' ])
+      case $_privilege {
+        Pattern[
+          '^$',
+          '^ALL$',
+          '^ALL PRIVILEGES$',
+          '^DELETE$',
+          '^INSERT$',
+          '^REFERENCES$',
+          '^SELECT$',
+          '^TRIGGER$',
+          '^TRUNCATE$',
+          '^UPDATE$'
+        ]:       { }
+        default: { fail('Illegal value for $privilege parameter') }
+      }
       $unless_function = 'custom'
       $on_db = $db
       $onlyif_function = undef
@@ -223,9 +269,13 @@ define postgresql::server::grant (
       $unless_privilege = $_privilege ? {
         'ALL'            => 'USAGE',
         'ALL PRIVILEGES' => 'USAGE',
-        default          => $_privilege,
+        Pattern[
+          '^$',
+          '^CREATE$',
+          '^USAGE$'
+        ]                => $_privilege,
+        default          => fail('Illegal value for $privilege parameter'),
       }
-      validate_re($unless_privilege, [ '^$','^CREATE$','^USAGE$','^ALL$','^ALL PRIVILEGES$' ])
       $unless_function = 'has_language_privilege'
       $on_db = $db
       $onlyif_function = $onlyif_exists ? {
@@ -247,13 +297,16 @@ define postgresql::server::grant (
   #   object_type => 'TABLE',
   #   object_name => [$schema, $table],
   # }
-  if is_array($_object_name) {
-    $_togrant_object = join($_object_name, '"."')
-    # Never put double quotes into has_*_privilege function
-    $_granted_object = join($_object_name, '.')
-  } else {
-    $_granted_object = $_object_name
-    $_togrant_object = $_object_name
+  case $_object_name {
+    Array:   {
+      $_togrant_object = join($_object_name, '"."')
+      # Never put double quotes into has_*_privilege function
+      $_granted_object = join($_object_name, '.')
+    }
+    default: {
+      $_granted_object = $_object_name
+      $_togrant_object = $_object_name
+    }
   }
 
   $_unless = $unless_function ? {

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -55,6 +55,29 @@ describe 'postgresql::server::grant', :type => :define do
     ) }
   end
 
+  context 'SeQuEnCe case insensitive object_type match' do
+    let :params do
+      {
+        :db => 'test',
+        :role => 'test',
+        :privilege => 'usage',
+        :object_type => 'SeQuEnCe',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to contain_postgresql__server__grant('test') }
+    it { is_expected.to contain_postgresql_psql('grant:test').with(
+      {
+        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* "test"/m,
+        'unless'  => /SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)/m,
+      }
+    ) }
+  end
+
   context 'all sequences' do
     let :params do
       {
@@ -136,7 +159,31 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql("grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1','PGPORT'    => '1234' } ).with_port( '5678' ) }
   end
 
-  context 'invalid objectype' do
+  context 'with specific schema name' do
+    let :params do
+      {
+        :db          => 'test',
+        :role        => 'test',
+        :privilege   => 'all',
+        :object_name => ['myschema', 'mytable'],
+        :object_type => 'table',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to contain_postgresql__server__grant('test') }
+    it { is_expected.to contain_postgresql_psql('grant:test').with(
+      {
+        'command' => /GRANT ALL ON TABLE "myschema"."mytable" TO\s* "test"/m,
+        'unless'  => /SELECT 1 WHERE has_table_privilege\('test',\s*'myschema.mytable', 'INSERT'\)/m,
+      }
+    ) }
+  end
+
+  context 'invalid object_type' do
     let :params do
       {
         :db => 'test',
@@ -150,6 +197,61 @@ describe 'postgresql::server::grant', :type => :define do
       "class {'postgresql::server':}"
     end
 
-    it { is_expected.to compile.and_raise_error(/"INVALID" does not match/) }
+    it { is_expected.to compile.and_raise_error(/parameter 'object_type' expects a match for Pattern/) }
   end
+
+  context 'invalid object_name - wrong type' do
+    let :params do
+      {
+        :db          => 'test',
+        :role        => 'test',
+        :privilege   => 'all',
+        :object_name => 1,
+        :object_type => 'table',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.and_raise_error(/parameter 'object_name' expects a value of type Undef, Array, or String, got Integer/) }
+  end
+
+  context 'invalid object_name - insufficent array elements' do
+    let :params do
+      {
+        :db          => 'test',
+        :role        => 'test',
+        :privilege   => 'all',
+        :object_name => ['oops'],
+        :object_type => 'table',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.and_raise_error(/parameter 'object_name' variant 0 expects size to be 2, got 1/) }
+  end
+
+  context 'invalid object_name - too many array elements' do
+    let :params do
+      {
+        :db          => 'test',
+        :role        => 'test',
+        :privilege   => 'all',
+        :object_name => ['myschema', 'mytable', 'oops'],
+        :object_type => 'table',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.and_raise_error(/parameter 'object_name' variant 0 expects size to be 2, got 3/) }
+  end
+
 end


### PR DESCRIPTION
Replace validate_re calls with puppet datatype `Pattern`
Replace is_array with puppet datatype `Array`

---

### Bug fix object_parameter

Replace String with vairant to accept undef, string or two element array.
Array required to enable specific schema name to be applied to object.

See manifests/server/grant.pp circa line 300