### PR TITLE
Add Fedora 31 compatibility

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -153,6 +153,7 @@ class postgresql::globals (
   $default_version = $::osfamily ? {
     /^(RedHat|Linux)/ => $::operatingsystem ? {
       'Fedora' => $::operatingsystemrelease ? {
+        /^(31)$/       => '11.6',
         /^(30)$/       => '11.2',
         /^(29)$/       => '10.6',
         /^(28)$/       => '10.4',


### PR DESCRIPTION
Fedora 31 includes postgresql 11.6 by default.