### PR TITLE
Change initdb option '--xlogdir' to '-X' for PG10 compatibility

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -72,7 +72,7 @@ class postgresql::server::initdb {
     $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
     $ic_xlog = $xlogdir ? {
       undef   => $ic_base,
-      default => "${ic_base} --xlogdir '${xlogdir}'"
+      default => "${ic_base} -X '${xlogdir}'"
     }
 
     # The xlogdir need to be present before initdb runs.


### PR DESCRIPTION
initdb in PG10 doesn't accept the --xlogdir option, it has been renamed to --waldir. The short option -X is accepted by all current PG versions.