### PR TITLE
(maint) Fix to grant_spec.rb regarding database test on earlier machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ Manages grant-based access privileges for users, wrapping the `postgresql::serve
 
 ##### `ensure`
 
-Specifies whether to grant or revoke the privilege. Default is to grant the privilege.
+Specifies whether to grant or revoke the privilege. Revoke or 'absent' works only in PostgreSQL version 9.1.24 or later.
 
 Valid values: 'present', 'absent'.
 * 'present' to grant the privilege


### PR DESCRIPTION
The database test has issues on machines with postgresql version's prior to '9.1.24'.
This is due to the fact that the functions implement by 'https://github.com/puppetlabs/puppetlabs-postgresql/pull/891', i.e. 'ensure => absent uses REVOKE instead of GRANT' was not implemented in postgresql databases until this version. No issue has arisen with the use of revoke on separate tables however so the test's involving them have been left alone.
This PR introduces an exemption on the specified test that prevent's it from being run against machines that do not support it and a warning has been included within the readme file.