### PR TITLE
Treat $version as an integer for comparison, defaults to string

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -141,7 +141,7 @@ class postgresql::server::config {
     value => $port,
   }
 
-  if ($password_encryption) and ($version >= 10){
+  if ($password_encryption) and (versioncmp($version, '10') >= 10){
     postgresql::server::config_entry { 'password_encryption':
       value => $password_encryption,
     }


### PR DESCRIPTION
When setting password_encryption an operator AND calls a comparison of the $version variable to an integer.  $version is a string - breaking the comparison.  This should fix that - although it may not be the best way to do so and someone with greater skill has a better method.