### PR TITLE
Fix incorrectly quoted GRANT cmd on functions

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -392,7 +392,7 @@ define postgresql::server::grant (
         true    => 'function_exists',
         default => undef,
       }
-      $_quoted_args = join($object_arguments.map |$arg| { "\"${arg}\"" }, ',')
+      $_quoted_args = join($object_arguments, ',')
       $arguments = "(${_quoted_args})"
     }
 

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -383,7 +383,7 @@ define postgresql::server::grant (
         default => undef,
       }
       $arguments = ''
-     $_enquote_object = false
+      $_enquote_object = false
     }
     'FUNCTION': {
       $unless_privilege = $_privilege ? {

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -49,11 +49,11 @@ define postgresql::server::grant (
   case $ensure {
     default: {
       # default is 'present'
-      $sql_command = 'GRANT %s ON %s "%s"%s TO "%s"'
+      $sql_command = 'GRANT %s ON %s "%s%s" TO "%s"'
       $unless_is = true
     }
     'absent': {
-      $sql_command = 'REVOKE %s ON %s "%s"%s FROM "%s"'
+      $sql_command = 'REVOKE %s ON %s "%s%s" FROM "%s"'
       $unless_is = false
     }
   }

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -421,7 +421,10 @@ define postgresql::server::grant (
   # }
   case $_object_name {
     Array:   {
-      $_togrant_object = join($_object_name, '"."')
+      $_togrant_object = $_enquote_object ? {
+        false   => join($_object_name, '.'),
+        default => join($_object_name, '"."'),
+      }
       # Never put double quotes into has_*_privilege function
       $_granted_object = join($_object_name, '.')
     }

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -249,7 +249,7 @@ describe 'postgresql::server::grant', type: :define do
         role: 'test',
         privilege: 'execute',
         object_name: 'test',
-        object_arguments: ['text', 'text'],
+        object_arguments: ['text', 'boolean'],
         object_type: 'function',
       }
     end
@@ -262,8 +262,8 @@ describe 'postgresql::server::grant', type: :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it do
       is_expected.to contain_postgresql_psql('grant:test')
-        .with_command(%r{GRANT EXECUTE ON FUNCTION "test"\("text","text"\) TO\s* "test"}m)
-        .with_unless(%r{SELECT 1 WHERE has_function_privilege\('test',\s* 'test\("text","text"\)', 'EXECUTE'\)}m)
+        .with_command(%r{GRANT EXECUTE ON FUNCTION test\(text,boolean\) TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE has_function_privilege\('test',\s* 'test\(text,boolean\)', 'EXECUTE'\)}m)
     end
   end
 
@@ -274,7 +274,7 @@ describe 'postgresql::server::grant', type: :define do
         role: 'test',
         privilege: 'execute',
         object_name: ['myschema', 'test'],
-        object_arguments: ['text', 'text'],
+        object_arguments: ['text', 'boolean'],
         object_type: 'function',
       }
     end
@@ -287,8 +287,8 @@ describe 'postgresql::server::grant', type: :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it do
       is_expected.to contain_postgresql_psql('grant:test')
-        .with_command(%r{GRANT EXECUTE ON FUNCTION "myschema"."test"\("text","text"\) TO\s* "test"}m)
-        .with_unless(%r{SELECT 1 WHERE has_function_privilege\('test',\s* 'myschema.test\("text","text"\)', 'EXECUTE'\)}m)
+        .with_command(%r{GRANT EXECUTE ON FUNCTION myschema.test\(text,boolean\) TO\s* "test"}m)
+        .with_unless(%r{SELECT 1 WHERE has_function_privilege\('test',\s* 'myschema.test\(text,boolean\)', 'EXECUTE'\)}m)
     end
   end
 


### PR DESCRIPTION
The existing code failed miserably to grant permissions on functions. 

Using the following code:
```puppet
postgresql::server::grant { "grant_func_privs":
  role                    => 'rewind',
  db                      => 'postgres',
  privilege               => 'EXECUTE',
  object_type             => 'FUNCTION',
  object_name             => 'pg_catalog.pg_ls_dir',
  object_arguments        => ['text', 'boolean', 'boolean'],
  require                 => Postgresql::Server::Role[$rewind_user],
}
```
The created queries were:
```sql
GRANT EXECUTE ON FUNCTION "pg_catalog.pg_ls_dir"("text","boolean","boolean") TO "rewind";
```
and for the "unless" case:
```sql
SELECT COUNT(*) FROM (SELECT 1 WHERE has_function_privilege('rewind', 'pg_catalog.pg_ls_dir("text","boolean","boolean")', 'EXECUTE') = true);"
```
The patches in this series fix that to be:
```sql
GRANT EXECUTE ON FUNCTION pg_catalog.pg_ls_dir(text,boolean,boolean) TO "rewind";
SELECT COUNT(*) FROM (SELECT 1 WHERE has_function_privilege('rewind', 'pg_catalog.pg_ls_dir(text,boolean,boolean)', 'EXECUTE') = true);"
```
since both the types and the complete function expression must not be quoted. 