### PR TITLE
Fix provider crashing when some options are set in .psqlrc

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -11,6 +11,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
     end
 
     command = [resource[:psql_path]]
+    command.push('--no-psqlrc')
     command.push('-d', resource[:db]) if resource[:db]
     command.push('-p', resource[:port]) if resource[:port]
     command.push('-t', '-c', '"' + sql.gsub('"', '\"') + '"')

--- a/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       let(:attributes) { { db: 'spec_db' } }
 
       it 'executes with the given psql_path on the given DB' do
-        expect(provider).to receive(:run_command).with(['psql', '-d',
+        expect(provider).to receive(:run_command).with(['psql', '-d', '--no-psqlrc',
                                                         attributes[:db], '-t', '-c', '"SELECT \'something\' as \"Custom column\""'], 'postgres',
                                                        'postgres', {})
 
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       it 'executes with the given psql_path on the given DB' do
         expect(Dir).to receive(:chdir).with(attributes[:cwd]).and_yield
         expect(provider).to receive(:run_command).with([attributes[:psql_path],
-                                                        '-d', attributes[:db], '-t', '-c', '"SELECT \'something\' as \"Custom column\""'],
+                                                        '--no-psqlrc','-d', attributes[:db], '-t', '-c', '"SELECT \'something\' as \"Custom column\""'],
                                                        attributes[:psql_user], attributes[:psql_group], {})
 
         provider.run_sql_command('SELECT \'something\' as "Custom column"')
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       end
 
       it 'executes with the given search_path' do
-        expect(provider).to receive(:run_command).with(['psql', '-t', '-c',
+        expect(provider).to receive(:run_command).with(['psql', '--no-psqlrc','-t', '-c',
                                                         '"set search_path to schema1; SELECT \'something\' as \"Custom column\""'],
                                                        'postgres', 'postgres', {})
 
@@ -62,7 +62,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
       end
 
       it 'executes with the given search_path' do
-        expect(provider).to receive(:run_command).with(['psql', '-t', '-c',
+        expect(provider).to receive(:run_command).with(['psql', '--no-psqlrc','-t', '-c',
                                                         '"set search_path to schema1,schema2; SELECT \'something\' as \"Custom column\""'],
                                                        'postgres', 'postgres',
                                                        {})
@@ -76,6 +76,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
 
     it 'executes with the given port' do
       expect(provider).to receive(:run_command).with(['psql',
+                                                      '--no-psqlrc',
                                                       '-p', '5555',
                                                       '-t', '-c', '"SELECT something"'],
                                                      'postgres', 'postgres', {})
@@ -88,6 +89,7 @@ describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
 
     it 'executes with the given host' do
       expect(provider).to receive(:run_command).with(['psql',
+                                                      '--no-psqlrc',
                                                       '-t', '-c',
                                                       '"SELECT something"'],
                                                      'postgres', 'postgres', 'PGHOST' => '127.0.0.1')


### PR DESCRIPTION
In some cases, like setting `\x auto` or trying to `\echo` anything in .psqlrc will make provider crash:

    Warning: /Stage[main]/Main/Node[some-server]/Postgresql::Server::Role[backup]/Postgresql_psql[ALTER ROLE "backup" NOCREATEROLE]: Skipping because of failed dependencies
    Error: Error executing SQL; psql returned pid 16230 exit 1: 'Expanded display is used automatically.
    server: some-server.example.com
    ERROR:  role "somerole" already exists

passing option to ignore .psqlrc fixes this, and any other changes that might be set up from this file.

We used puppet to change prompt (red on production servers, green on devs) and add hostname to `psql` to eliminate mistakes and it turned out that this module depends on CLI behaviour of psql.

Removing loading the .psqlrc file should make that behaviour more consistent.