### PR TITLE
Fix syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ To change the ownership of all objects within a database using
 
 ```puppet
 postgresql::server::reassign_owned_by { 'new owner is meerkat':
-  db        => 'test_db',
-  old_owner => 'marmot',
-  new_owner => 'meerkat',
+  db       => 'test_db',
+  old_role => 'marmot',
+  new_role => 'meerkat',
 }
 ```
 


### PR DESCRIPTION
Documentation error, `reassign_owned_by` uses `*_role` not `*_owner`