### PR TITLE
Strip quotes from role names

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -187,7 +187,7 @@ define postgresql::server::grant (
                 SELECT DISTINCT
                        object_schema,
                        object_name,
-                       (regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[1] AS grantee,
+                       regexp_replace((regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[1],'\"','','g') AS grantee,
                        regexp_split_to_table((regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[2],E'\\s*') AS privs_split
                   FROM (
                    SELECT n.nspname as object_schema,
@@ -221,7 +221,7 @@ define postgresql::server::grant (
                 SELECT DISTINCT
                        object_schema,
                        object_name,
-                       (regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[1] AS grantee,
+                       regexp_replace((regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[1],'\"','','g') AS grantee,
                        regexp_split_to_table((regexp_split_to_array(regexp_replace(privs,E'/.*',''),'='))[2],E'\\s*') AS privs_split
                   FROM (
                    SELECT n.nspname as object_schema,


### PR DESCRIPTION
This resolves a bug in the detection of existing permissions for roles being granted USAGE on ALL SEQUENCES. We found that role names that need to be quoted (like those containing -) will come back from the $custom_unless queries wrapped in double quotes, causing the query, which is limited using the unquoted role name, never to detect the presence of permissions. When the grant is set to 'present' this causes the grant to be applied on every puppet run. When the grant is set to 'absent' this causes the permissions to remain, even though they should be removed. Stripping out the double quotes from the role name within the query resolves the issue.

We have validated this on 9.4+, but I see no reason why it wouldn't work on across the board.