### PR TITLE
add parameter "version" to postgresql::server::extension - fix dependency on database

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -32,6 +32,12 @@ define postgresql::server::extension (
     }
   }
 
+  if( $database != 'postgres' ) {
+    # The database postgres cannot managed by this module, so it is exempt from this dependency
+    Postgresql_psql {
+      require => Postgresql::Server::Database[$database],
+    }
+  }
 
   postgresql_psql {"Add ${extension} extension to ${database}":
 
@@ -43,10 +49,6 @@ define postgresql::server::extension (
     db               => $database,
     command          => $command,
     unless           => "SELECT t.count FROM (SELECT count(extname) FROM pg_extension WHERE extname = '${extension}') as t WHERE t.count ${unless_comp} 1",
-  }
-
-  if($database != undef and defined(Postgresql::Server::Database[$database])) {
-    Postgresql::Server::Database[$database]->Postgresql_psql["Add ${extension} extension to ${database}"]
   }
 
   if $package_name {
@@ -78,9 +80,6 @@ define postgresql::server::extension (
       connect_settings => $connect_settings,
       command          => $alter_extension_sql,
       unless           => $update_unless,
-    }
-    if($database != undef and defined(Postgresql::Server::Database[$database])) {
-      Postgresql::Server::Database[$database]->Postgresql_psql["${database}: ${alter_extension_sql}"]
     }
   }
 }

--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -8,7 +8,8 @@ describe 'postgresql::globals', type: :class do
           :family               => 'Debian',
           :name                 => 'Debian',
           :release => {
-            :full => '6.0'
+            :full => '6.0',
+            :major => '6'
           }
         },
         :osfamily               => 'Debian',

--- a/spec/unit/classes/repo_spec.rb
+++ b/spec/unit/classes/repo_spec.rb
@@ -7,7 +7,8 @@ describe 'postgresql::repo', :type => :class do
         :name                 => 'Debian',
         :family               => 'Debian',
         :release => {
-          :full               => '6.0'
+          :full               => '6.0',
+          :major              => '6'
         }
       },
       :osfamily               => 'Debian',

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -7,7 +7,8 @@ describe 'postgresql::server', :type => :class do
         :family  => 'Debian',
         :name => 'Debian',
         :release => {
-          :full => '6.0'
+          :full => '6.0',
+          :major => '6'
         }
       },
       :osfamily => 'Debian',


### PR DESCRIPTION
The previous change to the module postgresql::server::extension introduced a conditional dependency on the database which contains the extension.

This dependency was implemented in a way that did not work properly in all cases.

This update addresses this,  and the dependency on the database should now apply consistently.