### PR TITLE
Add new common repo which contains add-ons

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -57,6 +57,7 @@
 # @param repo_proxy Sets the proxy option for the official PostgreSQL yum-repositories only.
 #
 # @param repo_baseurl Sets the baseurl for the PostgreSQL repository. Useful if you host your own mirror of the repository.
+# @param yum_repo_commonurl Sets the url for the PostgreSQL common Yum repository. Useful if you host your own mirror of the YUM repository.
 #
 # @param needs_initdb Explicitly calls the initdb operation after the server package is installed and before the PostgreSQL service is started.
 #
@@ -142,6 +143,7 @@ class postgresql::globals (
   $postgis_version                                 = undef,
   $repo_proxy                                      = undef,
   $repo_baseurl                                    = undef,
+  $yum_repo_commonurl                              = undef,
 
   $needs_initdb                                    = undef,
 
@@ -265,9 +267,10 @@ class postgresql::globals (
   # Setup of the repo only makes sense globally, so we are doing this here.
   if($manage_package_repo) {
     class { 'postgresql::repo':
-      version => $globals_version,
-      proxy   => $repo_proxy,
-      baseurl => $repo_baseurl,
+      version   => $globals_version,
+      proxy     => $repo_proxy,
+      baseurl   => $repo_baseurl,
+      commonurl => $yum_repo_commonurl,
     }
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,6 +3,7 @@ class postgresql::repo (
   $version = undef,
   $proxy = undef,
   $baseurl = undef,
+  $commonurl = undef,
 ) {
   case $facts['os']['family'] {
     'RedHat', 'Linux': {

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -20,12 +20,23 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
     $label2 = 'rhel'
   }
   $default_baseurl = "https://download.postgresql.org/pub/repos/yum/${postgresql::repo::version}/${label1}/${label2}-\$releasever-\$basearch"
+  $default_commonurl = "https://download.postgresql.org/pub/repos/yum/common/${label1}/${label2}-\$releasever-\$basearch"
 
   $_baseurl = pick($postgresql::repo::baseurl, $default_baseurl)
+  $_commonurl = pick($postgresql::repo::commonurl, $default_commonurl)
 
   yumrepo { 'yum.postgresql.org':
     descr    => "PostgreSQL ${postgresql::repo::version} \$releasever - \$basearch",
     baseurl  => $_baseurl,
+    enabled  => 1,
+    gpgcheck => 1,
+    gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",
+    proxy    => $postgresql::repo::proxy,
+  }
+
+  yumrepo { 'pgdg-common':
+    descr    => "PostgreSQL common RPMs \$releasever - \$basearch",
+    baseurl  => $_commonurl,
     enabled  => 1,
     gpgcheck => 1,
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}",

--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -75,6 +75,10 @@ describe 'postgresql::globals', type: :class do
           'enabled' => '1',
           'proxy'   => 'http://proxy-server:8080',
         )
+        is_expected.to contain_yumrepo('pgdg-common').with(
+          'enabled' => '1',
+          'proxy'   => 'http://proxy-server:8080',
+        )
       end
     end
 
@@ -82,7 +86,8 @@ describe 'postgresql::globals', type: :class do
       let(:params) do
         {
           manage_package_repo: true,
-          repo_baseurl: 'http://mirror.localrepo.com',
+          repo_baseurl: 'http://mirror.localrepo.com/pgdg-postgresql',
+          yum_repo_commonurl: 'http://mirror.localrepo.com/pgdg-common',
         }
       end
 
@@ -93,7 +98,11 @@ describe 'postgresql::globals', type: :class do
       it do
         is_expected.to contain_yumrepo('yum.postgresql.org').with(
           'enabled' => '1',
-          'baseurl' => 'http://mirror.localrepo.com',
+          'baseurl' => 'http://mirror.localrepo.com/pgdg-postgresql',
+        )
+        is_expected.to contain_yumrepo('pgdg-common').with(
+          'enabled' => '1',
+          'baseurl' => 'http://mirror.localrepo.com/pgdg-common',
         )
       end
     end


### PR DESCRIPTION
Detailed in https://yum.postgresql.org/news/new-repo-rpms-released/, many add-ons and extensions were moved to a common repo. Without this common repo certain addon installations will fail.