### PR TITLE
(maint) Use 'policycoreutils-python-utils' on RHEL 8

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -24,10 +24,19 @@ def install_dependencies
     package { 'iproute2': ensure => installed }
   MANIFEST
   LitmusHelper.instance.apply_manifest(iproute2) if os[:family] == 'ubuntu' && os[:release].start_with?('18.04')
-  selinux = <<-MANIFEST
+
+  return unless os[:family] == 'redhat'
+
+  selinux = if os[:release].start_with?('6', '7')
+              <<-MANIFEST
     package { 'policycoreutils-python': ensure => installed }
-  MANIFEST
-  LitmusHelper.instance.apply_manifest(selinux) if os[:family] == 'redhat' && os[:release].start_with?('6', '7')
+              MANIFEST
+            elsif os[:release].start_with?('8')
+              <<-MANIFEST
+    package { 'policycoreutils-python-utils': ensure => installed }
+              MANIFEST
+            end
+  LitmusHelper.instance.apply_manifest(selinux)
 end
 
 def postgresql_version


### PR DESCRIPTION
The `policycoreutils-python` package has now been replaced by the `policycoreutils-python-utils`
on RHEL 8 according to [this documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#selinux-python3_security)