### PR TITLE
(MODULES-6014) Add support for Fedora 27 to puppetlabs-postgresql

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -65,7 +65,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
-        /^(26)$/       => '9.6',
+        /^(26|27)$/    => '9.6',
         /^(24|25)$/    => '9.5',
         /^(22|23)$/    => '9.4',
         /^(21)$/       => '9.3',


### PR DESCRIPTION
Fedora 27 provides postgresql-server version 9.6 in the default repositories.