### PR TITLE
Enclose schema owner name in double quotes.

### DIFF
--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -51,7 +51,7 @@ define postgresql::server::schema(
 
   if $owner {
     postgresql_psql { "${db}: ALTER SCHEMA \"${schema}\" OWNER TO \"${owner}\"":
-      command => "ALTER SCHEMA \"${schema}\" OWNER TO ${owner}",
+      command => "ALTER SCHEMA \"${schema}\" OWNER TO \"${owner}\"",
       unless  => "SELECT 1 FROM pg_namespace JOIN pg_roles rol ON nspowner = rol.oid WHERE nspname = '${schema}' AND rolname = '${owner}'",
       require => Postgresql_psql["${db}: CREATE SCHEMA \"${schema}\""],
     }


### PR DESCRIPTION
After updating from puppetlabs-postgresql 3.3.2 to 4.9.0 (we cannot go any newer currently) we found that schema owner names containing a dash character ("-") lead to an SQL syntax error in manifests/server/schema.pp (namely in the `"ALTER SCHEMA \"${schema}\" OWNER TO ${owner}"` statement). In 3.3.2 the owner name was enclosed in double quotes: `"AUTHORIZATION \"${owner}\""`

This PR contains a proposed fix. If accepted please backport to 4.9.x.