### PR TITLE
Don't update password encrypted with SCRAM-SHA-256 if not changed

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -130,6 +130,8 @@ define postgresql::server::role(
     if $password_hash and $update_password {
       if($password_hash =~ /^md5.+/) {
         $pwd_hash_sql = $password_hash
+      } elsif($password_hash =~ /^SCRAM\-SHA\-256\$/) {
+        $pwd_hash_sql = $password_hash
       } else {
         $pwd_md5 = md5("${password_hash}${username}")
         $pwd_hash_sql = "md5${pwd_md5}"


### PR DESCRIPTION
Currently we're seeing a lot of spurious updates to a user, when the given `password_hash` is encrypted with SCRAM-SHA-256. For more information about the format, see [pg_authid](https://www.postgresql.org/docs/12/catalog-pg-authid.html).