### PR TITLE
(MODULES-8553) Fix dependency on apt by explicitly using 'puppetlabs-postgresql' as tag

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -27,6 +27,6 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
     },
   }
 
-  Apt::Source['apt.postgresql.org']->Package<|tag == 'postgresql'|>
+  Apt::Source['apt.postgresql.org']->Package<|tag == 'puppetlabs-postgresql'|>
   Class['Apt::Update'] -> Package<|tag == 'postgresql'|>
 }


### PR DESCRIPTION
Updating to explicitly call puppetlabs-postgresql as a tag for apt to avoid dependency conflicts.