### PR TITLE
pdksync - (maint) Override pdk gem version to master branch (PDK-1525 workaround until release)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gem 'pdk', git: 'https://github.com/puppetlabs/pdk.git', branch: 'master'
 
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -122,6 +122,9 @@ class postgresql::server::config {
           }
         }
       }
+      default: {
+        $package_name = 'policycoreutils'
+      }
     }
 
     ensure_packages([$package_name])


### PR DESCRIPTION
## Description
### PDKSync update
pdksync - (maint) Override pdk gem version to master branch (PDK-1525 workaround until release)
pdk version: `1.12.0` 
### Add Default Option to Case Statement
Add default option to case statement in `manifests/server/config.pp` to allow lint tests to pass. The block modified is mapping a process / pkg name to the port it's using, as is required by SELinux. I defaulted to `policycoreutils` given derivates of this RPM package all contain the substring `policycoreutils` in it: https://www.rpmfind.net/linux/rpm2html/search.php?query=policycoreutils