### PR TITLE
Allow usage of grant and role when not managing postgresql::server

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -11,6 +11,8 @@
 # @param onlyif_exists Create grant only if doesn't exist
 # @param connect_settings Specifies a hash of environment variables used when connecting to a remote server.
 # @param ensure Specifies whether to grant or revoke the privilege. Default is to grant the privilege. Valid values: 'present', 'absent'.
+# @param group Sets the OS group to run psql
+# @param psql_path Sets the path to psql command
 define postgresql::server::grant (
   String $role,
   String $db,
@@ -44,6 +46,8 @@ define postgresql::server::grant (
   Enum['present',
         'absent'
   ] $ensure                        = 'present',
+  String $group                    = $postgresql::server::group,
+  String $psql_path                = $postgresql::server::psql_path,
 ) {
 
   case $ensure {
@@ -60,8 +64,6 @@ define postgresql::server::grant (
     }
   }
 
-  $group     = $postgresql::server::group
-  $psql_path = $postgresql::server::psql_path
 
   if ! $object_name {
     $_object_name = $db

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -14,6 +14,10 @@
 # @param username Defines the username of the role to create.
 # @param connect_settings Specifies a hash of environment variables used when connecting to a remote server.
 # @param ensure Specify whether to create or drop the role. Specifying 'present' creates the role. Specifying 'absent' drops the role.
+# @param psql_user Sets the OS user to run psql
+# @param psql_group Sets the OS group to run psql
+# @param psql_path Sets path to psql command
+# @param module_workdir Specifies working directory under which the psql command should be executed. May need to specify if '/tmp' is on volume mounted with noexec option.
 define postgresql::server::role(
   $update_password = true,
   $password_hash    = false,
@@ -28,12 +32,12 @@ define postgresql::server::role(
   $connection_limit = '-1',
   $username         = $title,
   $connect_settings = $postgresql::server::default_connect_settings,
+  $psql_user        = $postgresql::server::user,
+  $psql_group       = $postgresql::server::group,
+  $psql_path        = $postgresql::server::psql_path,
+  $module_workdir   = $postgresql::server::module_workdir,
   Enum['present', 'absent'] $ensure = 'present',
 ) {
-  $psql_user      = $postgresql::server::user
-  $psql_group     = $postgresql::server::group
-  $psql_path      = $postgresql::server::psql_path
-  $module_workdir = $postgresql::server::module_workdir
 
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -292,6 +292,28 @@ describe 'postgresql::server::grant', type: :define do
     end
   end
 
+  context 'standalone not managing server' do
+    let :params do
+      {
+        db: 'test',
+        role: 'test',
+        privilege: 'execute',
+        object_name: ['myschema', 'test'],
+        object_arguments: ['text', 'boolean'],
+        object_type: 'function',
+        group: 'postgresql',
+        psql_path: '/usr/bin',
+        psql_user: 'postgres',
+        psql_db: 'db',
+        port: 1542,
+        connect_settings: {},
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_class('postgresql::server') }
+  end
+
   context 'invalid object_type' do
     let :params do
       {

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -147,4 +147,29 @@ describe 'postgresql::server::role', type: :define do
     it { is_expected.to compile }
     it { is_expected.to contain_postgresql__server__role('test') }
   end
+
+  context 'standalone not managing server' do
+    let :params do
+      {
+        password_hash: 'new-pa$s',
+        connect_settings: { 'PGHOST' => 'postgres-db-server',
+                            'DBVERSION'  => '9.1',
+                            'PGPORT'     => '1234',
+                            'PGUSER'     => 'login-user',
+                            'PGPASSWORD' => 'login-pass' },
+        psql_user: 'postgresql',
+        psql_group: 'postgresql',
+        psql_path: '/usr/bin',
+        module_workdir: '/tmp',
+        db: 'db',
+      }
+    end
+
+    let :pre_condition do
+      ''
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_class('postgresql::server') }
+  end
 end


### PR DESCRIPTION
Some installations use other ways to install postgresql.
But people still want to make use of grant and role defined type.

This PR moves all variables with default values set to `postgresql::server::<var>` into the defined types parameter list.
A spec test was added to ensure that postgresql::server class is not part of the catalog.
