### PR TITLE
Ignore psqlrc

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
     command = [resource[:psql_path]]
     command.push('-d', resource[:db]) if resource[:db]
     command.push('-p', resource[:port]) if resource[:port]
-    command.push('-t', '-c', '"' + sql.gsub('"', '\"') + '"')
+    command.push('-t', '-X', '-c', '"' + sql.gsub('"', '\"') + '"')
 
     environment = get_environment
 


### PR DESCRIPTION
When psqlrc has custom settings, psql will output lots of unwanted messages and unless will fail. By ignoring psqlrc with the -X option, psql will output only tuples as required by the already present -t option.