### PR TITLE
Allow adding roles, config entires and hba rules via hiera

### DIFF
--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -120,6 +120,8 @@ Puppet::Type.newtype(:postgresql_psql) do
     newvalues(:true, :false)
   end
 
+  autorequire(:class) { ['Postgresql::Server::Service'] }
+
   def should_run_sql(refreshing = false)
     onlyif_param = @parameters[:onlyif]
     unless_param = @parameters[:unless]

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -74,11 +74,15 @@ class postgresql::server (
   # Reload has its own ordering, specified by other defines
   class { "${pg}::reload": require => Class["${pg}::install"] }
 
-  anchor { "${pg}::start": }
-  -> class { "${pg}::install": }
-  -> class { "${pg}::initdb": }
-  -> class { "${pg}::config": }
-  -> class { "${pg}::service": }
-  -> class { "${pg}::passwd": }
-  -> anchor { "${pg}::end": }
+  contain postgresql::server::install
+  contain postgresql::server::initdb
+  contain postgresql::server::config
+  contain postgresql::server::service
+  contain postgresql::server::passwd
+
+  Class['postgresql::server::install']
+  -> Class['postgresql::server::initdb']
+  -> Class['postgresql::server::config']
+  -> Class['postgresql::server::service']
+  -> Class['postgresql::server::passwd']
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -55,6 +55,11 @@ class postgresql::server (
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
   $module_workdir             = $postgresql::params::module_workdir,
+
+  Hash[String, Hash] $roles         = {},
+  Hash[String, Any] $config_entries = {},
+  Hash[String, Hash] $pg_hba_rules  = {},
+
   #Deprecated
   $version                    = undef,
 ) inherits postgresql::params {
@@ -85,4 +90,22 @@ class postgresql::server (
   -> Class['postgresql::server::config']
   -> Class['postgresql::server::service']
   -> Class['postgresql::server::passwd']
+
+  $roles.each |$rolename, $role| {
+    postgresql::server::role { $rolename:
+      * => $role,
+    }
+  }
+
+  $config_entries.each |$entry, $value| {
+    postgresql::server::config_entry { $entry:
+      value => $value,
+    }
+  }
+
+  $pg_hba_rules.each |$rule_name, $rule| {
+    postgresql::server::pg_hba_rule { $rule_name:
+      * => $rule,
+    }
+  }
 }

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -413,7 +413,6 @@ define postgresql::server::grant (
     psql_path        => $psql_path,
     unless           => $_unless,
     onlyif           => $_onlyif,
-    require          => Class['postgresql::server']
   }
 
   if($role != undef and defined(Postgresql::Server::Role[$role])) {

--- a/manifests/server/reassign_owned_by.pp
+++ b/manifests/server/reassign_owned_by.pp
@@ -45,7 +45,6 @@ define postgresql::server::reassign_owned_by (
     psql_group       => $group,
     psql_path        => $psql_path,
     onlyif           => $onlyif,
-    require          => Class['postgresql::server']
   }
 
   if($old_role != undef and defined(Postgresql::Server::Role[$old_role])) {

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -47,10 +47,7 @@ define postgresql::server::role(
     psql_path  => $psql_path,
     connect_settings => $connect_settings,
     cwd        => $module_workdir,
-    require    => [
-      Postgresql_psql["CREATE ROLE ${username} ENCRYPTED PASSWORD ****"],
-      Class['postgresql::server'],
-    ],
+    require    => Postgresql_psql["CREATE ROLE ${username} ENCRYPTED PASSWORD ****"],
   }
 
   if $ensure == 'present' {
@@ -72,7 +69,7 @@ define postgresql::server::role(
       command     => "CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}",
       unless      => "SELECT 1 FROM pg_roles WHERE rolname = '${username}'",
       environment => $environment,
-      require     => Class['Postgresql::Server'],
+      require     => undef,
     }
 
     postgresql_psql {"ALTER ROLE \"${username}\" ${superuser_sql}":
@@ -128,7 +125,7 @@ define postgresql::server::role(
     # ensure == absent
     postgresql_psql { "DROP ROLE \"${username}\"":
       onlyif  => "SELECT 1 FROM pg_roles WHERE rolname = '${username}'",
-      require => Class['Postgresql::Server'],
+      require => undef,
     }
   }
 }

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -40,7 +40,7 @@ define postgresql::server::tablespace(
   postgresql_psql { "CREATE TABLESPACE \"${spcname}\"":
     command => "CREATE TABLESPACE \"${spcname}\" LOCATION '${location}'",
     unless  => "SELECT 1 FROM pg_tablespace WHERE spcname = '${spcname}'",
-    require => [Class['postgresql::server'], File[$location]],
+    require => File[$location],
   }
 
   if $owner {

--- a/spec/acceptance/overridden_settings_spec.rb
+++ b/spec/acceptance/overridden_settings_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper_acceptance'
+
+# These tests are designed to ensure that the module, when ran overrides,
+# sets up everything correctly and allows us to connect to Postgres.
+describe 'postgresql::server', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  pp = <<-MANIFEST
+    class { 'postgresql::server':
+      roles          => {
+        'testusername' => {
+          password_hash => postgresql_password('testusername', 'supersecret'),
+          createdb      => true,
+        },
+      },
+      config_entries => {
+        max_connections => 200,
+      },
+      pg_hba_rules   => {
+        'from_remote_host' => {
+          type        => 'host',
+          database    => 'mydb',
+          user        => 'myuser',
+          auth_method => 'md5',
+          address     => '192.0.2.100/32',
+        },
+      },
+    }
+
+    postgresql::server::database { 'testusername':
+      owner => 'testusername',
+    }
+  MANIFEST
+
+  it 'with additional hiera entries' do
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe port(5432) do
+    it { is_expected.to be_listening }
+  end
+
+  it 'can connect with psql' do
+    psql('--command="\l" postgres', 'postgres') do |r|
+      expect(r.stdout).to match(%r{List of databases})
+    end
+  end
+
+  it 'can connect with psql as testusername' do
+    shell('PGPASSWORD=supersecret psql -U testusername -h localhost --command="\l"') do |r|
+      expect(r.stdout).to match(%r{List of databases})
+    end
+  end
+end

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -163,4 +163,58 @@ describe 'postgresql::server', type: :class do
       is_expected.to contain_class('postgresql::repo').with_version('99.5')
     end
   end
+
+  describe 'additional roles' do
+    let(:params) do
+      {
+        roles: {
+          username: { createdb: true },
+        },
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql__server__role('username').with_createdb(true) }
+  end
+
+  describe 'additional config_entries' do
+    let(:params) do
+      {
+        config_entries: {
+          fsync: 'off',
+          checkpoint_segments: '20',
+        },
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql__server__config_entry('fsync').with_value('off') }
+    it { is_expected.to contain_postgresql__server__config_entry('checkpoint_segments').with_value('20') }
+  end
+
+  describe 'additional pg_hba_rules' do
+    let(:params) do
+      {
+        pg_hba_rules: {
+          from_remote_host: {
+            type: 'host',
+            database: 'mydb',
+            user: 'myuser',
+            auth_method: 'md5',
+            address: '192.0.2.100',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_postgresql__server__pg_hba_rule('from_remote_host')
+        .with_type('host')
+        .with_database('mydb')
+        .with_user('myuser')
+        .with_auth_method('md5')
+        .with_address('192.0.2.100')
+    end
+  end
 end

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -210,7 +210,7 @@ describe 'postgresql::server::grant', type: :define do
     it { is_expected.to contain_postgresql__server__role('test') }
     it do
       is_expected.to contain_postgresql_psql('grant:test') \
-        .that_requires('Postgresql::Server::Role[test]')
+        .that_requires(['Class[postgresql::server::service]', 'Postgresql::Server::Role[test]'])
     end
   end
 

--- a/spec/unit/defines/server/reassign_owned_by_spec.rb
+++ b/spec/unit/defines/server/reassign_owned_by_spec.rb
@@ -32,12 +32,13 @@ describe 'postgresql::server::reassign_owned_by', type: :define do
     MANIFEST
   end
 
+  it { is_expected.to compile.with_all_deps }
   it { is_expected.to contain_postgresql__server__reassign_owned_by('test') }
 
   it {
     is_expected.to contain_postgresql_psql('reassign_owned_by:test:REASSIGN OWNED BY "test_old_role" TO "test_new_role"')
       .with_command('REASSIGN OWNED BY "test_old_role" TO "test_new_role"')
       .with_onlyif(%r{SELECT tablename FROM pg_catalog.pg_tables WHERE\s*schemaname NOT IN \('pg_catalog', 'information_schema'\) AND\s*tableowner = 'test_old_role'.*}m)
-      .that_requires('Class[postgresql::server]')
+      .that_requires('Class[Postgresql::Server::Service]')
   }
 end

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -66,6 +66,7 @@ describe 'postgresql::server::role', type: :define do
         .with_unless("SELECT 1 FROM pg_roles WHERE rolname = 'test'")
         .with_port(5432)
         .with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGUSER' => 'login-user', 'PGPASSWORD' => 'login-pass')
+        .that_requires('Class[postgresql::server::service]')
     end
     it 'has alter role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
@@ -138,7 +139,7 @@ describe 'postgresql::server::role', type: :define do
     end
 
     it 'has drop role for "test" user if ensure absent' do
-      is_expected.to contain_postgresql_psql('DROP ROLE "test"')
+      is_expected.to contain_postgresql_psql('DROP ROLE "test"').that_requires('Class[postgresql::server::service]')
     end
   end
 end

--- a/spec/unit/defines/server/tablespace_spec.rb
+++ b/spec/unit/defines/server/tablespace_spec.rb
@@ -28,6 +28,7 @@ describe 'postgresql::server::tablespace', type: :define do
   end
 
   it { is_expected.to contain_postgresql__server__tablespace('test') }
+  it { is_expected.to contain_postgresql_psql('CREATE TABLESPACE "test"').that_requires('Class[postgresql::server::service]') }
 
   context 'with different owner' do
     let :params do


### PR DESCRIPTION
This includes refactoring like using contain rather than the anchor pattern.

The autorequires should ensure the sql is always executed after the server is configured. This was needed because the hiera entries would create a cyclic dependency. For some reason the test is failing so it might not be working.