### PR TITLE
Allow usage of PUBLIC role

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -436,7 +436,7 @@ define postgresql::server::grant (
   $_onlyif = $onlyif_function ? {
     'table_exists'    => "SELECT true FROM pg_tables WHERE tablename = '${_togrant_object}'",
     'language_exists' => "SELECT true from pg_language WHERE lanname = '${_togrant_object}'",
-    'role_exists'     => "SELECT 1 FROM pg_roles WHERE rolname = '${role}' or ${role} = 'PUBLIC'",
+    'role_exists'     => "SELECT 1 FROM pg_roles WHERE rolname = '${role}' or '${role}' = 'PUBLIC'",
     'function_exists' => "SELECT true FROM pg_proc WHERE (oid::regprocedure)::text = '${_togrant_object}${arguments}'",
     default           => undef,
   }

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -421,17 +421,22 @@ define postgresql::server::grant (
     }
   }
 
+  # Function like has_database_privilege() refer the PUBLIC pseudo role as 'public'
+  # So we need to replace 'PUBLIC' by 'public'.
+
   $_unless = $unless_function ? {
       false    => undef,
       'custom' => $custom_unless,
-      default  => "SELECT 1 WHERE ${unless_function}('${role}',
-                  '${_granted_object}${arguments}', '${unless_privilege}') = ${unless_is}",
+      default  => $role ? {
+        'PUBLIC' => "SELECT 1 WHERE ${unless_function}('public', '${_granted_object}${arguments}', '${unless_privilege}') = ${unless_is}",
+        default  => "SELECT 1 WHERE ${unless_function}('${role}', '${_granted_object}${arguments}', '${unless_privilege}') = ${unless_is}",
+      }
   }
 
   $_onlyif = $onlyif_function ? {
     'table_exists'    => "SELECT true FROM pg_tables WHERE tablename = '${_togrant_object}'",
     'language_exists' => "SELECT true from pg_language WHERE lanname = '${_togrant_object}'",
-    'role_exists'     => "SELECT 1 FROM pg_roles WHERE rolname = '${role}'",
+    'role_exists'     => "SELECT 1 FROM pg_roles WHERE rolname = '${role}' or ${role} = 'PUBLIC'",
     'function_exists' => "SELECT true FROM pg_proc WHERE (oid::regprocedure)::text = '${_togrant_object}${arguments}'",
     default           => undef,
   }


### PR DESCRIPTION
Re-open #1003 with a new unit test

To generate this kind of query: 
```sql
REVOKE CONNECT ON DATABASE database1 FROM PUBLIC;
```
I created following puppet code:
```puppet
postgresql::server::database_grant { 'revoke connect on database1':
    ensure => 'absent',
    db => 'database1',
    privilege => 'CONNECT',
    role => 'PUBLIC',
}
```

This generate following error:
```
Error: /Stage[main]/Profile::Postgresql_gis/Postgresql::Server::Grant[revoke ALL on schema public to public:]/Postgresql_psql[grant:revoke ALL on schema public to public:]: Could not evaluate: Error evaluating 'unless' clause, returned pid 7360 exit 1: 'ERROR:  role "PUBLIC" does not exist
```
because `PUBLIC` is a "implicit" role and is not listed in `pg_roles` table.

To fix this I modify query that test if role exists.