### PR TITLE
Various cleanups

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,37 +10,9 @@ install_ca_certs unless pe_install?
 
 UNSUPPORTED_PLATFORMS = %w[AIX windows Solaris Suse].freeze
 
-# monkey patch to get around apt/forge issue (PUP-8008)
-module Beaker::ModuleInstallHelper
-  include Beaker::DSL
-
-  def module_dependencies_from_metadata
-    metadata = module_metadata
-    return [] unless metadata.key?('dependencies')
-
-    dependencies = []
-
-    # get it outta here!
-    metadata['dependencies'].delete_if { |d| d['name'] == 'puppetlabs/apt' }
-
-    metadata['dependencies'].each do |d|
-      tmp = { module_name: d['name'].sub('/', '-') }
-
-      if d.key?('version_requirement')
-        tmp[:version] = module_version_from_requirement(tmp[:module_name],
-                                                        d['version_requirement'])
-      end
-      dependencies.push(tmp)
-    end
-
-    dependencies
-  end
-end
-
 install_bolt_on(hosts) unless pe_install?
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
-install_module_from_forge_on(hosts, 'puppetlabs/apt', '< 4.2.0')
 
 DEFAULT_PASSWORD = if default[:hypervisor] == 'vagrant'
                      'vagrant'

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -29,6 +29,7 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
   end
 
@@ -46,13 +47,13 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it {
-      is_expected.to contain_postgresql_psql('grant:test').with(
-        'command' => %r{GRANT USAGE ON SEQUENCE "test" TO\s* "test"}m,
-        'unless' => %r{SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)}m,
-      )
-    }
+    it do
+      is_expected.to contain_postgresql_psql('grant:test')
+        .with_command(%r{GRANT USAGE ON SEQUENCE "test" TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)}m)
+    end
   end
 
   context 'SeQuEnCe case insensitive object_type match' do
@@ -69,13 +70,13 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it {
-      is_expected.to contain_postgresql_psql('grant:test').with(
-        'command' => %r{GRANT USAGE ON SEQUENCE "test" TO\s* "test"}m,
-        'unless' => %r{SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)}m,
-      )
-    }
+    it do
+      is_expected.to contain_postgresql_psql('grant:test')
+        .with_command(%r{GRANT USAGE ON SEQUENCE "test" TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)}m)
+    end
   end
 
   context 'all sequences' do
@@ -93,13 +94,13 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it {
-      is_expected.to contain_postgresql_psql('grant:test').with(
-        'command' => %r{GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* "test"}m,
-        'unless' => %r{SELECT 1 WHERE NOT EXISTS \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\)}m, # rubocop:disable Metrics/LineLength
-      )
-    }
+    it do
+      is_expected.to contain_postgresql_psql('grant:test')
+        .with_command(%r{GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE NOT EXISTS \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\)}m) # rubocop:disable Metrics/LineLength
+    end
   end
 
   context 'with specific db connection settings - default port' do
@@ -116,6 +117,7 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('grant:test').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1').with_port(5432) }
   end
@@ -135,6 +137,7 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('grant:test').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234') }
   end
@@ -155,6 +158,7 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('grant:test').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234').with_port('5678') }
   end
@@ -174,13 +178,13 @@ describe 'postgresql::server::grant', type: :define do
       "class {'postgresql::server':}"
     end
 
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it {
-      is_expected.to contain_postgresql_psql('grant:test').with(
-        'command' => %r{GRANT ALL ON TABLE "myschema"."mytable" TO\s* "test"}m,
-        'unless' => %r{SELECT 1 WHERE has_table_privilege\('test',\s*'myschema.mytable', 'INSERT'\)}m,
-      )
-    }
+    it do
+      is_expected.to contain_postgresql_psql('grant:test')
+        .with_command(%r{GRANT ALL ON TABLE "myschema"."mytable" TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE has_table_privilege\('test',\s*'myschema.mytable', 'INSERT'\)}m)
+    end
   end
 
   context 'invalid object_type' do

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -187,6 +187,33 @@ describe 'postgresql::server::grant', type: :define do
     end
   end
 
+  context 'with a role defined' do
+    let :params do
+      {
+        db: 'test',
+        role: 'test',
+        privilege: 'all',
+        object_name: %w[myschema mytable],
+        object_type: 'table',
+      }
+    end
+
+    let :pre_condition do
+      <<-EOS
+      class {'postgresql::server':}
+      postgresql::server::role { 'test': }
+      EOS
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql__server__grant('test') }
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it do
+      is_expected.to contain_postgresql_psql('grant:test') \
+        .that_requires('Postgresql::Server::Role[test]')
+    end
+  end
+
   context 'invalid object_type' do
     let :params do
       {

--- a/spec/unit/defines/server/reassign_owned_by_spec.rb
+++ b/spec/unit/defines/server/reassign_owned_by_spec.rb
@@ -36,8 +36,8 @@ describe 'postgresql::server::reassign_owned_by', type: :define do
 
   it {
     is_expected.to contain_postgresql_psql('reassign_owned_by:test:REASSIGN OWNED BY "test_old_role" TO "test_new_role"')
-      .with('command' => 'REASSIGN OWNED BY "test_old_role" TO "test_new_role"',
-            'onlyif' => %r{SELECT tablename FROM pg_catalog.pg_tables WHERE\s*schemaname NOT IN \('pg_catalog', 'information_schema'\) AND\s*tableowner = 'test_old_role'.*}m)
+      .with_command('REASSIGN OWNED BY "test_old_role" TO "test_new_role"')
+      .with_onlyif(%r{SELECT tablename FROM pg_catalog.pg_tables WHERE\s*schemaname NOT IN \('pg_catalog', 'information_schema'\) AND\s*tableowner = 'test_old_role'.*}m)
       .that_requires('Class[postgresql::server]')
   }
 end

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -61,10 +61,11 @@ describe 'postgresql::server::role', type: :define do
     it { is_expected.to contain_postgresql__server__role('test') }
     it 'has create role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****')
-        .with('command' => "CREATE ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEROLE NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1", 'environment' => 'NEWPGPASSWD=new-pa$s',
-              'unless'  => "SELECT 1 FROM pg_roles WHERE rolname = 'test'", 'port' => '5432',
-              'connect_settings' => { 'PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1',
-                                      'PGUSER' => 'login-user', 'PGPASSWORD' => 'login-pass' })
+        .with_command("CREATE ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEROLE NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1")
+        .with_environment('NEWPGPASSWD=new-pa$s')
+        .with_unless("SELECT 1 FROM pg_roles WHERE rolname = 'test'")
+        .with_port(5432)
+        .with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGUSER' => 'login-user', 'PGPASSWORD' => 'login-pass')
     end
     it 'has alter role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')


### PR DESCRIPTION
While writing https://github.com/puppetlabs/puppetlabs-postgresql/pull/950 I needed verious cleanups. Because that PR is hard to finish, it's best to get these (safe) cleanups in so there's less changes in mid air. This reduces the change of merge conflicts.

See individual commits for the exact changes.