### PR TITLE
Enable suport for JIT in PostgreSQL >= 11

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,7 +15,8 @@
 # @param plperl_package_name Overrides the default PostgreSQL PL/Perl package name.
 # @param plpython_package_name Overrides the default PostgreSQL PL/Python package name.
 # @param python_package_name Overrides the default PostgreSQL Python package name.
-# @param postgis_package_name Overrides the default PostgreSQL PostGIS package name.     
+# @param postgis_package_name Overrides the default PostgreSQL PostGIS package name.
+# @param pgsql_llvmjit_package_name Overrides the default PostgreSQL postgresql11-llvmjit package name.
 #
 # @param service_name Overrides the default PostgreSQL service name.
 # @param service_provider Overrides the default PostgreSQL service provider.
@@ -81,64 +82,64 @@
 #
 #
 class postgresql::globals (
-  $client_package_name      = undef,
-  $server_package_name      = undef,
-  $contrib_package_name     = undef,
-  $devel_package_name       = undef,
-  $java_package_name        = undef,
-  $docs_package_name        = undef,
-  $perl_package_name        = undef,
-  $plperl_package_name      = undef,
-  $plpython_package_name    = undef,
-  $python_package_name      = undef,
-  $postgis_package_name     = undef,
+  $client_package_name        = undef,
+  $server_package_name        = undef,
+  $contrib_package_name       = undef,
+  $devel_package_name         = undef,
+  $java_package_name          = undef,
+  $docs_package_name          = undef,
+  $perl_package_name          = undef,
+  $plperl_package_name        = undef,
+  $plpython_package_name      = undef,
+  $python_package_name        = undef,
+  $postgis_package_name       = undef,
+  $pgsql_llvmjit_package_name = undef,
+  $service_name               = undef,
+  $service_provider           = undef,
+  $service_status             = undef,
+  $default_database           = undef,
 
-  $service_name             = undef,
-  $service_provider         = undef,
-  $service_status           = undef,
-  $default_database         = undef,
+  $validcon_script_path       = undef,
 
-  $validcon_script_path     = undef,
+  $initdb_path                = undef,
+  $createdb_path              = undef,
+  $psql_path                  = undef,
+  $pg_hba_conf_path           = undef,
+  $pg_ident_conf_path         = undef,
+  $postgresql_conf_path       = undef,
+  $recovery_conf_path         = undef,
+  $default_connect_settings   = {},
 
-  $initdb_path              = undef,
-  $createdb_path            = undef,
-  $psql_path                = undef,
-  $pg_hba_conf_path         = undef,
-  $pg_ident_conf_path       = undef,
-  $postgresql_conf_path     = undef,
-  $recovery_conf_path       = undef,
-  $default_connect_settings = {},
+  $pg_hba_conf_defaults       = undef,
 
-  $pg_hba_conf_defaults     = undef,
+  $datadir                    = undef,
+  $confdir                    = undef,
+  $bindir                     = undef,
+  $xlogdir                    = undef,
+  $logdir                     = undef,
+  $log_line_prefix            = undef,
 
-  $datadir                  = undef,
-  $confdir                  = undef,
-  $bindir                   = undef,
-  $xlogdir                  = undef,
-  $logdir                   = undef,
-  $log_line_prefix          = undef,
+  $user                       = undef,
+  $group                      = undef,
 
-  $user                     = undef,
-  $group                    = undef,
+  $version                    = undef,
+  $postgis_version            = undef,
+  $repo_proxy                 = undef,
+  $repo_baseurl               = undef,
 
-  $version                  = undef,
-  $postgis_version          = undef,
-  $repo_proxy               = undef,
-  $repo_baseurl             = undef,
+  $needs_initdb               = undef,
 
-  $needs_initdb             = undef,
+  $encoding                   = undef,
+  $locale                     = undef,
+  $data_checksums             = undef,
+  $timezone                   = undef,
 
-  $encoding                 = undef,
-  $locale                   = undef,
-  $data_checksums           = undef,
-  $timezone                 = undef,
+  $manage_pg_hba_conf         = undef,
+  $manage_pg_ident_conf       = undef,
+  $manage_recovery_conf       = undef,
 
-  $manage_pg_hba_conf       = undef,
-  $manage_pg_ident_conf     = undef,
-  $manage_recovery_conf     = undef,
-
-  $manage_package_repo      = undef,
-  $module_workdir           = undef,
+  $manage_package_repo        = undef,
+  $module_workdir             = undef,
 ) {
   # We are determining this here, because it is needed by the package repo
   # class.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,6 @@
 class postgresql::params inherits postgresql::globals {
   $version                    = $postgresql::globals::globals_version
   $postgis_version            = $postgresql::globals::globals_postgis_version
-  $pgsql_llvmjit_package_name = $postgresql::globals::pgsql_llvmjit_package_name
   $listen_addresses           = undef
   $port                       = 5432
   $log_line_prefix            = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class postgresql::params inherits postgresql::globals {
       $needs_initdb       = pick($needs_initdb, true)
       $version_parts      = split($version, '[.]')
 
-      if $version_parts[0].scanf('%i') >= 10 {
+      if $version_parts[0].scanf('%i')[0] >= 10 {
         $package_version = $version_parts[0]
       } else {
         $package_version = "${version_parts[0]}${version_parts[1]}"
@@ -98,7 +98,7 @@ class postgresql::params inherits postgresql::globals {
       }
 
       #JIT is only available from PostgreSQL 11
-      if $version_parts[0].scanf('%i') >= 11 and $jit_enable == true {
+      if $version_parts[0].scanf('%i')[0] >= 11 and $jit_enable == true {
         if $postgresql::globals::pgsql_llvmjit_package_name {
           $pgsql_llvmjit_package_name = $postgresql::globals::postgis_package_name
         } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class postgresql::params inherits postgresql::globals {
       $needs_initdb       = pick($needs_initdb, true)
       $version_parts      = split($version, '[.]')
 
-      if $version_parts[0].scanf("%i") >= 10 {
+      if $version_parts[0].scanf('%i') >= 10 {
         $package_version = $version_parts[0]
       } else {
         $package_version = "${version_parts[0]}${version_parts[1]}"
@@ -98,7 +98,7 @@ class postgresql::params inherits postgresql::globals {
       }
 
       #JIT is only available from PostgreSQL 11
-      if $version_parts[0].scanf("%i") >= 11 and $jit_enable == true {
+      if $version_parts[0].scanf('%i') >= 11 and $jit_enable == true {
         if $postgresql::globals::pgsql_llvmjit_package_name {
           $pgsql_llvmjit_package_name = $postgresql::globals::postgis_package_name
         } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class postgresql::params inherits postgresql::globals {
       $needs_initdb       = pick($needs_initdb, true)
       $version_parts      = split($version, '[.]')
 
-      if $version_parts.scanf("%i") >= 10 {
+      if $version_parts[0].scanf("%i") >= 10 {
         $package_version = $version_parts[0]
       } else {
         $package_version = "${version_parts[0]}${version_parts[1]}"
@@ -98,7 +98,7 @@ class postgresql::params inherits postgresql::globals {
       }
 
       #JIT is only available from PostgreSQL 11
-      if $version_parts.scanf("%i") >= 11 and $jit_enable == true {
+      if $version_parts[0].scanf("%i") >= 11 and $jit_enable == true {
         if $postgresql::globals::pgsql_llvmjit_package_name {
           $pgsql_llvmjit_package_name = $postgresql::globals::postgis_package_name
         } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -102,7 +102,7 @@ class postgresql::params inherits postgresql::globals {
         if $postgresql::globals::pgsql_llvmjit_package_name {
           $pgsql_llvmjit_package_name = $postgresql::globals::postgis_package_name
         } else {
-          $pgsql_llvmjit_package_name = "postgresql${version}-llvmjit"
+          $pgsql_llvmjit_package_name = "postgresql${package_version}-llvmjit"
         }
       }else {
         $pgsql_llvmjit_package_name = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -64,13 +64,13 @@
 # @param manage_pg_hba_conf Boolean. Whether to manage the pg_hba.conf.
 # @param manage_pg_ident_conf Boolean. Overwrites the pg_ident.conf file.
 # @param manage_recovery_conf Boolean. Specifies whether or not manage the recovery.conf.
-# @param module_workdir Working directory for the PostgreSQL module 
+# @param module_workdir Working directory for the PostgreSQL module
 #
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
 #
-# @param version Sets PostgreSQL version 
+# @param version Sets PostgreSQL version
 #
 #
 class postgresql::server (
@@ -91,7 +91,7 @@ class postgresql::server (
   $service_reload             = $postgresql::params::service_reload,
   $service_status             = $postgresql::params::service_status,
   $default_database           = $postgresql::params::default_database,
-  $jit_enable                 = $postgresql::params::jit_enable
+  $jit_enable                 = $postgresql::params::jit_enable,
   $default_connect_settings   = $postgresql::globals::default_connect_settings,
   $listen_addresses           = $postgresql::params::listen_addresses,
   $port                       = $postgresql::params::port,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,7 @@
 #
 # @param service_ensure Ensure service is installed
 # @param service_enable Enable the PostgreSQL service
+# @param jit_enable Enable the PostgreSQL JIT implementation (Only available from PostgreSQL 11)
 # @param service_manage Defines whether or not Puppet should manage the service.
 # @param service_name Overrides the default PostgreSQL service name.
 # @param service_restart_on_change Overrides the default behavior to restart your PostgreSQL service when a config entry has been changed that requires a service restart to become active.
@@ -90,6 +91,7 @@ class postgresql::server (
   $service_reload             = $postgresql::params::service_reload,
   $service_status             = $postgresql::params::service_status,
   $default_database           = $postgresql::params::default_database,
+  $jit_enable                 = $postgresql::params::jit_enable
   $default_connect_settings   = $postgresql::globals::default_connect_settings,
   $listen_addresses           = $postgresql::params::listen_addresses,
   $port                       = $postgresql::params::port,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -22,6 +22,7 @@ class postgresql::server::config {
   $service_name               = $postgresql::server::service_name
   $log_line_prefix            = $postgresql::server::log_line_prefix
   $timezone                   = $postgresql::server::timezone
+  $jit_enable                 = $postgresql::server::jit_enable
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -127,6 +128,15 @@ class postgresql::server::config {
   if $log_line_prefix {
     postgresql::server::config_entry {'log_line_prefix':
       value => $log_line_prefix,
+    }
+  }
+
+  if $jit_enable {
+    postgresql::server::config_entry {'jit':
+      value => 'on',
+    }
+    postgresql::server::config_entry {'jit_provider':
+      value => 'llvmjit',
     }
   }
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -76,7 +76,7 @@ define postgresql::server::database(
 
   $tablespace_option = $tablespace ? {
     undef   => '',
-    default => "TABLESPACE = \"${tablespace}\"",
+    default => "TABLESPACE \"${tablespace}\"",
   }
 
   if $createdb_path != undef {

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,7 +1,9 @@
 # @api private
 class postgresql::server::install {
-  $package_ensure      = $postgresql::server::package_ensure
-  $package_name        = $postgresql::server::package_name
+  $package_ensure             = $postgresql::server::package_ensure
+  $package_name               = $postgresql::server::package_name
+  $jit_enable                 = $postgresql::server::jit_enable
+  $pgsql_llvmjit_package_name = $postgresql::server::install::pgsql_llvmjit_package_name
 
   $_package_ensure = $package_ensure ? {
     true     => 'present',
@@ -17,6 +19,17 @@ class postgresql::server::install {
     # This is searched for to create relationships with the package repos, be
     # careful about its removal
     tag    => 'puppetlabs-postgresql',
+  }
+
+  if $jit_enable == true {
+    package { 'postgresql-jit-package':
+      ensure => $_package_ensure,
+      name   => $pgsql_llvmjit_package_name,
+
+      # This is searched for to create relationships with the package repos, be
+      # careful about its removal
+      tag    => 'puppetlabs-postgresql',
+    }
   }
 
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -3,7 +3,7 @@ class postgresql::server::install {
   $package_ensure             = $postgresql::server::package_ensure
   $package_name               = $postgresql::server::package_name
   $jit_enable                 = $postgresql::server::jit_enable
-  $pgsql_llvmjit_package_name = $postgresql::server::install::pgsql_llvmjit_package_name
+  $pgsql_llvmjit_package_name = $postgresql::server::pgsql_llvmjit_package_name
 
   $_package_ensure = $package_ensure ? {
     true     => 'present',


### PR DESCRIPTION
Dear, 

With this merge request JIT can be enabled on PostgreSQL 11.   
As per example from other packages, it is possible to enable JIT and to change the default package name. 

The change has been tested on RHEL only. 