### PR TITLE
MODULES-6194 - Add scram-sha-256 as a valid pg_hba_rule auth method

### DIFF
--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -33,6 +33,7 @@ define postgresql::server::pg_hba_rule(
     }
 
     $allowed_auth_methods = $postgresql_version ? {
+      '10'  => ['trust', 'reject', 'scram-sha-256', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'bsd'],
       '9.6' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'bsd'],
       '9.5' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.4' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
@@ -44,7 +45,7 @@ define postgresql::server::pg_hba_rule(
       '8.3' => ['trust', 'reject', 'md5', 'crypt', 'password', 'gss', 'sspi', 'krb5', 'ident', 'ldap', 'pam'],
       '8.2' => ['trust', 'reject', 'md5', 'crypt', 'password', 'krb5', 'ident', 'ldap', 'pam'],
       '8.1' => ['trust', 'reject', 'md5', 'crypt', 'password', 'krb5', 'ident', 'pam'],
-      default => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'crypt', 'bsd']
+      default => ['trust', 'reject', 'scram-sha-256', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'crypt', 'bsd']
     }
 
     assert_type(Enum[$allowed_auth_methods], $auth_method)

--- a/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -122,5 +122,35 @@ describe 'postgresql::server::pg_hba_rule', :type => :define do
       end
     end
 
+    context 'allows scram-sha-256 on postgres 10' do
+      let :pre_condition do
+        <<-EOS
+          class { 'postgresql::globals':
+            version => '10',
+          }
+          class { 'postgresql::server': }
+        EOS
+      end
+
+      let :params do
+        {
+          :type => 'local',
+          :database => 'all',
+          :user => 'all',
+          :address => '0.0.0.0/0',
+          :auth_method => 'scram-sha-256',
+          :target => target,
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(
+          {
+           :content => /local\s+all\s+all\s+0\.0\.0\.0\/0\s+scram-sha-256/
+          }
+        )
+      end
+    end
+
   end
 end


### PR DESCRIPTION
With Postgres 10, scram-sha-256 is a new type of password
hashing, improving over md5 hashing.

Currently, attempting to use this method results in an error.

See https://www.postgresql.org/docs/current/static/auth-methods.html#AUTH-PASSWORD for more details.

Forge ticket: https://tickets.puppetlabs.com/browse/MODULES-6194