### PR TITLE
(FM-6875) Reduce max_connections when testing

### DIFF
--- a/spec/acceptance/overridden_settings_spec.rb
+++ b/spec/acceptance/overridden_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'postgresql::server', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfa
         },
       },
       config_entries => {
-        max_connections => 200,
+        max_connections => 120,
       },
       pg_hba_rules   => {
         'from_remote_host' => {


### PR DESCRIPTION
The oracle-7 and debian-7 hosts in our CI are failing due to this.