### PR TITLE
change username/group/datadir defaults for FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,15 +205,15 @@ class postgresql::params inherits postgresql::globals {
 
     'FreeBSD': {
       case $version {
-        '96', '10': {
-          $user                 = pick($user, 'postgres')
-          $group                = pick($group, 'postgres')
-          $datadir              = pick($datadir, "/var/db/postgres/data${version}")
-        }
-        default: {
+        '94', '95': {
           $user                 = pick($user, 'pgsql')
           $group                = pick($group, 'pgsql')
           $datadir              = pick($datadir, '/usr/local/pgsql/data')
+        }
+        default: {
+          $user                 = pick($user, 'postgres')
+          $group                = pick($group, 'postgres')
+          $datadir              = pick($datadir, "/var/db/postgres/data${version}")
         }
       }
 


### PR DESCRIPTION
old (9.4, 9.5) PostgreSQL packages on FreeBSD use other $user, $group and $datadir
settings. Currently the latest version available is 11.
Instead of listing new PostgreSQL versions for new settings swap old settings (9.4, 9.5) and defaults