### PR TITLE
Add Fedora 30 compatibility

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -65,6 +65,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
+        /^(30)$/       => '11.2',
         /^(29)$/       => '10.6',
         /^(28)$/       => '10.4',
         /^(26|27)$/    => '9.6',


### PR DESCRIPTION
Fedora 30 includes postgresql 11.2 packages.

