### PR TITLE
Fix custom port in extension

### DIFF
--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -178,9 +178,86 @@ describe 'postgresql::server::extension', type: :define do
   end
 
   context 'without including postgresql::server' do
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
     it {
       is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"')
         .with(db: 'postgres', command: 'CREATE EXTENSION "pg_repack"')
     }
+  end
+
+  context 'default port' do
+    let :params do
+      {
+        database: 'postgres',
+        extension: 'pg_repack',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_port('5432') }
+  end
+
+  context 'port overriden by explicit parameter' do
+    let :params do
+      {
+        database: 'postgres',
+        extension: 'pg_repack',
+        port: 1234,
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_port('1234') }
+  end
+
+  context 'with specific db connection settings' do
+    let :params do
+      {
+        database: 'postgres',
+        extension: 'pg_repack',
+        connect_settings: { 'PGHOST' => 'postgres-db-server',
+                            'DBVERSION' => '9.1',
+                            'PGPORT' => '1234' },
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234').with_port(nil) }
+  end
+
+  context 'with specific db connection settings - port overriden by explicit parameter' do
+    let :params do
+      {
+        database: 'postgres',
+        extension: 'pg_repack',
+        connect_settings: { 'PGHOST' => 'postgres-db-server',
+                            'DBVERSION' => '9.1',
+                            'PGPORT' => '1234' },
+        port: 5678,
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234').with_port('5678') }
   end
 end

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -178,7 +178,6 @@ describe 'postgresql::server::extension', type: :define do
   end
 
   context 'without including postgresql::server' do
-
     let :pre_condition do
       "class {'postgresql::server':}"
     end
@@ -238,7 +237,11 @@ describe 'postgresql::server::extension', type: :define do
     end
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234').with_port(nil) }
+    it {
+      is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"')
+        .with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234')
+        .with_port(nil)
+    }
   end
 
   context 'with specific db connection settings - port overriden by explicit parameter' do
@@ -258,6 +261,10 @@ describe 'postgresql::server::extension', type: :define do
     end
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"').with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234').with_port('5678') }
+    it {
+      is_expected.to contain_postgresql_psql('postgres: CREATE EXTENSION "pg_repack"')
+        .with_connect_settings('PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1', 'PGPORT' => '1234')
+        .with_port('5678')
+    }
   end
 end


### PR DESCRIPTION
When postgres server does not use a standard port, the resource extension still try to connect with standard postgres port instead of the port configured in `$postgresql::server::port`.
This PR add a test with a custom port to demonstrate issue. A commit to fix the issue will be append.