### PR TITLE
(MODULES-9658) - custom ports are not labeled correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ While this module supports both 1.x and 2.x versions of the 'puppetlabs-apt' mod
 
 PostGIS is currently considered an unsupported feature, as it doesn't work on all platforms correctly.
 
-### All versions of RHEL/CentOS
+### All versions of RHEL/CentOS with manage_selinux => false
 
-If you have SELinux enabled you must add any custom ports you use to the `postgresql_port_t` context.  You can do this as follows:
+If you have SELinux enabled and you are *not* using the selinux module to manage SELinux (this is the default configuration) you will need to label any custom ports you use with the `postgresql_port_t` context.  The postgresql service will not start until this is done.  To label a port use the semanage command as follows:
 
 ```shell
 semanage port -a -t postgresql_port_t -p tcp $customport

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -143,6 +143,7 @@ class postgresql::globals (
   $manage_pg_hba_conf       = undef,
   $manage_pg_ident_conf     = undef,
   $manage_recovery_conf     = undef,
+  $manage_selinux           = undef,
 
   $manage_package_repo      = undef,
   $module_workdir           = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
   $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
   $manage_recovery_conf       = pick($manage_recovery_conf, false)
+  $manage_selinux             = pick($manage_selinux, false)
   $package_ensure             = 'present'
   $module_workdir             = pick($module_workdir,'/tmp')
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -131,6 +131,7 @@ class postgresql::server (
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
   $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
+  Boolean $manage_selinux     = $postgresql::params::manage_selinux,
   $module_workdir             = $postgresql::params::module_workdir,
 
   $manage_datadir             = $postgresql::params::manage_datadir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -108,9 +108,28 @@ class postgresql::server::config {
 
   # ensure that SELinux has a proper label for the port defined
   if $postgresql::server::manage_selinux == true and $facts['selinux'] == true {
+    case $facts['osfamily'] {
+      'RedHat', 'Linux': {
+        if $facts['operatingsystem'] == 'Amazon' {
+          $package_name = 'policycoreutils'
+        }
+        else {
+          $package_name = $facts['operatingsystemmajrelease'] ? {
+            '5'     => 'policycoreutils',
+            '6'     => 'policycoreutils-python',
+            '7'     => 'policycoreutils-python',
+            default => 'policycoreutils-python-utils',
+          }
+        }
+      }
+    }
+
+    ensure_packages([$package_name])
+
     exec { "/usr/sbin/semanage port -a -t postgresql_port_t -p tcp ${port}":
-        unless => "/usr/sbin/semanage port -l | grep -qw ${port}",
-        before => Postgresql::Server::Config_entry['port'],
+        unless  => "/usr/sbin/semanage port -l | grep -qw ${port}",
+        before  => Postgresql::Server::Config_entry['port'],
+        require => Package[$package_name],
     }
   }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -106,9 +106,18 @@ class postgresql::server::config {
     }
   }
 
+  # ensure that SELinux has a proper label for the port defined
+  if $postgresql::server::manage_selinux == true and $facts['selinux'] == true {
+    exec { "/usr/sbin/semanage port -a -t postgresql_port_t -p tcp ${port}":
+        unless => "/usr/sbin/semanage port -l | grep -qw ${port}",
+        before => Postgresql::Server::Config_entry['port'],
+    }
+  }
+
   postgresql::server::config_entry { 'port':
     value => $port,
   }
+
   postgresql::server::config_entry { 'data_directory':
     value => $datadir,
   }

--- a/spec/acceptance/alternative_port_spec.rb
+++ b/spec/acceptance/alternative_port_spec.rb
@@ -8,7 +8,7 @@ describe 'postgresql::server', unless: UNSUPPORTED_PLATFORMS.include?(os[:family
   end
   it 'on an alternative port' do
     pp = <<-MANIFEST
-      class { 'postgresql::server': port => '55433' }
+      class { 'postgresql::server': port => '55433', manage_selinux => true }
     MANIFEST
 
     idempotent_apply(pp)

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -31,9 +31,12 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
+      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
         .that_comes_before('Postgresql::Server::Config_entry[port]')
+        .that_requires('Package[policycoreutils-python-utils]')
     end
 
     it 'has the correct systemd-override file' do
@@ -96,9 +99,12 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
+      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
         .that_comes_before('Postgresql::Server::Config_entry[port]')
+        .that_requires('Package[policycoreutils-python-utils]')
     end
 
     it 'has the correct systemd-override file' do
@@ -133,6 +139,30 @@ describe 'postgresql::server::config', type: :class do
         is_expected.to contain_file('systemd-override') \
           .with_content(%r{.include \/lib\/systemd\/system\/postgresql-9.4.service})
       end
+    end
+  end
+
+  describe 'on Amazon' do
+    let :facts do
+      {
+        osfamily: 'RedHat',
+        operatingsystem: 'Amazon',
+        operatingsystemrelease: '1.0',
+        concat_basedir: tmpfilename('server'),
+        kernel: 'Linux',
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        selinux: true,
+      }
+    end
+
+    it 'has SELinux port defined' do
+      is_expected.to contain_package('policycoreutils') .with(ensure: 'present')
+
+      is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
+        .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
+        .that_comes_before('Postgresql::Server::Config_entry[port]')
+        .that_requires('Package[policycoreutils]')
     end
   end
 

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'postgresql::server::config', type: :class do
   let(:pre_condition) do
-    'include postgresql::server'
+    'class { postgresql::server: manage_selinux => true }'
   end
 
   describe 'on RedHat 7' do
@@ -16,7 +16,24 @@ describe 'postgresql::server::config', type: :class do
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         selinux: true,
+        os: {
+          'architecture' => 'x86_64',
+          'family'       => 'RedHat',
+          'hardware'     => 'x86_64',
+          'name'         => 'CentOS',
+          'release'      => {
+            'full'  => '7.6.1810',
+            'major' => '7',
+            'minor' => '6',
+          },
+        },
       }
+    end
+
+    it 'has SELinux port defined' do
+      is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
+        .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
+        .that_comes_before('Postgresql::Server::Config_entry[port]')
     end
 
     it 'has the correct systemd-override file' do
@@ -65,7 +82,23 @@ describe 'postgresql::server::config', type: :class do
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         selinux: true,
+        os: {
+          'architecture' => 'x86_64',
+          'family'       => 'RedHat',
+          'hardware'     => 'x86_64',
+          'name'         => 'Fedora',
+          'release'      => {
+            'full'  => '21',
+            'major' => '21',
+          },
+        },
       }
+    end
+
+    it 'has SELinux port defined' do
+      is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
+        .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
+        .that_comes_before('Postgresql::Server::Config_entry[port]')
     end
 
     it 'has the correct systemd-override file' do
@@ -123,6 +156,10 @@ describe 'postgresql::server::config', type: :class do
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         selinux: false,
       }
+    end
+
+    it 'does not have SELinux port defined' do
+      is_expected.not_to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
     end
 
     it 'has the correct systemd-override file' do


### PR DESCRIPTION
When a node has SELinux enabled the port must be labeled properly to allow the postgresql service to start.