### PR TITLE
(MODULES-4854) remove allow_deprecations

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,5 +3,3 @@ NOTICE:
   unmanaged: true
 appveyor.yml:
   delete: true
-spec/spec_helper.rb:
-  allow_deprecations: true


### PR DESCRIPTION
This module has been released to drop puppet 3 so we will no longer allow deprecated functions via unit testing.