### PR TITLE
Bump dependency, because of new major release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 7.0.0"
+      "version_requirement": ">= 2.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
The version needs to be upgraded because there is a new major release of ```puppetlabs-apt```. Otherwise there will be problems with Travis CI builds, because ```puppetlabs-postgresql``` has a dependency on ```puppetlabs-apt 6.3.0```, while other modules already want to use ```puppetlabs-apt 7.0.0```.

For example:
```
ubuntu1404-64-1 08:55:05$ puppet module install puppetlabs-postgresql -v 5.12.1
  Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  Notice: Downloading from https://forgeapi.puppet.com ...
  Notice: Installing -- do not interrupt ...
  /etc/puppetlabs/code/environments/production/modules
  └─┬ puppetlabs-postgresql (v5.12.1)
    ├─┬ puppetlabs-apt (v6.3.0)
    │ └── puppetlabs-translate (v1.2.0)
    ├── puppetlabs-concat (v5.3.0)
    └── puppetlabs-stdlib (v5.2.0)
...
Failure/Error: install_module_dependencies_on(hosts)
Beaker::Host::CommandFailure:
  Host 'ubuntu1404-64-1' exited with 1 running:
   puppet module install puppetlabs-apt -v 7.0.0
  Last 10 lines of output were:
  	Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  	Error: Could not install module 'puppetlabs-apt' (v7.0.0)
  	  Module 'puppetlabs-apt' (v6.3.0) is already installed
  	    Use `puppet module upgrade` to install a different version
  	    Use `puppet module install --force` to re-install only this module
``` 