### PR TITLE
(MODULES-6542) - Adding SLES 11 & 12 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,6 +62,13 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11 SP1",
+        "12"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",


### PR DESCRIPTION
Currently we are already testing on these platforms and they are compatible, therefore adding as supported OS following product decision. @davinhanlon 