### PR TITLE
add extra parameter "extra_systemd_config" 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class postgresql::params inherits postgresql::globals {
   $package_ensure             = 'present'
   $module_workdir             = pick($module_workdir,'/tmp')
   $password_encryption        = undef
+  $extra_systemd_config       = ''
   $manage_datadir             = true
   $manage_logdir              = true
   $manage_xlogdir             = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -75,6 +75,7 @@
 #
 # @param version Sets PostgreSQL version
 #
+# @param extra_systemd_config Adds extra config to systemd config file, can for instance be used to add extra openfiles. This can be a multi line string
 #
 class postgresql::server (
   $postgres_password          = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -138,6 +138,7 @@ class postgresql::server (
   $manage_logdir              = $postgresql::params::manage_logdir,
   $manage_xlogdir             = $postgresql::params::manage_xlogdir,
   $password_encryption        = $postgresql::params::password_encryption,
+  $extra_systemd_config       = $postgresql::params::extra_systemd_config,
 
   Hash[String, Hash] $roles         = {},
   Hash[String, Any] $config_entries = {},

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -23,6 +23,7 @@ class postgresql::server::config {
   $log_line_prefix            = $postgresql::server::log_line_prefix
   $timezone                   = $postgresql::server::timezone
   $password_encryption        = $postgresql::server::password_encryption
+  $extra_systemd_config       = $postgresql::server::extra_systemd_config
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -12,3 +12,4 @@ Environment=DATA_DIR=<%= @datadir %>
 <%- else -%>
 Environment=PGDATA=<%= @datadir %>
 <%- end -%>
+<%= @extra_systemd_config %>


### PR DESCRIPTION
This add an extra parameter to make it possible to add lines to /etc/systemd/system/portgresql-<version>.service.
This is needed for instance to provide for extra open files for postgres.
LimitNOFILE=10000

This is implemented as a multi line string. This way you can add multiple lines to the systemd file.