### PR TITLE
This pull request fixes an augeas warning 

### DIFF
--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -126,7 +126,7 @@ define postgresql::server::config_entry (
         }
         -> augeas { 'override PGPORT in /etc/sysconfig/pgsql/postgresql':
           lens    => 'Shellvars.lns',
-          incl    => '/etc/sysconfig/pgsql/*',
+          incl    => '/etc/sysconfig/pgsql/postgresql',
           context => '/files/etc/sysconfig/pgsql/postgresql',
           changes => "set PGPORT ${value}",
           require => File['/etc/sysconfig/pgsql/postgresql'],
@@ -145,7 +145,7 @@ define postgresql::server::config_entry (
         }
         -> augeas { 'override PGDATA in /etc/sysconfig/pgsql/postgresql':
           lens    => 'Shellvars.lns',
-          incl    => '/etc/sysconfig/pgsql/*',
+          incl    => '/etc/sysconfig/pgsql/postgresql',
           context => '/files/etc/sysconfig/pgsql/postgresql',
           changes => "set PGDATA ${value}",
           require => File['/etc/sysconfig/pgsql/postgresql'],


### PR DESCRIPTION
If the folder /etc/sysconfig/pgsql/postgresql contains files other than in bash format (conf for example), augeas shoows warning for both varibles. 

```
Warning: Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas): Loading failed for one or more files, see debug for /augeas//error output
Warning: Augeas[override PGPORT in /etc/sysconfig/pgsql/postgresql](provider=augeas): Loading failed for one or more files, see debug for /augeas//error output
```
I suggest this fix to avoid warning. Also it makes more sence to load only one file in augeas than all files in sysconfig/pgsql/ directory .   