### PR TITLE
Parameters `databases` to `postgresql::server` for hiera

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,6 +59,7 @@ class postgresql::server (
   Hash[String, Hash] $roles         = {},
   Hash[String, Any] $config_entries = {},
   Hash[String, Hash] $pg_hba_rules  = {},
+  Hash[String, Hash] $databases     = {},
 
   #Deprecated
   $version                    = undef,
@@ -90,6 +91,12 @@ class postgresql::server (
   -> Class['postgresql::server::config']
   -> Class['postgresql::server::service']
   -> Class['postgresql::server::passwd']
+
+  $databases.each |$databasename, $databases| {
+    postgresql::server::db { $databasename:
+      * => $databases,
+    }
+  }
 
   $roles.each |$rolename, $role| {
     postgresql::server::role { $rolename:


### PR DESCRIPTION
Building on https://github.com/puppetlabs/puppetlabs-postgresql/pull/950

This adds a hash class parameter for simple database/user creation.

An example hiera config would be:
```
name:
  dbname: name_db
  user: name_user
  password: name_pass
  grant: ALL
```