### PR TITLE
defaulted psql_path to postgresql::server::psql_path

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -9,7 +9,7 @@ class postgresql::server::service {
   $user             = $postgresql::server::user
   $port             = $postgresql::server::port
   $default_database = $postgresql::server::default_database
-  $psql_path        = $postgresql::params::psql_path
+  $psql_path        = $postgresql::server::psql_path
   $connect_settings = $postgresql::server::default_connect_settings
 
   anchor { 'postgresql::server::service::begin': }


### PR DESCRIPTION

The `psql_path` variable declared within the  `postgresql::server::service` class defaults by calling the default directly from `params` rather than from the parent service class like other variables.  Since these are not parameters, this makes `psql_path` impossible to override using class params/hiera.   It looks like this was done in error as `$postgresql::server::psql_path` exists and defaults to the params entry.

This fix defaults it to `$postgresql::server::psql_path` and should give the same default behavour but allow you to override `postgresql::server::psql_path: foo` in Hiera.

