### PR TITLE
(MODULES-8553) Further cleanup for package tag issues

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -10,7 +10,7 @@ class postgresql::client (
     package { 'postgresql-client':
       ensure => $package_ensure,
       name   => $package_name,
-      tag    => 'postgresql',
+      tag    => 'puppetlabs-postgresql',
     }
   }
 

--- a/manifests/lib/devel.pp
+++ b/manifests/lib/devel.pp
@@ -13,7 +13,7 @@ class postgresql::lib::devel(
   package { 'postgresql-devel':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
   if $link_pg_config {

--- a/manifests/lib/docs.pp
+++ b/manifests/lib/docs.pp
@@ -8,7 +8,7 @@ class postgresql::lib::docs (
   package { 'postgresql-docs':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
 }

--- a/manifests/lib/java.pp
+++ b/manifests/lib/java.pp
@@ -8,7 +8,7 @@ class postgresql::lib::java (
   package { 'postgresql-jdbc':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
 }

--- a/manifests/lib/perl.pp
+++ b/manifests/lib/perl.pp
@@ -8,6 +8,7 @@ class postgresql::lib::perl(
   package { 'perl-DBD-Pg':
     ensure => $package_ensure,
     name   => $package_name,
+    tag    => 'puppetlabs-postgresql',
   }
 
 }

--- a/manifests/lib/python.pp
+++ b/manifests/lib/python.pp
@@ -8,6 +8,7 @@ class postgresql::lib::python(
   package { 'python-psycopg2':
     ensure => $package_ensure,
     name   => $package_name,
+    tag    => 'puppetlabs-postgresql',
   }
 
 }

--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -28,5 +28,5 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
   }
 
   Apt::Source['apt.postgresql.org']->Package<|tag == 'puppetlabs-postgresql'|>
-  Class['Apt::Update'] -> Package<|tag == 'postgresql'|>
+  Class['Apt::Update'] -> Package<|tag == 'puppetlabs-postgresql'|>
 }

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -32,5 +32,5 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
     proxy    => $postgresql::repo::proxy,
   }
 
-  Yumrepo['yum.postgresql.org'] -> Package<|tag == 'postgresql'|>
+  Yumrepo['yum.postgresql.org'] -> Package<|tag == 'puppetlabs-postgresql'|>
 }

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -11,7 +11,7 @@ class postgresql::server::contrib (
   package { 'postgresql-contrib':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
   anchor { 'postgresql::server::contrib::start': }

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -87,7 +87,7 @@ define postgresql::server::extension (
 
     ensure_packages($package_name, {
       ensure  => $_package_ensure,
-      tag     => 'postgresql',
+      tag     => 'puppetlabs-postgresql',
       require => $package_require,
       before  => $package_before,
     })

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -16,7 +16,7 @@ class postgresql::server::install {
 
     # This is searched for to create relationships with the package repos, be
     # careful about its removal
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
 }

--- a/manifests/server/plperl.pp
+++ b/manifests/server/plperl.pp
@@ -7,7 +7,7 @@ class postgresql::server::plperl(
   package { 'postgresql-plperl':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
   anchor { 'postgresql::server::plperl::start': }

--- a/manifests/server/plpython.pp
+++ b/manifests/server/plpython.pp
@@ -7,7 +7,7 @@ class postgresql::server::plpython(
   package { 'postgresql-plpython':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
   anchor { 'postgresql::server::plpython::start': }

--- a/manifests/server/postgis.pp
+++ b/manifests/server/postgis.pp
@@ -7,7 +7,7 @@ class postgresql::server::postgis (
   package { 'postgresql-postgis':
     ensure => $package_ensure,
     name   => $package_name,
-    tag    => 'postgresql',
+    tag    => 'puppetlabs-postgresql',
   }
 
   anchor { 'postgresql::server::postgis::start': }

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -22,7 +22,7 @@ describe 'postgresql::client', type: :class do
     it 'modifies package' do
       is_expected.to contain_package('postgresql-client').with(ensure: 'absent',
                                                                name: 'mypackage',
-                                                               tag: 'postgresql')
+                                                               tag: 'puppetlabs-postgresql')
     end
 
     it 'has specified validate connexion' do
@@ -35,7 +35,7 @@ describe 'postgresql::client', type: :class do
 
   describe 'with no parameters' do
     it 'creates package with postgresql tag' do
-      is_expected.to contain_package('postgresql-client').with(tag: 'postgresql')
+      is_expected.to contain_package('postgresql-client').with(tag: 'puppetlabs-postgresql')
     end
   end
 

--- a/spec/unit/classes/lib/java_spec.rb
+++ b/spec/unit/classes/lib/java_spec.rb
@@ -14,7 +14,7 @@ describe 'postgresql::lib::java', type: :class do
       is_expected.to contain_package('postgresql-jdbc').with(
         name: 'libpostgresql-jdbc-java',
         ensure: 'present',
-        tag: 'postgresql',
+        tag: 'puppetlabs-postgresql',
       )
     }
   end
@@ -32,7 +32,7 @@ describe 'postgresql::lib::java', type: :class do
       is_expected.to contain_package('postgresql-jdbc').with(
         name: 'postgresql-jdbc',
         ensure: 'present',
-        tag: 'postgresql',
+        tag: 'puppetlabs-postgresql',
       )
     }
     describe 'when parameters are supplied' do
@@ -44,7 +44,7 @@ describe 'postgresql::lib::java', type: :class do
         is_expected.to contain_package('postgresql-jdbc').with(
           name: 'somepackage',
           ensure: 'latest',
-          tag: 'postgresql',
+          tag: 'puppetlabs-postgresql',
         )
       }
     end

--- a/spec/unit/classes/lib/pgdocs_spec.rb
+++ b/spec/unit/classes/lib/pgdocs_spec.rb
@@ -14,7 +14,7 @@ describe 'postgresql::lib::docs', type: :class do
       is_expected.to contain_package('postgresql-docs').with(
         name: 'postgresql-docs',
         ensure: 'present',
-        tag: 'postgresql',
+        tag: 'puppetlabs-postgresql',
       )
     }
     describe 'when parameters are supplied' do
@@ -26,7 +26,7 @@ describe 'postgresql::lib::docs', type: :class do
         is_expected.to contain_package('postgresql-docs').with(
           name: 'somepackage',
           ensure: 'latest',
-          tag: 'postgresql',
+          tag: 'puppetlabs-postgresql',
         )
       }
     end

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -28,13 +28,13 @@ describe 'postgresql::server::contrib', type: :class do
     it 'creates package with correct params' do
       is_expected.to contain_package('postgresql-contrib').with(ensure: 'absent',
                                                                 name: 'mypackage',
-                                                                tag: 'postgresql')
+                                                                tag: 'puppetlabs-postgresql')
     end
   end
 
   describe 'with no parameters' do
     it 'creates package with postgresql tag' do
-      is_expected.to contain_package('postgresql-contrib').with(tag: 'postgresql')
+      is_expected.to contain_package('postgresql-contrib').with(tag: 'puppetlabs-postgresql')
     end
   end
 

--- a/spec/unit/classes/server/plperl_spec.rb
+++ b/spec/unit/classes/server/plperl_spec.rb
@@ -21,7 +21,7 @@ describe 'postgresql::server::plperl', type: :class do
     it { is_expected.to contain_class('postgresql::server::plperl') }
     it 'creates package' do
       is_expected.to contain_package('postgresql-plperl').with(ensure: 'present',
-                                                               tag: 'postgresql')
+                                                               tag: 'puppetlabs-postgresql')
     end
   end
 
@@ -37,7 +37,7 @@ describe 'postgresql::server::plperl', type: :class do
     it 'creates package with correct params' do
       is_expected.to contain_package('postgresql-plperl').with(ensure: 'absent',
                                                                name: 'mypackage',
-                                                               tag: 'postgresql')
+                                                               tag: 'puppetlabs-postgresql')
     end
   end
 end

--- a/spec/unit/classes/server/plpython_spec.rb
+++ b/spec/unit/classes/server/plpython_spec.rb
@@ -22,7 +22,7 @@ describe 'postgresql::server::plpython', type: :class do
     it { is_expected.to contain_class('postgresql::server::plpython') }
     it 'creates package' do
       is_expected.to contain_package('postgresql-plpython').with(ensure: 'present',
-                                                                 tag: 'postgresql')
+                                                                 tag: 'puppetlabs-postgresql')
     end
   end
 
@@ -38,7 +38,7 @@ describe 'postgresql::server::plpython', type: :class do
     it 'creates package with correct params' do
       is_expected.to contain_package('postgresql-plpython').with(ensure: 'absent',
                                                                  name: 'mypackage',
-                                                                 tag: 'postgresql')
+                                                                 tag: 'puppetlabs-postgresql')
     end
   end
 end

--- a/spec/unit/classes/server/postgis_spec.rb
+++ b/spec/unit/classes/server/postgis_spec.rb
@@ -28,13 +28,13 @@ describe 'postgresql::server::postgis', type: :class do
     it 'creates package with correct params' do
       is_expected.to contain_package('postgresql-postgis').with(ensure: 'absent',
                                                                 name: 'mypackage',
-                                                                tag: 'postgresql')
+                                                                tag: 'puppetlabs-postgresql')
     end
   end
 
   describe 'with no parameters' do
     it 'creates package with postgresql tag' do
-      is_expected.to contain_package('postgresql-postgis').with(tag: 'postgresql')
+      is_expected.to contain_package('postgresql-postgis').with(tag: 'puppetlabs-postgresql')
     end
   end
 end


### PR DESCRIPTION
Update all this modules tagged packages to use 'puppetlabs-postgresql' instead of just 'postgresql' which is ambiguous and causing dependancy issues.