### PR TITLE
Fix/directory defined twice

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,11 +1,11 @@
 # @summary Class for setting cross-class global overrides.
 #
 # @note
-#   Most server-specific defaults should be overridden in the postgresql::server class. 
+#   Most server-specific defaults should be overridden in the postgresql::server class.
 #   This class should be used only if you are using a non-standard OS, or if you are changing elements that can only be changed here, such as version or manage_package_repo.
 #
 #
-# @param client_package_name  Overrides the default PostgreSQL client package name.    
+# @param client_package_name  Overrides the default PostgreSQL client package name.
 # @param server_package_name Overrides the default PostgreSQL server package name.
 # @param contrib_package_name Overrides the default PostgreSQL contrib package name.
 # @param devel_package_name Overrides the default PostgreSQL devel package name.
@@ -15,7 +15,7 @@
 # @param plperl_package_name Overrides the default PostgreSQL PL/Perl package name.
 # @param plpython_package_name Overrides the default PostgreSQL PL/Python package name.
 # @param python_package_name Overrides the default PostgreSQL Python package name.
-# @param postgis_package_name Overrides the default PostgreSQL PostGIS package name.     
+# @param postgis_package_name Overrides the default PostgreSQL PostGIS package name.
 #
 # @param service_name Overrides the default PostgreSQL service name.
 # @param service_provider Overrides the default PostgreSQL service provider.
@@ -31,50 +31,54 @@
 # @param pg_ident_conf_path Specifies the path to your pg_ident.conf file.
 # @param postgresql_conf_path Sets the path to your postgresql.conf file.
 # @param recovery_conf_path Path to your recovery.conf file.
-# @param default_connect_settings Default connection settings. 
+# @param default_connect_settings Default connection settings.
 #
-# @param pg_hba_conf_defaults Disables the defaults supplied with the module for pg_hba.conf if set to false. 
+# @param pg_hba_conf_defaults Disables the defaults supplied with the module for pg_hba.conf if set to false.
 #
-# @param datadir 
+# @param datadir
 #    Overrides the default PostgreSQL data directory for the target platform.
-#    Changing the datadir after installation causes the server to come to a full stop before making the change. 
-#    For Red Hat systems, the data directory must be labeled appropriately for SELinux. 
+#    Changing the datadir after installation causes the server to come to a full stop before making the change.
+#    For Red Hat systems, the data directory must be labeled appropriately for SELinux.
 #    On Ubuntu, you must explicitly set needs_initdb = true to allow Puppet to initialize the database in the new datadir (needs_initdb defaults to true on other systems).
 #    Warning! If datadir is changed from the default, Puppet does not manage purging of the original data directory, which causes it to fail if the data directory is changed back to the original
-# 
-# @param confdir Overrides the default PostgreSQL configuration directory for the target platform.                  
+#
+# @param confdir Overrides the default PostgreSQL configuration directory for the target platform.
 # @param bindir Overrides the default PostgreSQL binaries directory for the target platform.
-# @param xlogdir Overrides the default PostgreSQL xlog directory.                 
+# @param xlogdir Overrides the default PostgreSQL xlog directory.
 # @param logdir Overrides the default PostgreSQL log directory.
-# @param log_line_prefix Overrides the default PostgreSQL log prefix.          
+# @param log_line_prefix Overrides the default PostgreSQL log prefix.
 #
 # @param user Overrides the default PostgreSQL super user and owner of PostgreSQL related files in the file system.
 # @param group Overrides the default postgres user group to be used for related files in the file system.
 #
-# @param version The version of PostgreSQL to install and manage.                 
-# @param postgis_version Defines the version of PostGIS to install, if you install PostGIS.         
-# @param repo_proxy Sets the proxy option for the official PostgreSQL yum-repositories only. 
+# @param version The version of PostgreSQL to install and manage.
+# @param postgis_version Defines the version of PostGIS to install, if you install PostGIS.
+# @param repo_proxy Sets the proxy option for the official PostgreSQL yum-repositories only.
 #
 # @param repo_baseurl Sets the baseurl for the PostgreSQL repository. Useful if you host your own mirror of the repository.
 #
-# @param needs_initdb Explicitly calls the initdb operation after the server package is installed and before the PostgreSQL service is started.            
+# @param needs_initdb Explicitly calls the initdb operation after the server package is installed and before the PostgreSQL service is started.
 #
-# @param encoding 
-#   Sets the default encoding for all databases created with this module. 
+# @param encoding
+#   Sets the default encoding for all databases created with this module.
 #   On certain operating systems, this is also used during the template1 initialization, so it becomes a default outside of the module as well.
-# @param locale 
+# @param locale
 #   Sets the default database locale for all databases created with this module.
 #   On certain operating systems, this is also used during the template1 initialization, so it becomes a default outside of the module as well.
 #   On Debian, you'll need to ensure that the 'locales-all' package is installed for full functionality of PostgreSQL.
-# @param data_checksums 
+# @param data_checksums
 #   Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
 #   Warning: This option is used during initialization by initdb, and cannot be changed later.
-#         
+#
 # @param timezone Sets the default timezone of the postgresql server. The postgresql built-in default is taking the systems timezone information.
 #
 # @param manage_pg_hba_conf Allow Puppet to manage the pg_hba.conf file.
 # @param manage_pg_ident_conf Allow Puppet to manage the pg_ident.conf file.
 # @param manage_recovery_conf Allow Puppet to manage the recovery.conf file.
+#
+# @param manage_datadir Set to false if you have file{ $datadir: } already defined
+# @param manage_logdir Set to false if you have file{ $logdir: } already defined
+# @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
 #
 # @param manage_package_repo Sets up official PostgreSQL repositories on your host if set to true.
 # @param module_workdir Specifies working directory under which the psql command should be executed. May need to specify if '/tmp' is on volume mounted with noexec option.
@@ -117,6 +121,9 @@ class postgresql::globals (
   $xlogdir                  = undef,
   $logdir                   = undef,
   $log_line_prefix          = undef,
+  $manage_datadir           = undef,
+  $manage_logdir            = undef,
+  $manage_xlogdir           = undef,
 
   $user                     = undef,
   $group                    = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,10 @@ class postgresql::params inherits postgresql::globals {
   $package_ensure             = 'present'
   $module_workdir             = pick($module_workdir,'/tmp')
 
+  $manage_datadir             = true
+  $manage_logdir              = true
+  $manage_xlogdir             = true
+
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {
     'RedHat', 'Linux': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -63,13 +63,17 @@
 # @param manage_pg_hba_conf Boolean. Whether to manage the pg_hba.conf.
 # @param manage_pg_ident_conf Boolean. Overwrites the pg_ident.conf file.
 # @param manage_recovery_conf Boolean. Specifies whether or not manage the recovery.conf.
-# @param module_workdir Working directory for the PostgreSQL module 
+# @param module_workdir Working directory for the PostgreSQL module
+#
+# @param manage_datadir Set to false if you have file{ $datadir: } already defined
+# @param manage_logdir Set to false if you have file{ $logdir: } already defined
+# @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
 #
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
 #
-# @param version Sets PostgreSQL version 
+# @param version Sets PostgreSQL version
 #
 #
 class postgresql::server (
@@ -128,6 +132,10 @@ class postgresql::server (
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
   $module_workdir             = $postgresql::params::module_workdir,
+
+  $manage_datadir             = $postgresql::params::manage_datadir,
+  $manage_logdir              = $postgresql::params::manage_logdir,
+  $manage_xlogdir             = $postgresql::params::manage_xlogdir,
 
   Hash[String, Hash] $roles         = {},
   Hash[String, Any] $config_entries = {},

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -38,16 +38,15 @@ class postgresql::server::initdb {
 
   if($manage_datadir) {
     # Make sure the data directory exists, and has the correct permissions.
-    file { "postgresql_${datadir}":
+    file { $datadir:
       ensure  => directory,
-      path    => $datadir,
       owner   => $user,
       group   => $group,
       mode    => '0700',
       seltype => $seltype,
     }
   } else {
-    # change already defined datadir
+    # changes an already defined datadir
     File <| title == $datadir |> {
       ensure  => directory,
       owner   => $user,
@@ -68,7 +67,7 @@ class postgresql::server::initdb {
         seltype => $seltype,
       }
     } else {
-      # change already defined xlogdir
+      # changes an already defined xlogdir
       File <| title == $xlogdir |>  {
         ensure  => directory,
         owner   => $user,
@@ -89,7 +88,7 @@ class postgresql::server::initdb {
         seltype => $logdir_type,
       }
     } else {
-      # change already defined logdir
+      # changes an already defined logdir
       File <| title == $logdir |> {
         ensure  => directory,
         owner   => $user,

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -5,6 +5,9 @@ class postgresql::server::initdb {
   $datadir        = $postgresql::server::datadir
   $xlogdir        = $postgresql::server::xlogdir
   $logdir         = $postgresql::server::logdir
+  $manage_datadir = $postgresql::server::manage_datadir
+  $manage_logdir  = $postgresql::server::manage_logdir
+  $manage_xlogdir = $postgresql::server::manage_xlogdir
   $encoding       = $postgresql::server::encoding
   $locale         = $postgresql::server::locale
   $data_checksums = $postgresql::server::data_checksums
@@ -33,18 +36,19 @@ class postgresql::server::initdb {
     $logdir_type = undef
   }
 
-  # Make sure the data directory exists, and has the correct permissions.
-  file { $datadir:
-    ensure  => directory,
-    owner   => $user,
-    group   => $group,
-    mode    => '0700',
-    seltype => $seltype,
-  }
-
-  if($xlogdir) {
-    # Make sure the xlog directory exists, and has the correct permissions.
-    file { $xlogdir:
+  if($manage_datadir) {
+    # Make sure the data directory exists, and has the correct permissions.
+    file { "postgresql_${datadir}":
+      ensure  => directory,
+      path    => $datadir,
+      owner   => $user,
+      group   => $group,
+      mode    => '0700',
+      seltype => $seltype,
+    }
+  } else {
+    # change already defined datadir
+    File <| title == $datadir |> {
       ensure  => directory,
       owner   => $user,
       group   => $group,
@@ -53,13 +57,45 @@ class postgresql::server::initdb {
     }
   }
 
+  if($xlogdir) {
+    if($manage_xlogdir) {
+      # Make sure the xlog directory exists, and has the correct permissions.
+      file { $xlogdir:
+        ensure  => directory,
+        owner   => $user,
+        group   => $group,
+        mode    => '0700',
+        seltype => $seltype,
+      }
+    } else {
+      # change already defined xlogdir
+      File <| title == $xlogdir |>  {
+        ensure  => directory,
+        owner   => $user,
+        group   => $group,
+        mode    => '0700',
+        seltype => $seltype,
+      }
+    }
+  }
+
   if($logdir) {
-    # Make sure the log directory exists, and has the correct permissions.
-    file { $logdir:
-      ensure  => directory,
-      owner   => $user,
-      group   => $group,
-      seltype => $logdir_type,
+    if($manage_logdir) {
+      # Make sure the log directory exists, and has the correct permissions.
+      file { $logdir:
+        ensure  => directory,
+        owner   => $user,
+        group   => $group,
+        seltype => $logdir_type,
+      }
+    } else {
+      # change already defined logdir
+      File <| title == $logdir |> {
+        ensure  => directory,
+        owner   => $user,
+        group   => $group,
+        seltype => $logdir_type,
+      }
     }
   }
 

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -1,11 +1,13 @@
-# @summary This module creates tablespace. 
+# @summary This module creates tablespace.
 #
 # @param location Specifies the path to locate this tablespace.
+# @param manage_location Set to false if you have file{ $location: } already defined
 # @param owner Specifies the default owner of the tablespace.
 # @param spcname Specifies the name of the tablespace.
 # @param connect_settings Specifies a hash of environment variables used when connecting to a remote server.
 define postgresql::server::tablespace(
   $location,
+  $manage_location = true,
   $owner   = undef,
   $spcname = $title,
   $connect_settings = $postgresql::server::default_connect_settings,
@@ -31,15 +33,28 @@ define postgresql::server::tablespace(
     cwd              => $module_workdir,
   }
 
-  file { $location:
-    ensure  => directory,
-    owner   => $user,
-    group   => $group,
-    mode    => '0700',
-    seluser => 'system_u',
-    selrole => 'object_r',
-    seltype => 'postgresql_db_t',
-    require => Class['postgresql::server'],
+  if($manage_location) {
+    file { $location:
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      mode    => '0700',
+      seluser => 'system_u',
+      selrole => 'object_r',
+      seltype => 'postgresql_db_t',
+      require => Class['postgresql::server'],
+    }
+  } else {
+    File <| title == $location |> {
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      mode    => '0700',
+      seluser => 'system_u',
+      selrole => 'object_r',
+      seltype => 'postgresql_db_t',
+      require => Class['postgresql::server'],
+    }
   }
 
   postgresql_psql { "CREATE TABLESPACE \"${spcname}\"":

--- a/spec/unit/classes/server/initdb_spec.rb
+++ b/spec/unit/classes/server/initdb_spec.rb
@@ -21,17 +21,25 @@ describe 'postgresql::server::initdb', type: :class do
 
     it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
 
-    context 'with manage_datadir set to false' do
+    context 'with (log,manage,xlog)_datadir set to false' do
       let :pre_condition do
         "
         class {'postgresql::server':
+          manage_logdir  => false,
           manage_datadir => false,
+          manage_xlogdir => false,
+          logdir         => '/var/lib/pgsql/data/log',
+          xlogdir        => '/var/lib/pgsql/data/xlog',
         }
         file {'/var/lib/pgsql/data': ensure => 'directory'}
+        file {'/var/lib/pgsql/data/log': ensure => 'directory'}
+        file {'/var/lib/pgsql/data/xlog': ensure => 'directory'}
         "
       end
 
       it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
+      it { is_expected.to contain_file('/var/lib/pgsql/data/log').with_ensure('directory') }
+      it { is_expected.to contain_file('/var/lib/pgsql/data/xlog').with_ensure('directory') }
     end
   end
 

--- a/spec/unit/classes/server/initdb_spec.rb
+++ b/spec/unit/classes/server/initdb_spec.rb
@@ -20,7 +20,21 @@ describe 'postgresql::server::initdb', type: :class do
     end
 
     it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
+
+    context 'with manage_datadir set to false' do
+      let :pre_condition do
+        "
+        class {'postgresql::server':
+          manage_datadir => false,
+        }
+        file {'/var/lib/pgsql/data': ensure => 'directory'}
+        "
+      end
+
+      it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
+    end
   end
+
   describe 'on Amazon' do
     let :facts do
       {
@@ -36,6 +50,19 @@ describe 'postgresql::server::initdb', type: :class do
     end
 
     it { is_expected.to contain_file('/var/lib/pgsql92/data').with_ensure('directory') }
+
+    context 'with manage_datadir set to false' do
+      let :pre_condition do
+        "
+        class {'postgresql::server':
+          manage_datadir => false,
+        }
+        file {'/var/lib/pgsql92/data': ensure => 'directory'}
+        "
+      end
+
+      it { is_expected.to contain_file('/var/lib/pgsql92/data').with_ensure('directory') }
+    end
   end
 
   describe 'exec with module_workdir => /var/tmp' do

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -162,7 +162,9 @@ describe 'postgresql::server', type: :class do
 
     it 'contains the correct package version' do
       is_expected.to contain_class('postgresql::repo').with_version('99.5')
-      is_expected.to contain_file('/var/lib/postgresql/99.5/main')
+      is_expected.to contain_file('/var/lib/postgresql/99.5/main') # FIXME: be more precise
+      is_expected.to contain_concat('/etc/postgresql/99.5/main/pg_hba.conf') # FIXME: be more precise
+      is_expected.to contain_concat('/etc/postgresql/99.5/main/pg_ident.conf') # FIXME: be more precise
     end
   end
 

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -26,6 +26,7 @@ describe 'postgresql::server', type: :class do
   describe 'with no parameters' do
     it { is_expected.to contain_class('postgresql::params') }
     it { is_expected.to contain_class('postgresql::server') }
+    it { is_expected.to contain_file('/var/lib/postgresql/9.4/main') }
     it {
       is_expected.to contain_exec('postgresql_reload').with('command' => 'service postgresql reload')
     }
@@ -161,6 +162,7 @@ describe 'postgresql::server', type: :class do
 
     it 'contains the correct package version' do
       is_expected.to contain_class('postgresql::repo').with_version('99.5')
+      is_expected.to contain_file('/var/lib/postgresql/99.5/main')
     end
   end
 

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -144,6 +144,8 @@ describe 'postgresql::server::extension', type: :define do
     }
   end
 
+  it { is_expected.to contain_file('/var/lib/postgresql/8.4/main') }
+
   context 'with mandatory arguments only' do
     it {
       is_expected.to contain_postgresql_psql('template_postgis2: CREATE EXTENSION "postgis"')

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -144,7 +144,9 @@ describe 'postgresql::server::extension', type: :define do
     }
   end
 
-  it { is_expected.to contain_file('/var/lib/postgresql/8.4/main') }
+  it { is_expected.to contain_file('/var/lib/postgresql/8.4/main') } # FIXME: be more precise
+  it { is_expected.to contain_concat('/etc/postgresql/8.4/main/pg_hba.conf') } # FIXME: be more precise
+  it { is_expected.to contain_concat('/etc/postgresql/8.4/main/pg_ident.conf') } # FIXME: be more precise
 
   context 'with mandatory arguments only' do
     it {

--- a/spec/unit/defines/server/tablespace_spec.rb
+++ b/spec/unit/defines/server/tablespace_spec.rb
@@ -27,6 +27,7 @@ describe 'postgresql::server::tablespace', type: :define do
     "class {'postgresql::server':}"
   end
 
+  it { is_expected.to contain_file('/srv/data/foo').with_ensure('directory') }
   it { is_expected.to contain_postgresql__server__tablespace('test') }
   it { is_expected.to contain_postgresql_psql('CREATE TABLESPACE "test"').that_requires('Class[postgresql::server::service]') }
 
@@ -40,4 +41,21 @@ describe 'postgresql::server::tablespace', type: :define do
 
     it { is_expected.to contain_postgresql_psql('ALTER TABLESPACE "test" OWNER TO "test_owner"') }
   end
+
+  context 'with manage_location set to false' do
+    let :params do
+      {
+        location: '/srv/data/foo',
+        manage_location: false,
+      }
+    end
+    let :pre_condition do
+      "
+      class {'postgresql::server':}
+      file {'/srv/data/foo': ensure => 'directory'}
+      "
+    end
+    it { is_expected.to contain_file('/srv/data/foo').with_ensure('directory') }
+  end
+
 end

--- a/spec/unit/defines/server/tablespace_spec.rb
+++ b/spec/unit/defines/server/tablespace_spec.rb
@@ -49,13 +49,14 @@ describe 'postgresql::server::tablespace', type: :define do
         manage_location: false,
       }
     end
+
     let :pre_condition do
       "
       class {'postgresql::server':}
       file {'/srv/data/foo': ensure => 'directory'}
       "
     end
+
     it { is_expected.to contain_file('/srv/data/foo').with_ensure('directory') }
   end
-
 end


### PR DESCRIPTION
Adds parameters to allow **datadir/logdir/xlogdir** to be managed by another class and avoid a **duplicate declaration**.

Example use case: **$datadir** is a mounted filesystem managed by Puppet, so **file { $datadir: ... }** has to be defined outside of **PostgreSQL** scope.
