### PR TITLE
Change - Add support for Fedora 26

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -64,6 +64,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
+        /^(26)$/       => '9.6',
         /^(24|25)$/    => '9.5',
         /^(22|23)$/    => '9.4',
         /^(21)$/       => '9.3',


### PR DESCRIPTION
Fedora 26 provides postgresql-server version 9.6 by default.  Added
support to avoid puppet failures on Fedora 26 nodes.

See https://rpmfind.net/linux/RPM/fedora/updates/26/x86_64/p/postgresql-server-9.6.4-1.fc26.x86_64.html for details.