### PR TITLE
Fix: When assigning a tablespace to a database, no equal sign is needed in the query

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -76,7 +76,7 @@ define postgresql::server::database(
 
   $tablespace_option = $tablespace ? {
     undef   => '',
-    default => "TABLESPACE = \"${tablespace}\"",
+    default => "TABLESPACE \"${tablespace}\"",
   }
 
   if $createdb_path != undef {


### PR DESCRIPTION
According to the documentation*  no equal sign is needed when creating or altering a database. It is working during the database creation; but it fails during an alter statement. Therefore I propose to remove the equal sign both during the creation of the database and when altering. 

https://www.postgresql.org/docs/11/sql-alterdatabase.html
https://www.postgresql.org/docs/9.6/sql-alterdatabase.html
https://www.postgresql.org/docs/11/sql-createdatabase.html
https://www.postgresql.org/docs/9.6/sql-createdatabase.html