### PR TITLE
Correct versioncmp logic in config.pp

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -141,7 +141,7 @@ class postgresql::server::config {
     value => $port,
   }
 
-  if ($password_encryption) and (versioncmp($version, '10') >= 10){
+  if ($password_encryption) and (versioncmp($version, '10') >= 0){
     postgresql::server::config_entry { 'password_encryption':
       value => $password_encryption,
     }


### PR DESCRIPTION
This is a bit embarrassing but my last patch, although not breaking anything from prior state, also will not actually work as intended.  Version comparison works but versioncmp produces results of -1, 0 or 1 and must be compared against that result.  

This fix I tested more thoroughly.  :)  Sorry for the hassle.