### PR TITLE
(maint) - Removing Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,8 +50,7 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
-        "8",
-        "9"
+        "8"
       ]
     },
     {


### PR DESCRIPTION
This will be readded when work is carried out to make Debian 9
compatible with the code base.