### PR TITLE
(MAINT) Add a default function

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -61,6 +61,7 @@ _Private Classes_
 
 **Functions**
 
+* [`postgresql::default`](#postgresqldefault): 
 * [`postgresql_acls_to_resources_hash`](#postgresql_acls_to_resources_hash): This internal function translates the ipv(4|6)acls format into a resource suitable for create_resources. It is not intended to be used outsid
 * [`postgresql_escape`](#postgresql_escape): This function safely escapes a string using a consistent random tag
 * [`postgresql_password`](#postgresql_password): This function returns the postgresql password hash from the clear text username / password
@@ -1478,7 +1479,7 @@ Data type: `Any`
 
 Specifies a hash of environment variables used when connecting to a remote server.
 
-Default value: $postgresql::server::default_connect_settings
+Default value: postgresql::default('default_connect_settings')
 
 ### postgresql::server::grant
 
@@ -2596,6 +2597,24 @@ namevar
 The name of the slot to create. Must be a valid replication slot name.
 
 ## Functions
+
+### postgresql::default
+
+Type: Puppet Language
+
+The postgresql::default function.
+
+#### `postgresql::default(String $parameter_name)`
+
+The postgresql::default function.
+
+Returns: `Any`
+
+##### `parameter_name`
+
+Data type: `String`
+
+
 
 ### postgresql_acls_to_resources_hash
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -61,7 +61,7 @@ _Private Classes_
 
 **Functions**
 
-* [`postgresql::default`](#postgresqldefault): 
+* [`postgresql::default`](#postgresqldefault): This function pull default values from the `params` class  or `globals` class if the value is not present in `params`.
 * [`postgresql_acls_to_resources_hash`](#postgresql_acls_to_resources_hash): This internal function translates the ipv(4|6)acls format into a resource suitable for create_resources. It is not intended to be used outsid
 * [`postgresql_escape`](#postgresql_escape): This function safely escapes a string using a consistent random tag
 * [`postgresql_password`](#postgresql_password): This function returns the postgresql password hash from the clear text username / password
@@ -1479,7 +1479,7 @@ Data type: `Any`
 
 Specifies a hash of environment variables used when connecting to a remote server.
 
-Default value: postgresql::default('default_connect_settings')
+Default value: $postgresql::server::default_connect_settings
 
 ### postgresql::server::grant
 
@@ -1517,7 +1517,7 @@ Data type: `Pattern[#/(?i:^COLUMN$)/,
     /(?i:^DATABASE$)/,
     #/(?i:^FOREIGN DATA WRAPPER$)/,
     #/(?i:^FOREIGN SERVER$)/,
-    #/(?i:^FUNCTION$)/,
+    /(?i:^FUNCTION$)/,
     /(?i:^LANGUAGE$)/,
     #/(?i:^PROCEDURAL LANGUAGE$)/,
     /(?i:^TABLE$)/,
@@ -2602,13 +2602,29 @@ The name of the slot to create. Must be a valid replication slot name.
 
 Type: Puppet Language
 
-The postgresql::default function.
+This function pull default values from the `params` class  or `globals` class if the value is not present in `params`.
+
+#### Examples
+
+##### 
+
+```puppet
+postgresql::default('variable')
+```
 
 #### `postgresql::default(String $parameter_name)`
 
 The postgresql::default function.
 
 Returns: `Any`
+
+##### Examples
+
+###### 
+
+```puppet
+postgresql::default('variable')
+```
 
 ##### `parameter_name`
 

--- a/functions/default.pp
+++ b/functions/default.pp
@@ -5,6 +5,6 @@ function postgresql::default(
 
   #search for the variable name in params first
   #then fall back to globals if not found
-  getvar("postgresql::params::${parameter_name}",
+  pick( getvar("postgresql::params::${parameter_name}"),
     "postgresql::globals::${parameter_name}")
 }

--- a/functions/default.pp
+++ b/functions/default.pp
@@ -1,3 +1,14 @@
+# @summary This function pull default values
+# from the params or globals classes as
+# appropriate
+#
+# This function pull default values
+# from the params or globals classes as
+# appropriate
+#
+# @example
+#   postgresql::default('variable')
+
 function postgresql::default(
   String $parameter_name
 ){

--- a/functions/default.pp
+++ b/functions/default.pp
@@ -1,14 +1,8 @@
-# @summary This function pull default values
-# from the params or globals classes as
-# appropriate
-#
-# This function pull default values
-# from the params or globals classes as
-# appropriate
+# @summary This function pull default values from the `params` class  or `globals` class if the value is not present in `params`.
 #
 # @example
 #   postgresql::default('variable')
-
+#
 function postgresql::default(
   String $parameter_name
 ){

--- a/functions/default.pp
+++ b/functions/default.pp
@@ -1,0 +1,10 @@
+function postgresql::default(
+  String $parameter_name
+){
+  include postgresql::params
+
+  #search for the variable name in params first
+  #then fall back to globals if not found
+  getvar("postgresql::params::${parameter_name}",
+    "postgresql::globals::${parameter_name}")
+}

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -23,12 +23,12 @@ define postgresql::server::extension (
   String[1] $ensure            = 'present',
   $package_name                = undef,
   $package_ensure              = undef,
-  $connect_settings            = $postgresql::server::default_connect_settings,
+  $connect_settings            = $postgresql::server('default_connect_settings'),
   $database_resource_name      = $database,
 ) {
-  $user             = $postgresql::server::user
-  $group            = $postgresql::server::group
-  $psql_path        = $postgresql::server::psql_path
+  $user             = postgresql::default('user')
+  $group            = postgresql::default('group')
+  $psql_path        = postgresql::default('psql_path')
 
   case $ensure {
     'present': {

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -23,7 +23,7 @@ define postgresql::server::extension (
   String[1] $ensure            = 'present',
   $package_name                = undef,
   $package_ensure              = undef,
-  $connect_settings            = $postgresql::server('default_connect_settings'),
+  $connect_settings            = postgresql::default('default_connect_settings'),
   $database_resource_name      = $database,
 ) {
   $user             = postgresql::default('user')

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -155,3 +155,32 @@ describe 'postgresql::server::extension', type: :define do
     }
   end
 end
+
+describe 'postgresql::server::extension', type: :define do
+  let :facts do
+    {
+      osfamily: 'Debian',
+      operatingsystem: 'Debian',
+      operatingsystemrelease: '6.0',
+      kernel: 'Linux',
+      concat_basedir: tmpfilename('postgis'),
+      id: 'root',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let(:title) { 'pg_repack' }
+  let(:params) do
+    {
+      database: 'postgres',
+      extension: 'pg_repack',
+    }
+  end
+
+  context 'without including postgresql::server' do
+    it {
+      is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"')
+        .with(db: 'postgres', command: 'CREATE EXTENSION "pg_repack"')
+    }
+  end
+end

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -142,4 +142,9 @@ describe 'postgresql::server::role', type: :define do
       is_expected.to contain_postgresql_psql('DROP ROLE "test"').that_requires('Class[postgresql::server::service]')
     end
   end
+
+  context 'without including postgresql::server' do
+    it { is_expected.to compile }
+    it { is_expected.to contain_postgresql__server__role('test') }
+  end
 end


### PR DESCRIPTION
Prior to this commit, you could not easily use some of the defined
types without also declaring other classes in your manifest like
postgresql::server.  This is because we were grabbing default
values from postgresql::server.

After this commit, we introduce a pupept function that can return
default values based on the calculations in params/globals.  This
allows users to use defined types that use the default function
without declaring other classes.