### PR TITLE
(IAC-889) Set FastGettext.default_text_domain in Rakefile

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -42,6 +42,8 @@ Gemfile:
       ref: 20ee04ba1234e9e83eb2ffb5056e23d641c7a018
       condition: Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 Rakefile:
+  extras:
+    "FastGettext.default_text_domain = 'default-text-domain'"
   changelog_user: puppetlabs
 spec/spec_helper.rb:
   mock_with: ":rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,6 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
-  gem 'ed25519', '>= 1.2', '< 2.0'
-  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -86,3 +86,4 @@ EOM
   end
 end
 
+FastGettext.default_text_domain = 'default-text-domain'

--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,7 @@
       "version_requirement": ">= 5.5.10 < 7.0.0"
     }
   ],
-  "pdk-version": "1.17.0",
+  "pdk-version": "1.18.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g88b05c7"
+  "template-ref": "heads/master-0-g9c14433"
 }


### PR DESCRIPTION
The spec tests were failing due to the `metadata_lint` Rake task exiting with a return code of 1:
```
bundle exec rake check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint; echo $?
Running RuboCop...
Inspecting 0 files


0 files inspected, no offenses detected
---> syntax:manifests
Current textdomain ("master_domain") was not added, use FastGettext.add_text_domain !
1
```

See [this run](https://travis-ci.org/github/puppetlabs/puppetlabs-postgresql/jobs/697673413#L425-L426) on TravisCI too.

According to [MODULES-6598](https://tickets.puppetlabs.com/browse/MODULES-6598) there is a conflict with GetFastText initialisation between puppet_semantic and puppet.

This PR implements the workaround described in MODULES-6598](https://tickets.puppetlabs.com/browse/MODULES-6598), which is to set the `default_text_domain` parameter in `GetFastText`