### PR TITLE
Allow removal of config_entries via main class

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -184,7 +184,8 @@ class postgresql::server (
 
   $config_entries.each |$entry, $value| {
     postgresql::server::config_entry { $entry:
-      value => $value,
+      ensure => bool2str($value =~ Undef, 'absent', 'present'),
+      value  => $value,
     }
   }
 

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -209,13 +209,15 @@ describe 'postgresql::server', type: :class do
         config_entries: {
           fsync: 'off',
           checkpoint_segments: '20',
+          remove_me: :undef,
         },
       }
     end
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_postgresql__server__config_entry('fsync').with_value('off') }
-    it { is_expected.to contain_postgresql__server__config_entry('checkpoint_segments').with_value('20') }
+    it { is_expected.to contain_postgresql__server__config_entry('fsync').with_value('off').with_ensure('present') }
+    it { is_expected.to contain_postgresql__server__config_entry('checkpoint_segments').with_value('20').with_ensure('present') }
+    it { is_expected.to contain_postgresql__server__config_entry('remove_me').with_value(nil).with_ensure('absent') }
   end
 
   describe 'additional pg_hba_rules' do


### PR DESCRIPTION
This allows removal of config entries by setting their value to undef.  In doing so, users can remove values via hiera. One example is checkpoint_segments which was removed in PostgreSQL 9.5, but commonly used as a tuning parameter in older versions.

I'd like some verification on whether undef values really couldn't be passed in for some other use case, but I can't imagine any.