### PR TITLE
Add compatibility for Fedora 28

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -65,6 +65,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
+        /^(28)$/       => '10.4',
         /^(26|27)$/    => '9.6',
         /^(24|25)$/    => '9.5',
         /^(22|23)$/    => '9.4',


### PR DESCRIPTION
Fedora 28 provides postgresql-10.4-1.fc28.

Signed-off-by: John Florian <jflorian@doubledog.org>