### PR TITLE
Support current version of puppetlabs/apt.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 7.0.0"
+      "version_requirement": ">= 2.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Modifies [metadata](https://github.com/puppetlabs/puppetlabs-postgresql/tree/master/metadata.json) to fix dependency errors when used with the current version of [puppetlabs-apt](https://github.com/puppetlabs/puppetlabs-apt/blob/master/metadata.json#L3).