### PR TITLE
pdksync - Bump apt dependency to <7.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 6.0.0"
+      "version_requirement": ">= 2.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Bump apt dependency to <7.0.0
pdk version: `1.7.0` 
