### PR TITLE
Inherit 9.6 settings for later PgSQL version on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,7 +205,7 @@ class postgresql::params inherits postgresql::globals {
 
     'FreeBSD': {
       case $version {
-        '96': {
+        '96', '10': {
           $user                 = pick($user, 'postgres')
           $group                = pick($group, 'postgres')
           $datadir              = pick($datadir, "/var/db/postgres/data${version}")


### PR DESCRIPTION
Since version 96, we have other default settings. Inherit them for later versions