### PR TITLE
(MODULES-7479) Ensure net-tools is installed when testing on Ubuntu 18.04

### DIFF
--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -38,8 +38,8 @@ describe 'postgresql::server::db', unless: UNSUPPORTED_PLATFORMS.include?(fact('
       end
 
       result = shell('psql --version')
-      version = result.stdout.match(%r{\s(\d\.\d)})[1]
-      comment_information_function = if version > '8.1'
+      version = result.stdout.match(%r{\s(\d{1,2}\.\d)})[1]
+      comment_information_function = if version.to_f > 8.1
                                        'shobj_description'
                                      else
                                        'obj_description'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -82,7 +82,9 @@ RSpec.configure do |c|
     end
 
     # net-tools required for netstat utility being used by be_listening
-    if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7' || fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') == '9'
+    if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7' ||
+       fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') == '9' ||
+       fact('osfamily') == 'Debian' && fact('operatingsystemmajrelease') == '18.04'
       pp = <<-EOS
         package { 'net-tools': ensure => installed }
       EOS


### PR DESCRIPTION
The purpose of this pr is to make some small fixes to the test's to allow them to properly run against ubuntu 18.04, support for which was added in:
https://github.com/puppetlabs/puppetlabs-postgresql/pull/1005
While this previous pr contained the majority of changes needed, there were some that were missed and as such this pr has been made to finish them.