### PR TITLE
(MODULES-8352) Don't use empty encoding string on initdb

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -69,7 +69,7 @@ class postgresql::server::initdb {
     # We optionally add the locale switch if specified. Older versions of the
     # initdb command don't accept this switch. So if the user didn't pass the
     # parameter, lets not pass the switch at all.
-    $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
+    $ic_base = "${initdb_path} --pgdata '${datadir}'"
     $ic_xlog = $xlogdir ? {
       undef   => $ic_base,
       default => "${ic_base} -X '${xlogdir}'"
@@ -83,9 +83,15 @@ class postgresql::server::initdb {
       $require_before_initdb = [$datadir]
     }
 
-    $ic_locale = $locale ? {
+    # PostgreSQL 11 no longer allows empty encoding
+    $ic_encoding = $encoding ? {
       undef   => $ic_xlog,
-      default => "${ic_xlog} --locale '${locale}'"
+      default => "${ic_xlog} --encoding '${encoding}'"
+    }
+
+    $ic_locale = $locale ? {
+      undef   => $ic_encoding,
+      default => "${ic_encoding} --locale '${locale}'"
     }
 
     $initdb_command = $data_checksums ? {


### PR DESCRIPTION
pgsql 11 no longer allows initdb with an empty encoding string. Only
include the string when $encoding is set.