### PR TITLE
(MODULES-8352) - Fix undef encoding breaking PostgreSQL 11

### DIFF
--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -69,7 +69,12 @@ class postgresql::server::initdb {
     # We optionally add the locale switch if specified. Older versions of the
     # initdb command don't accept this switch. So if the user didn't pass the
     # parameter, lets not pass the switch at all.
-    $ic_base = "${initdb_path} --encoding '${encoding}' --pgdata '${datadir}'"
+    $ic_encoding = $encoding ? {
+      undef => '',
+      default => "--encoding '${ic_encoding}'"
+    }
+
+    $ic_base = "${initdb_path} ${ic_encoding} --pgdata '${datadir}'"
     $ic_xlog = $xlogdir ? {
       undef   => $ic_base,
       default => "${ic_base} -X '${xlogdir}'"


### PR DESCRIPTION
On PostgreSQL 11, the default value for the encoding parameter is undef. When initdb uses this, it throws an error:

```
Notice: /Stage[main]/Postgresql::Server::Initdb/Exec[postgresql_initdb]/returns: initdb: "" is not a valid server encoding name
Error: '/usr/pgsql-11/bin/initdb --encoding '' --pgdata '/var/lib/pgsql/11/data'' returned 1 instead of one of [0]
```

The changes fix this by checking for an encoding value and omitting the argument if it is undef.