### PR TITLE
Use package names in catalogue if specified

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,9 +7,8 @@ class postgresql::client (
 ) inherits postgresql::params {
 
   if $package_name != 'UNSET' {
-    package { 'postgresql-client':
+    package { $package_name:
       ensure => $package_ensure,
-      name   => $package_name,
       tag    => 'postgresql',
     }
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -10,9 +10,8 @@ class postgresql::server::install {
     default => $package_ensure,
   }
 
-  package { 'postgresql-server':
+  package { $package_name:
     ensure => $_package_ensure,
-    name   => $package_name,
 
     # This is searched for to create relationships with the package repos, be
     # careful about its removal

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -14,14 +14,13 @@ describe 'postgresql::client', type: :class do
       {
         validcon_script_path: '/opt/bin/my-validate-con.sh',
         package_ensure: 'absent',
-        package_name: 'mypackage',
+        package_name: 'postgresql99-client',
         file_ensure: 'file',
       }
     end
 
     it 'modifies package' do
-      is_expected.to contain_package('postgresql-client').with(ensure: 'absent',
-                                                               name: 'mypackage',
+      is_expected.to contain_package('postgresql99-client').with(ensure: 'absent',
                                                                tag: 'postgresql')
     end
 


### PR DESCRIPTION
I was wondering why my code was getting an error about package name I provided for 'postgresql10-server' missing from the catalogue.

After looking closer I realised it's because the package name used by the module is different to what I specified. This means both `version` and `server_package_name` can't be tested for directly.

globals.pp does a good job of defining the package name and it should be clear from looking there what package name this module will add to the catalogue.