### PR TITLE
(MODULES-3804) Fix sort order of pg_hba_rule entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,12 @@ Specifies a way to uniquely identify this resource, but functionally does nothin
 
 Sets an order for placing the rule in `pg_hba.conf`.
 
+This can be either a string or an integer.
+If it is an integer, it will be converted to a string by zero-padding it to three digits.
+E.g. `42` will be zero-padded to the string `'042'`.
+
+The `pg_hba_rule` fragments are sorted using the `alpha` sorting [order](https://forge.puppet.com/puppetlabs/concat/reference#order).
+
 Default value: 150.
 
 #### `postgresql_version`

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -32,6 +32,13 @@ define postgresql::server::pg_hba_rule(
       fail('You must specify an address property when type is host based')
     }
 
+    if $order =~ Integer {
+      $_order = sprintf('%03d', $order)
+    }
+    else {
+      $_order = $order
+    }
+
     $allowed_auth_methods = $postgresql_version ? {
       '10'  => ['trust', 'reject', 'scram-sha-256', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'bsd'],
       '9.6' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'bsd'],
@@ -55,7 +62,7 @@ define postgresql::server::pg_hba_rule(
     concat::fragment { $fragname:
       target  => $target,
       content => template('postgresql/pg_hba_rule.conf'),
-      order   => $order,
+      order   => $_order,
     }
   }
 }

--- a/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -145,4 +145,93 @@ describe 'postgresql::server::pg_hba_rule', type: :define do
       end
     end
   end
+
+  context 'order' do
+    context 'default' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'local',
+          database: 'all',
+          user: 'all',
+          auth_method: 'ident',
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(order: '150')
+      end
+    end
+
+    context 'string' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'local',
+          database: 'all',
+          user: 'all',
+          auth_method: 'ident',
+          order: '12',
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(order: '12')
+      end
+    end
+
+    context 'short integer' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'local',
+          database: 'all',
+          user: 'all',
+          auth_method: 'ident',
+          order: 12,
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(order: '012')
+      end
+    end
+
+    context 'long integer' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'local',
+          database: 'all',
+          user: 'all',
+          auth_method: 'ident',
+          order: 1234,
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(order: '1234')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `$order`-parameter to `pg_hba_rule` can be either an integer or a
string, but the corresponding `concat`-resource is configured to sort
the entries using alphanumeric sort.

The result is that a `pg_hba_rule` entry with `order => 2` sorts after
an entry with `order => 10`.

This is also a problem with the default `pg_hba_rule` entries, which
uses numeric order values 1, 2, 3, 4, 100 and 101. These are sorted in
the incorrect order (1, 100, 101, 2, 3, 4).

Unfortunately, since string values are allowed in the
`$order`-parameter, we cannot simply change the `concat`-resource to
use numeric sort.

This patch fixes this issue by zero-padding all integer values to
three digits. E.g. 1 becomes `001`, and 10 becomes `010`. This should
work well for integer values from 0 through 999, and works well with
earlier versions of the module which used string values in that range
for the `$order`-parameter.