### PR TITLE
Fixing https://tickets.puppetlabs.com/browse/MODULES-8535

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -162,7 +162,7 @@ class postgresql::server::config {
   }
 
   if $::osfamily == 'RedHat' {
-    if ${version} =~ /^9\./ {
+    if $version =~ /^9\./ {
       $include_file = "postgresql-${version}"
     } else {
       $include_file = "postgresql" # 10+ does not append version number

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -162,11 +162,7 @@ class postgresql::server::config {
   }
 
   if $::osfamily == 'RedHat' {
-    if $version =~ /^9\./ {
-      $include_file = "postgresql-${version}"
-    } else {
-      $include_file = "postgresql" # 10+ does not append version number
-    }    
+    $include_file = "postgresql-${version}"
     if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       # Template uses:
       # - $::operatingsystem

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -162,6 +162,11 @@ class postgresql::server::config {
   }
 
   if $::osfamily == 'RedHat' {
+    if ${version} =~ /^9\./ {
+      $include_file = "postgresql-${version}"
+    } else {
+      $include_file = "postgresql" # 10+ does not append version number
+    }    
     if $::operatingsystemrelease =~ /^7/ or $::operatingsystem == 'Fedora' {
       # Template uses:
       # - $::operatingsystem

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -27,7 +27,7 @@ describe 'postgresql::server::config', type: :class do
     end
     it 'has the correct systemd-override file #content' do
       is_expected.to contain_file('systemd-override') \
-        .with_content(%r{.include \/usr\/lib\/systemd\/system\/postgresql.service})
+        .with_content(%r{.include \/usr\/lib\/systemd\/system\/postgresql-\d[.]\d.service})
     end
 
     describe 'with manage_package_repo => true and a version' do

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,9 +1,9 @@
 <%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
-.include /usr/lib64/systemd/system/<%= @service_name %>.service
+.include /usr/lib64/systemd/system/<%= @include_file %>.service
 <%- elsif scope.lookupvar('::operatingsystem') == 'Fedora' -%>
-.include /lib/systemd/system/<%= @service_name %>.service
+.include /lib/systemd/system/<%= @include_file %>.service
 <% else -%>
-.include /usr/lib/systemd/system/<%= @service_name %>.service
+.include /usr/lib/systemd/system/<%= @include_file %>.service
 <% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,9 +1,11 @@
 <%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
-.include /usr/lib64/systemd/system/<%= @include_file %>.service
+.include /usr/lib64/systemd/system/<%= @service_name %>.service
 <%- elsif scope.lookupvar('::operatingsystem') == 'Fedora' -%>
-.include /lib/systemd/system/<%= @include_file %>.service
-<% else -%>
+.include /lib/systemd/system/<%= @service_name %>.service
+<%- elsif scope.lookupvar('::operatingsystem') == 'CentOS' -%>
 .include /usr/lib/systemd/system/<%= @include_file %>.service
+<% else -%>
+.include /usr/lib/systemd/system/<%= @service_name %>.service
 <% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>


### PR DESCRIPTION
When using postgres::globals::service_name  for installation of postgres 9.x, the resulting .service file in /etd/systemd/system/ contains a wrong include command - the path includes uses ${service_name} which could be something arbitrary. It must use postgresql-${version} for 9.x and just postgresql for 10+