### PR TITLE
Fix sql statement for the grants condition

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -335,6 +335,7 @@ define postgresql::server::grant (
                    WHERE g.grantee = '${role}'
                      AND g.table_schema = '${schema}'
                      AND g.privilege_type = '${_privilege}'
+                     AND g.table_name = t.tablename
                    )
              )"
         }


### PR DESCRIPTION
The sql statement that determines if the `GRANT` should be applied
or not for the case where the `object_type` is "ALL TABLES IN SCHEMA"
is missing a crucial part in the WHERE clause.

The `SELECT` sub-statement should have a condition that links the bove
SELECT statements together so that a correlation can be made and the
comparison actually returns correct values.

Without the correlation, the SQL statement will always return true, if
a single table in the schema has the given `${_privilege}` set.