### PR TITLE
Add postgis support for postgres 11 and 12

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -240,6 +240,8 @@ class postgresql::globals (
     '9.5'   => '2.3',
     '9.6'   => '2.3',
     '10'    => '2.4',
+    '11'    => '3.0',
+    '12'    => '3.0',
     default => undef,
   }
   $globals_postgis_version = $postgis_version ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -175,6 +175,8 @@ class postgresql::params inherits postgresql::globals {
       $contrib_package_name   = pick($contrib_package_name, "postgresql-contrib-${version}")
       if $postgis_version and versioncmp($postgis_version, '2') < 0 {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis")
+      } elsif $postgis_version and versioncmp($postgis_version, '3') >= 0 {
+        $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis-3")
       } else {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis-${postgis_version}")
       }


### PR DESCRIPTION
Adds postgis support for postgres 11 and 12 by mapping default versions.

Also updates the $postgis_package_name selection for Debian-based distros to reflect the fact that postgis has dropped the minor version number from library (and Debian package) names  from 3.0 onwards (https://trac.osgeo.org/postgis/ticket/3807).