### PR TITLE
Fix contrib package name under debian 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,7 +187,7 @@ class postgresql::params inherits postgresql::globals {
           /^6/    => pick($java_package_name, 'libpg-java'),
           default => pick($java_package_name, 'libpostgresql-jdbc-java'),
         },
-      default  => pick($java_package_name, 'libpostgresql-jdbc-java'),
+        default  => pick($java_package_name, 'libpostgresql-jdbc-java'),
       }
       $perl_package_name      = pick($perl_package_name, 'libdbd-pg-perl')
       $plperl_package_name    = pick($plperl_package_name, "postgresql-plperl-${version}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,7 +173,11 @@ class postgresql::params inherits postgresql::globals {
 
       $client_package_name    = pick($client_package_name, "postgresql-client-${version}")
       $server_package_name    = pick($server_package_name, "postgresql-${version}")
-      $contrib_package_name   = pick($contrib_package_name, "postgresql-contrib-${version}")
+      if $::operatingsystem == 'Debian' and $::operatingsystemrelease =~ /^10/ and $postgresql::globals::manage_package_repo != true {
+        $contrib_package_name = pick($contrib_package_name, 'postgresql-contrib')
+      } else {
+        $contrib_package_name = pick($contrib_package_name, "postgresql-contrib-${version}")
+      }
       if $postgis_version and versioncmp($postgis_version, '2') < 0 {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis")
       } elsif $postgis_version and versioncmp($postgis_version, '3') >= 0 {


### PR DESCRIPTION
Under Debian Buster, when we use only debian repo (ie. without using postgresql repo), the PostgreSQL contrib package `postgresql-contrib-11` does not exist, only `postgresql-contrib` is available.

This PR fixes the wrong package name.

Note: Without this fix patch, module usage does not fail during puppet run, instead it notices the following message every run:
```log
Notice: /Stage[main]/Postgresql::Server::Contrib/Package[postgresql-contrib]/ensure: created (corrective)
```

IMHO, this behavior is due to some magic done by `apt`, here the log when I run manually the install with the wrong package name:
```shell-session
$ sudo apt install postgresql-contrib-11
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'postgresql-11' instead of 'postgresql-contrib-11'
postgresql-11 is already the newest version (11.7-0+deb10u1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```