### PR TITLE
Fix wrong link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [v6.3.0](https://github.com/puppetlabs/puppetlabs-postgresql/tree/v6.2.0) (2019-12-17)
+## [v6.3.0](https://github.com/puppetlabs/puppetlabs-postgresql/tree/v6.3.0) (2019-12-17)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-postgresql/compare/v6.2.0...v6.2.0)
 


### PR DESCRIPTION
Under the text 6.3.0 the link point to the branch 6.2.0