### PR TITLE
Do not require installation of server packages

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -71,14 +71,20 @@ class postgresql::server (
     warning('Passing "createdb_path" to postgresql::server is deprecated, it can be removed safely for the same behaviour')
   }
 
-  # Reload has its own ordering, specified by other defines
-  class { "${pg}::reload": require => Class["${pg}::install"] }
+  if $package_ensure != 'purged' {
+    # Reload has its own ordering, specified by other defines
+    class { "${pg}::reload": require => Class["${pg}::install"] }
 
-  anchor { "${pg}::start": }
-  -> class { "${pg}::install": }
-  -> class { "${pg}::initdb": }
-  -> class { "${pg}::config": }
-  -> class { "${pg}::service": }
-  -> class { "${pg}::passwd": }
-  -> anchor { "${pg}::end": }
+    anchor { "${pg}::start": }
+    -> class { "${pg}::install": }
+    -> class { "${pg}::initdb": }
+    -> class { "${pg}::config": }
+    -> class { "${pg}::service": }
+    -> class { "${pg}::passwd": }
+    -> anchor { "${pg}::end": }
+  } else {
+    anchor { "${pg}::start": }
+    -> class { "${pg}::service": }
+    -> anchor { "${pg}::end": }
+  }
 }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -118,7 +118,7 @@ define postgresql::server::role(
     }
     postgresql_psql { "ALTER ROLE ${username} ENCRYPTED PASSWORD ****":
       command     => "ALTER ROLE \"${username}\" ${password_sql}",
-      unless      => "SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
+      unless      => "SELECT 1 FROM pg_user WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
       environment => $environment,
     }
   }


### PR DESCRIPTION
This PR solves

MODULES-5068: pg_shadow does not exist in RDS @ AWS
MODULES-5069: Can't manage a remote PostgreSQL instance without installing server locally