### PR TITLE
Use puppet4 functions-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class { 'postgresql::server':
 
 postgresql::server::db { 'mydatabasename':
   user     => 'mydatabaseuser',
-  password => postgresql_password('mydatabaseuser', 'mypassword'),
+  password => postgresql::password('mydatabaseuser', 'mypassword'),
 }
 ```
 
@@ -99,7 +99,7 @@ class { 'postgresql::server':
 }
 
 postgresql::server::role { 'marmot':
-  password_hash => postgresql_password('marmot', 'mypasswd'),
+  password_hash => postgresql::password('marmot', 'mypasswd'),
 }
 
 postgresql::server::database_grant { 'test1':
@@ -363,8 +363,8 @@ The postgresql module comes with many options for configuring the server. While 
 
 **Functions:**
 
-* [postgresql_password](#function-postgresql_password)
-* [postgresql_acls_to_resources_hash](#function-postgresql_acls_to_resources_hashacl_array-id-order_offset)
+* [postgresql::password](#function-postgresql_password)
+* [postgresql::acls_to_resources_hash](#function-postgresql_acls_to_resources_hashacl_array-id-order_offset)
 
 **Tasks:**
 
@@ -1520,14 +1520,14 @@ Specifies whether to grant login capability for the new role.
 Default value: `true`.
 
 ##### `password_hash`
-Sets the hash to use during password creation. If the password is not already pre-encrypted in a format that PostgreSQL supports, use the `postgresql_password` function to provide an MD5 hash here, for example:
+Sets the hash to use during password creation. If the password is not already pre-encrypted in a format that PostgreSQL supports, use the `postgresql::password` function to provide an MD5 hash here, for example:
 
 ##### `update_password`
 If set to true, updates the password on changes. Set this to false to not modify the role's password after creation.
 
 ```puppet
 postgresql::server::role { 'myusername':
-  password_hash => postgresql_password('myusername', 'mypassword'),
+  password_hash => postgresql::password('myusername', 'mypassword'),
 }
 ```
 
@@ -1817,10 +1817,10 @@ Sets the number of attempts after failure before giving up and failing the resou
 
 #### postgresql_password
 
-Generates a PostgreSQL encrypted password, use `postgresql_password`. Call it from the command line and then copy and paste the encrypted password into your manifest:
+Generates a PostgreSQL encrypted password, use `postgresql::password`. Call it from the command line and then copy and paste the encrypted password into your manifest:
 
 ```shell
-puppet apply --execute 'notify { 'test': message => postgresql_password('username', 'password') }'
+puppet apply --execute 'notify { 'test': message => postgresql::password('username', 'password') }'
 ```
 
 Alternatively, you can call this from your production manifests, but the manifests will then contain a clear text version of your passwords.

--- a/lib/puppet/functions/postgresql/acls_to_resources_hash.rb
+++ b/lib/puppet/functions/postgresql/acls_to_resources_hash.rb
@@ -1,0 +1,66 @@
+#    This internal function translates the ipv(4|6)acls format into a resource
+#    suitable for create_resources. It is not intended to be used outside of the
+#    postgresql internal classes/defined resources.
+#
+#    This function accepts an array of strings that are pg_hba.conf rules. It
+#    will return a hash that can be fed into create_resources to create multiple
+#    individual pg_hba_rule resources.
+#
+#    The second parameter is an identifier that will be included in the namevar
+#    to provide uniqueness. It must be a string.
+#
+#    The third parameter is an order offset, so you can start the order at an
+#    arbitrary starting point.
+Puppet::Functions.create_function(:'postgresql::acls_to_resources_hash') do
+  dispatch :acls_to_resources_hash do
+    required_param 'Array', :acls
+    required_param 'String', :id
+    required_param 'Integer', :offset
+    return_type 'Hash'
+  end
+
+  def acls_to_resources_hash(acls, id, offset)
+    func_name = "postgresql::acls_to_resources_hash()"
+
+    resources = {}
+    acls.each do |acl|
+      index = acls.index(acl)
+
+      parts = acl.split
+
+      raise(Puppet::ParseError, "#{func_name}: acl line #{index} does not " +
+        "have enough parts") unless parts.length >= 4
+
+      resource = {
+        'type' => parts[0],
+        'database' => parts[1],
+        'user' => parts[2],
+        'order' => format('%03d', offset + index),
+      }
+      if parts[0] == 'local' then
+        resource['auth_method'] = parts[3]
+        if parts.length > 4 then
+          resource['auth_option'] = parts.last(parts.length - 4).join(" ")
+        end
+      else
+        if parts[4] =~ /^\d/
+          resource['address'] = parts[3] + ' ' + parts[4]
+          resource['auth_method'] = parts[5]
+
+          if parts.length > 6 then
+            resource['auth_option'] = parts.last(parts.length - 6).join(" ")
+          end
+        else
+          resource['address'] = parts[3]
+          resource['auth_method'] = parts[4]
+
+          if parts.length > 5 then
+            resource['auth_option'] = parts.last(parts.length - 5).join(" ")
+          end
+        end
+      end
+      resources["postgresql class generated rule #{id} #{index}"] = resource
+    end
+    resources
+  end
+end

--- a/lib/puppet/functions/postgresql/escape.rb
+++ b/lib/puppet/functions/postgresql/escape.rb
@@ -1,0 +1,23 @@
+# Safely escapes a string using $$ using a random tag which should be consistent
+
+require 'digest/md5'
+
+Puppet::Functions.create_function(:'postgresql::escape') do
+  dispatch :escape do
+    required_param 'String', :password
+    return_type 'String'
+  end
+
+  def escape(password)
+    if password !~ /\$\$/ and password[-1] != '$'
+      retval = "$$#{password}$$"
+    else
+      escape = Digest::MD5.hexdigest(password)[0..5].gsub(/\d/,'')
+      until password !~ /#{escape}/
+        escape = Digest::MD5.hexdigest(escape)[0..5].gsub(/\d/,'')
+      end
+      retval = "$#{escape}$#{password}$#{escape}$"
+    end
+    retval
+  end
+end

--- a/lib/puppet/functions/postgresql/password.rb
+++ b/lib/puppet/functions/postgresql/password.rb
@@ -1,0 +1,16 @@
+# hash a string as mysql's "PASSWORD()" function would do it
+# Returns the postgresql password hash from the clear text username / password.
+
+require 'digest/md5'
+
+Puppet::Functions.create_function(:'postgresql::password') do
+  dispatch :password do
+    required_param 'String', :username
+    required_param 'Variant[String, Integer]', :password
+    return_type 'String'
+  end
+
+  def password(username, password)
+    'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)
+  end
+end

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -88,14 +88,14 @@ class postgresql::server::config {
 
     # ipv4acls are passed as an array of rule strings, here we transform
     # them into a resources hash, and pass the result to create_resources
-    $ipv4acl_resources = postgresql_acls_to_resources_hash($ipv4acls,
+    $ipv4acl_resources = postgresql::acls_to_resources_hash($ipv4acls,
     'ipv4acls', 10)
     create_resources('postgresql::server::pg_hba_rule', $ipv4acl_resources)
 
 
     # ipv6acls are passed as an array of rule strings, here we transform
     # them into a resources hash, and pass the result to create_resources
-    $ipv6acl_resources = postgresql_acls_to_resources_hash($ipv6acls,
+    $ipv6acl_resources = postgresql::acls_to_resources_hash($ipv6acls,
     'ipv6acls', 102)
     create_resources('postgresql::server::pg_hba_rule', $ipv6acl_resources)
   }

--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -20,7 +20,7 @@ class postgresql::server::passwd {
     #  configured to allow the postgres system user to connect via psql
     #  without specifying a password ('ident' or 'trust' security). This is
     #  the default for pg_hba.conf.
-    $escaped = postgresql_escape($postgres_password)
+    $escaped = postgresql::escape($postgres_password)
     exec { 'set_postgres_postgrespw':
       # This command works w/no password because we run it as postgres system
       # user

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -85,7 +85,7 @@ class { 'postgresql::server':
 
 postgresql::server::db { 'mydatabasename':
   user     => 'mydatabaseuser',
-  password => postgresql_password('mydatabaseuser', 'mypassword'),
+  password => postgresql::password('mydatabaseuser', 'mypassword'),
 }
 ```
 
@@ -98,7 +98,7 @@ class { 'postgresql::server':
 }
 
 postgresql::server::role { 'marmot':
-  password_hash => postgresql_password('marmot', 'mypasswd'),
+  password_hash => postgresql::password('marmot', 'mypasswd'),
 }
 
 postgresql::server::database_grant { 'test1':
@@ -362,8 +362,8 @@ postgresqlモジュールには、サーバー設定用に多数のオプショ�
 
 **関数:**
 
-* [postgresql_password](#function-postgresql_password)
-* [postgresql_acls_to_resources_hash](#function-postgresql_acls_to_resources_hashacl_array-id-order_offset)
+* [postgresql::password](#function-postgresql_password)
+* [postgresql::acls_to_resources_hash](#function-postgresql_acls_to_resources_hashacl_array-id-order_offset)
 
 ### クラス
 
@@ -1517,14 +1517,14 @@ PostgreSQLのロールまたはユーザを作成します。
 デフォルト値: `true`。
 
 ##### `password_hash`
-パスワード作成中に使用するハッシュを設定します。PostgreSQLがサポートする形式でパスワードが暗号化されていない場合、ここで、`postgresql_password`関数を使用して、MD5ハッシュを提供します。例は次のとおりです。
+パスワード作成中に使用するハッシュを設定します。PostgreSQLがサポートする形式でパスワードが暗号化されていない場合、ここで、`postgresql::password`関数を使用して、MD5ハッシュを提供します。例は次のとおりです。
 
 ##### `update_password`
 trueに設定すると、変更時にパスワードが更新されます。作成後にロールのパスワードを変更しない場合は、falseに設定してください。
 
 ```puppet
 postgresql::server::role { 'myusername':
-  password_hash => postgresql_password('myusername', 'mypassword'),
+  password_hash => postgresql::password('myusername', 'mypassword'),
 }
 ```
 
@@ -1814,10 +1814,10 @@ Unixソケットとident認証を使用するとき、このユーザとして�
 
 #### postgresql_password
 
-PostgreSQL暗号化パスワードを生成します。次のように、`postgresql_password`をコマンドラインから呼び出し、暗号化されたパスワードをマニフェストにコピーペーストします。
+PostgreSQL暗号化パスワードを生成します。次のように、`postgresql::password`をコマンドラインから呼び出し、暗号化されたパスワードをマニフェストにコピーペーストします。
 
 ```shell
-puppet apply --execute 'notify { 'test': message => postgresql_password('username', 'password') }'
+puppet apply --execute 'notify { 'test': message => postgresql::password('username', 'password') }'
 ```
 
 本番マニフェストからこの関数を呼び出すことも可能ですが、その場合、マニフェストには暗号化していない平文のパスワードを含める必要があります。

--- a/spec/acceptance/postgresql_conn_validator_spec.rb
+++ b/spec/acceptance/postgresql_conn_validator_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql_conn_validator', :unless => UNSUPPORTED_PLATFORMS.include?(
       postgres_password => 'space password',
     }->
     postgresql::server::role { 'testuser':
-      password_hash => postgresql_password('testuser','test1'),
+      password_hash => postgresql::password('testuser','test1'),
     }->
     postgresql::server::database { 'testdb':
       owner   => 'testuser',

--- a/spec/acceptance/remote_access_spec.rb
+++ b/spec/acceptance/remote_access_spec.rb
@@ -29,7 +29,7 @@ describe 'remote-access', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
 
         postgresql::server::db { 'puppet':
           user     => 'puppet',
-          password => postgresql_password('puppet', 'puppet'),
+          password => postgresql::password('puppet', 'puppet'),
         }
 
         postgresql::server::pg_hba_rule { 'allow full yolo access password':

--- a/spec/acceptance/server/grant_role_spec.rb
+++ b/spec/acceptance/server/grant_role_spec.rb
@@ -29,7 +29,7 @@ describe 'postgresql::server::grant_role:', :unless => UNSUPPORTED_PLATFORMS.inc
         }
 
         postgresql::server::role { $user:
-          password_hash => postgresql_password($user, $password),
+          password_hash => postgresql::password($user, $password),
         }
 
         postgresql::server::database { $db:
@@ -95,7 +95,7 @@ describe 'postgresql::server::grant_role:', :unless => UNSUPPORTED_PLATFORMS.inc
         }
 
         postgresql::server::role { $user:
-          password_hash => postgresql_password($user, $password),
+          password_hash => postgresql::password($user, $password),
           superuser     => true,
         }
 
@@ -163,7 +163,7 @@ describe 'postgresql::server::grant_role:', :unless => UNSUPPORTED_PLATFORMS.inc
         }
 
         postgresql::server::role { $user:
-          password_hash => postgresql_password($user, $password),
+          password_hash => postgresql::password($user, $password),
         }
 
         postgresql::server::database { $db:

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -17,7 +17,7 @@ describe 'postgresql::server::grant:', :unless => UNSUPPORTED_PLATFORMS.include?
     class { 'postgresql::server': }
 
     postgresql::server::role { $owner:
-      password_hash => postgresql_password($owner, $password),
+      password_hash => postgresql::password($owner, $password),
     }
 
     # Since we are not testing pg_hba or any of that, make a local user for ident auth

--- a/spec/acceptance/server/reassign_owned_by_spec.rb
+++ b/spec/acceptance/server/reassign_owned_by_spec.rb
@@ -17,7 +17,7 @@ describe 'postgresql::server::reassign_owned_by:', :unless => UNSUPPORTED_PLATFO
     class { 'postgresql::server': }
 
     postgresql::server::role { $old_owner:
-      password_hash => postgresql_password($old_owner, $password),
+      password_hash => postgresql::password($old_owner, $password),
     }
 
     # Since we are not testing pg_hba or any of that, make a local user for ident auth

--- a/spec/acceptance/server/schema_spec.rb
+++ b/spec/acceptance/server/schema_spec.rb
@@ -24,7 +24,7 @@ describe 'postgresql::server::schema:', :unless => UNSUPPORTED_PLATFORMS.include
         }
 
         postgresql::server::role { $user:
-          password_hash => postgresql_password($user, $password),
+          password_hash => postgresql::password($user, $password),
         }
 
         postgresql::server::database { $db:

--- a/spec/acceptance/sql_task_spec.rb
+++ b/spec/acceptance/sql_task_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql task', if: puppet_version =~ %r{(5\.\d\.\d)} && !pe_install
         class { 'postgresql::server': } ->
         postgresql::server::db { 'spec1':
           user     => 'root1',
-          password => postgresql_password('root1', 'password'),
+          password => postgresql::password('root1', 'password'),
         }
     EOS
 

--- a/spec/functions/postgresql_acls_to_resources_hash_spec.rb
+++ b/spec/functions/postgresql_acls_to_resources_hash_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe 'postgresql::acls_to_resources_hash' do
+  context 'individual transform tests' do
+    it do
+      input = 'local   all             postgres                                ident'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"local",
+          "database"=>"all",
+          "user"=>"postgres",
+          "auth_method"=>"ident",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'local   all             root                                ident'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"local",
+          "database"=>"all",
+          "user"=>"root",
+          "auth_method"=>"ident",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input_array = [
+        'local   all             all                                     ident',
+      ]
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"local",
+          "database"=>"all",
+          "user"=>"all",
+          "auth_method"=>"ident",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params(input_array, 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'host    all             all             127.0.0.1/32            md5'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"host",
+          "database"=>"all",
+          "user"=>"all",
+          "address"=>"127.0.0.1/32",
+          "auth_method"=>"md5",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'host    all             all             0.0.0.0/0            md5'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"host",
+          "database"=>"all",
+          "user"=>"all",
+          "address"=>"0.0.0.0/0",
+          "auth_method"=>"md5",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'host    all             all             ::1/128                 md5'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"host",
+          "database"=>"all",
+          "user"=>"all",
+          "address"=>"::1/128",
+          "auth_method"=>"md5",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'host    all             all             1.1.1.1 255.255.255.0    md5'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"host",
+          "database"=>"all",
+          "user"=>"all",
+          "address"=>"1.1.1.1 255.255.255.0",
+          "auth_method"=>"md5",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+
+    it do
+      input = 'host    all             all             1.1.1.1 255.255.255.0   ldap ldapserver=ldap.example.net ldapprefix="cn=" ldapsuffix=", dc=example, dc=net"'
+      result = {
+        "postgresql class generated rule test 0"=>{
+          "type"=>"host",
+          "database"=>"all",
+          "user"=>"all",
+          "address"=>"1.1.1.1 255.255.255.0",
+          "auth_method"=>"ldap",
+          "auth_option"=>"ldapserver=ldap.example.net ldapprefix=\"cn=\" ldapsuffix=\", dc=example, dc=net\"",
+          "order"=>"100",
+        },
+      }
+
+      is_expected.to run.with_params([input], 'test', 100).and_return(result)
+    end
+  end
+
+  it 'should return an empty hash when input is empty array' do
+    is_expected.to run.with_params([], 'test', 100).and_return({})
+  end
+end

--- a/spec/functions/postgresql_escape_spec.rb
+++ b/spec/functions/postgresql_escape_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'postgresql::escape' do
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('foo', 'bar').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('foo').and_return('$$foo$$') }
+  it { is_expected.to run.with_params('fo$$o').and_return('$ed$fo$$o$ed$') }
+  it { is_expected.to run.with_params('foo$').and_return('$a$foo$$a$') }
+end

--- a/spec/functions/postgresql_password_spec.rb
+++ b/spec/functions/postgresql_password_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'postgresql::password' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('foo').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('foo', 'bar', 'baz').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('foo', 'bar').and_return('md596948aad3fcae80c08a35c9b5958cd89') }
+  it { is_expected.to run.with_params('foo', 1234).and_return('md539a0e1b308278a8de5e007cd1f795920') }
+end


### PR DESCRIPTION
The legacy puppet3 functions-api should be avoided.
This migrates the existing functions to the new api and uses it in the module. It also adds the tests for the new functions based on those for the olds.
We should keep the legacy functions for now to allow compatibility for those using the functions outside out this module.