### PR TITLE
(MODULES-7460) - Updating grant table to include INSERT privileges

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -248,6 +248,7 @@ define postgresql::server::grant (
           /^ALL$/,
           /^ALL PRIVILEGES$/,
           /^DELETE$/,
+          /^INSERT$/,
           /^REFERENCES$/,
           /^SELECT$/,
           /^TRIGGER$/,


### PR DESCRIPTION
The `INSERT` parameter has been overlooked when removing legacy validate functions and adding to a case statement. It can be seen in the following commit: https://github.com/puppetlabs/puppetlabs-postgresql/commit/0b676ef3117d47914b82faa502dab1cf134dfe4e in manifests/server/grant.pp on line 193.

Putting `INSERT` back in and adding a test to catch this in the future.