### PR TITLE
Manage postgresql_conf_path file permissions

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -30,6 +30,7 @@
 # @param pg_hba_conf_path Specifies the path to your pg_hba.conf file.
 # @param pg_ident_conf_path Specifies the path to your pg_ident.conf file.
 # @param postgresql_conf_path Sets the path to your postgresql.conf file.
+# @param postgresql_conf_mode Sets the mode of your postgresql.conf file. Only relevant if manage_postgresql_conf_perms is true.
 # @param recovery_conf_path Path to your recovery.conf file.
 # @param default_connect_settings Default connection settings.
 #
@@ -75,6 +76,10 @@
 # @param manage_pg_hba_conf Allow Puppet to manage the pg_hba.conf file.
 # @param manage_pg_ident_conf Allow Puppet to manage the pg_ident.conf file.
 # @param manage_recovery_conf Allow Puppet to manage the recovery.conf file.
+# @param manage_postgresql_conf_perms
+#   Whether to manage the postgresql conf file permissions. This means owner,
+#   group and mode. Contents are not managed but should be managed through
+#   postgresql::server::config_entry.
 #
 # @param manage_datadir Set to false if you have file{ $datadir: } already defined
 # @param manage_logdir Set to false if you have file{ $logdir: } already defined
@@ -85,68 +90,70 @@
 #
 #
 class postgresql::globals (
-  $client_package_name      = undef,
-  $server_package_name      = undef,
-  $contrib_package_name     = undef,
-  $devel_package_name       = undef,
-  $java_package_name        = undef,
-  $docs_package_name        = undef,
-  $perl_package_name        = undef,
-  $plperl_package_name      = undef,
-  $plpython_package_name    = undef,
-  $python_package_name      = undef,
-  $postgis_package_name     = undef,
+  $client_package_name                             = undef,
+  $server_package_name                             = undef,
+  $contrib_package_name                            = undef,
+  $devel_package_name                              = undef,
+  $java_package_name                               = undef,
+  $docs_package_name                               = undef,
+  $perl_package_name                               = undef,
+  $plperl_package_name                             = undef,
+  $plpython_package_name                           = undef,
+  $python_package_name                             = undef,
+  $postgis_package_name                            = undef,
 
-  $service_name             = undef,
-  $service_provider         = undef,
-  $service_status           = undef,
-  $default_database         = undef,
+  $service_name                                    = undef,
+  $service_provider                                = undef,
+  $service_status                                  = undef,
+  $default_database                                = undef,
 
-  $validcon_script_path     = undef,
+  $validcon_script_path                            = undef,
 
-  $initdb_path              = undef,
-  $createdb_path            = undef,
-  $psql_path                = undef,
-  $pg_hba_conf_path         = undef,
-  $pg_ident_conf_path       = undef,
-  $postgresql_conf_path     = undef,
-  $recovery_conf_path       = undef,
-  $default_connect_settings = {},
+  $initdb_path                                     = undef,
+  $createdb_path                                   = undef,
+  $psql_path                                       = undef,
+  $pg_hba_conf_path                                = undef,
+  $pg_ident_conf_path                              = undef,
+  $postgresql_conf_path                            = undef,
+  Optional[Stdlib::Filemode] $postgresql_conf_mode = undef,
+  $recovery_conf_path                              = undef,
+  $default_connect_settings                        = {},
 
-  $pg_hba_conf_defaults     = undef,
+  $pg_hba_conf_defaults                            = undef,
 
-  $datadir                  = undef,
-  $confdir                  = undef,
-  $bindir                   = undef,
-  $xlogdir                  = undef,
-  $logdir                   = undef,
-  $log_line_prefix          = undef,
-  $manage_datadir           = undef,
-  $manage_logdir            = undef,
-  $manage_xlogdir           = undef,
+  $datadir                                         = undef,
+  $confdir                                         = undef,
+  $bindir                                          = undef,
+  $xlogdir                                         = undef,
+  $logdir                                          = undef,
+  $log_line_prefix                                 = undef,
+  $manage_datadir                                  = undef,
+  $manage_logdir                                   = undef,
+  $manage_xlogdir                                  = undef,
 
-  $user                     = undef,
-  $group                    = undef,
+  $user                                            = undef,
+  $group                                           = undef,
 
-  $version                  = undef,
-  $postgis_version          = undef,
-  $repo_proxy               = undef,
-  $repo_baseurl             = undef,
+  $version                                         = undef,
+  $postgis_version                                 = undef,
+  $repo_proxy                                      = undef,
+  $repo_baseurl                                    = undef,
 
-  $needs_initdb             = undef,
+  $needs_initdb                                    = undef,
 
-  $encoding                 = undef,
-  $locale                   = undef,
-  $data_checksums           = undef,
-  $timezone                 = undef,
+  $encoding                                        = undef,
+  $locale                                          = undef,
+  $data_checksums                                  = undef,
+  $timezone                                        = undef,
 
-  $manage_pg_hba_conf       = undef,
-  $manage_pg_ident_conf     = undef,
-  $manage_recovery_conf     = undef,
-  $manage_selinux           = undef,
+  $manage_pg_hba_conf                              = undef,
+  $manage_pg_ident_conf                            = undef,
+  $manage_recovery_conf                            = undef,
+  $manage_postgresql_conf_perms                    = undef,
+  $manage_selinux                                  = undef,
 
-  $manage_package_repo      = undef,
-  $module_workdir           = undef,
+  $manage_package_repo                             = undef,
+  $module_workdir                                  = undef,
 ) {
   # We are determining this here, because it is needed by the package repo
   # class.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,34 +1,35 @@
 # @api private
 class postgresql::params inherits postgresql::globals {
-  $version                    = $postgresql::globals::globals_version
-  $postgis_version            = $postgresql::globals::globals_postgis_version
-  $listen_addresses           = undef
-  $port                       = 5432
-  $log_line_prefix            = undef
-  $ip_mask_deny_postgres_user = '0.0.0.0/0'
-  $ip_mask_allow_all_users    = '127.0.0.1/32'
-  $ipv4acls                   = []
-  $ipv6acls                   = []
-  $encoding                   = $postgresql::globals::encoding
-  $locale                     = $postgresql::globals::locale
-  $data_checksums             = $postgresql::globals::data_checksums
-  $timezone                   = $postgresql::globals::timezone
-  $service_ensure             = 'running'
-  $service_enable             = true
-  $service_manage             = true
-  $service_restart_on_change  = true
-  $service_provider           = $postgresql::globals::service_provider
-  $manage_pg_hba_conf         = pick($manage_pg_hba_conf, true)
-  $manage_pg_ident_conf       = pick($manage_pg_ident_conf, true)
-  $manage_recovery_conf       = pick($manage_recovery_conf, false)
-  $manage_selinux             = pick($manage_selinux, false)
-  $package_ensure             = 'present'
-  $module_workdir             = pick($module_workdir,'/tmp')
-  $password_encryption        = undef
-  $extra_systemd_config       = ''
-  $manage_datadir             = true
-  $manage_logdir              = true
-  $manage_xlogdir             = true
+  $version                      = $postgresql::globals::globals_version
+  $postgis_version              = $postgresql::globals::globals_postgis_version
+  $listen_addresses             = undef
+  $port                         = 5432
+  $log_line_prefix              = undef
+  $ip_mask_deny_postgres_user   = '0.0.0.0/0'
+  $ip_mask_allow_all_users      = '127.0.0.1/32'
+  $ipv4acls                     = []
+  $ipv6acls                     = []
+  $encoding                     = $postgresql::globals::encoding
+  $locale                       = $postgresql::globals::locale
+  $data_checksums               = $postgresql::globals::data_checksums
+  $timezone                     = $postgresql::globals::timezone
+  $service_ensure               = 'running'
+  $service_enable               = true
+  $service_manage               = true
+  $service_restart_on_change    = true
+  $service_provider             = $postgresql::globals::service_provider
+  $manage_pg_hba_conf           = pick($manage_pg_hba_conf, true)
+  $manage_pg_ident_conf         = pick($manage_pg_ident_conf, true)
+  $manage_recovery_conf         = pick($manage_recovery_conf, false)
+  $manage_postgresql_conf_perms = pick($manage_postgresql_conf_perms, true)
+  $manage_selinux               = pick($manage_selinux, false)
+  $package_ensure               = 'present'
+  $module_workdir               = pick($module_workdir,'/tmp')
+  $password_encryption          = undef
+  $extra_systemd_config         = ''
+  $manage_datadir               = true
+  $manage_logdir                = true
+  $manage_xlogdir               = true
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $facts['os']['family'] {
@@ -78,6 +79,7 @@ class postgresql::params inherits postgresql::globals {
           default  => pick($datadir, "/var/lib/pgsql/${version}/data"),
         }
         $confdir                = pick($confdir, $datadir)
+        $postgresql_conf_mode   = pick($postgresql_conf_mode, '0600')
       }
 
       case $facts['os']['name'] {
@@ -212,6 +214,7 @@ class postgresql::params inherits postgresql::globals {
       }
       $service_reload         = "service ${service_name} reload"
       $psql_path              = pick($psql_path, '/usr/bin/psql')
+      $postgresql_conf_mode   = pick($postgresql_conf_mode, '0644')
     }
 
     'Gentoo': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,7 @@
 # @param pg_hba_conf_path Specifies the path to your pg_hba.conf file.
 # @param pg_ident_conf_path Specifies the path to your pg_ident.conf file.
 # @param postgresql_conf_path Specifies the path to your postgresql.conf file.
+# @param postgresql_conf_mode Sets the mode of your postgresql.conf file. Only relevant if manage_postgresql_conf_perms is true.
 # @param recovery_conf_path Specifies the path to your recovery.conf file.
 #
 # @param datadir PostgreSQL data directory
@@ -63,6 +64,10 @@
 # @param manage_pg_hba_conf Boolean. Whether to manage the pg_hba.conf.
 # @param manage_pg_ident_conf Boolean. Overwrites the pg_ident.conf file.
 # @param manage_recovery_conf Boolean. Specifies whether or not manage the recovery.conf.
+# @param manage_postgresql_conf_perms
+#   Whether to manage the postgresql conf file permissions. This means owner,
+#   group and mode. Contents are not managed but should be managed through
+#   postgresql::server::config_entry.
 # @param module_workdir Working directory for the PostgreSQL module
 #
 # @param manage_datadir Set to false if you have file{ $datadir: } already defined
@@ -78,68 +83,70 @@
 # @param extra_systemd_config Adds extra config to systemd config file, can for instance be used to add extra openfiles. This can be a multi line string
 #
 class postgresql::server (
-  $postgres_password          = undef,
+  $postgres_password                               = undef,
 
-  $package_name               = $postgresql::params::server_package_name,
-  $package_ensure             = $postgresql::params::package_ensure,
+  $package_name                                    = $postgresql::params::server_package_name,
+  $package_ensure                                  = $postgresql::params::package_ensure,
 
-  $plperl_package_name        = $postgresql::params::plperl_package_name,
-  $plpython_package_name      = $postgresql::params::plpython_package_name,
+  $plperl_package_name                             = $postgresql::params::plperl_package_name,
+  $plpython_package_name                           = $postgresql::params::plpython_package_name,
 
-  $service_ensure             = $postgresql::params::service_ensure,
-  $service_enable             = $postgresql::params::service_enable,
-  $service_manage             = $postgresql::params::service_manage,
-  $service_name               = $postgresql::params::service_name,
-  $service_restart_on_change  = $postgresql::params::service_restart_on_change,
-  $service_provider           = $postgresql::params::service_provider,
-  $service_reload             = $postgresql::params::service_reload,
-  $service_status             = $postgresql::params::service_status,
-  $default_database           = $postgresql::params::default_database,
-  $default_connect_settings   = $postgresql::globals::default_connect_settings,
-  $listen_addresses           = $postgresql::params::listen_addresses,
-  $port                       = $postgresql::params::port,
-  $ip_mask_deny_postgres_user = $postgresql::params::ip_mask_deny_postgres_user,
-  $ip_mask_allow_all_users    = $postgresql::params::ip_mask_allow_all_users,
-  Array[String[1]] $ipv4acls  = $postgresql::params::ipv4acls,
-  Array[String[1]] $ipv6acls  = $postgresql::params::ipv6acls,
+  $service_ensure                                  = $postgresql::params::service_ensure,
+  $service_enable                                  = $postgresql::params::service_enable,
+  $service_manage                                  = $postgresql::params::service_manage,
+  $service_name                                    = $postgresql::params::service_name,
+  $service_restart_on_change                       = $postgresql::params::service_restart_on_change,
+  $service_provider                                = $postgresql::params::service_provider,
+  $service_reload                                  = $postgresql::params::service_reload,
+  $service_status                                  = $postgresql::params::service_status,
+  $default_database                                = $postgresql::params::default_database,
+  $default_connect_settings                        = $postgresql::globals::default_connect_settings,
+  $listen_addresses                                = $postgresql::params::listen_addresses,
+  $port                                            = $postgresql::params::port,
+  $ip_mask_deny_postgres_user                      = $postgresql::params::ip_mask_deny_postgres_user,
+  $ip_mask_allow_all_users                         = $postgresql::params::ip_mask_allow_all_users,
+  Array[String[1]] $ipv4acls                       = $postgresql::params::ipv4acls,
+  Array[String[1]] $ipv6acls                       = $postgresql::params::ipv6acls,
 
-  $initdb_path                = $postgresql::params::initdb_path,
-  $createdb_path              = $postgresql::params::createdb_path,
-  $psql_path                  = $postgresql::params::psql_path,
-  $pg_hba_conf_path           = $postgresql::params::pg_hba_conf_path,
-  $pg_ident_conf_path         = $postgresql::params::pg_ident_conf_path,
-  $postgresql_conf_path       = $postgresql::params::postgresql_conf_path,
-  $recovery_conf_path         = $postgresql::params::recovery_conf_path,
+  $initdb_path                                     = $postgresql::params::initdb_path,
+  $createdb_path                                   = $postgresql::params::createdb_path,
+  $psql_path                                       = $postgresql::params::psql_path,
+  $pg_hba_conf_path                                = $postgresql::params::pg_hba_conf_path,
+  $pg_ident_conf_path                              = $postgresql::params::pg_ident_conf_path,
+  $postgresql_conf_path                            = $postgresql::params::postgresql_conf_path,
+  Optional[Stdlib::Filemode] $postgresql_conf_mode = $postgresql::params::postgresql_conf_mode,
+  $recovery_conf_path                              = $postgresql::params::recovery_conf_path,
 
-  $datadir                    = $postgresql::params::datadir,
-  $xlogdir                    = $postgresql::params::xlogdir,
-  $logdir                     = $postgresql::params::logdir,
+  $datadir                                         = $postgresql::params::datadir,
+  $xlogdir                                         = $postgresql::params::xlogdir,
+  $logdir                                          = $postgresql::params::logdir,
 
-  $log_line_prefix            = $postgresql::params::log_line_prefix,
+  $log_line_prefix                                 = $postgresql::params::log_line_prefix,
 
-  $pg_hba_conf_defaults       = $postgresql::params::pg_hba_conf_defaults,
+  $pg_hba_conf_defaults                            = $postgresql::params::pg_hba_conf_defaults,
 
-  $user                       = $postgresql::params::user,
-  $group                      = $postgresql::params::group,
+  $user                                            = $postgresql::params::user,
+  $group                                           = $postgresql::params::group,
 
-  $needs_initdb               = $postgresql::params::needs_initdb,
+  $needs_initdb                                    = $postgresql::params::needs_initdb,
 
-  $encoding                   = $postgresql::params::encoding,
-  $locale                     = $postgresql::params::locale,
-  $data_checksums             = $postgresql::params::data_checksums,
-  $timezone                   = $postgresql::params::timezone,
+  $encoding                                        = $postgresql::params::encoding,
+  $locale                                          = $postgresql::params::locale,
+  $data_checksums                                  = $postgresql::params::data_checksums,
+  $timezone                                        = $postgresql::params::timezone,
 
-  $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
-  $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,
-  $manage_recovery_conf       = $postgresql::params::manage_recovery_conf,
-  Boolean $manage_selinux     = $postgresql::params::manage_selinux,
-  $module_workdir             = $postgresql::params::module_workdir,
+  $manage_pg_hba_conf                              = $postgresql::params::manage_pg_hba_conf,
+  $manage_pg_ident_conf                            = $postgresql::params::manage_pg_ident_conf,
+  $manage_recovery_conf                            = $postgresql::params::manage_recovery_conf,
+  Boolean $manage_postgresql_conf_perms            = $postgresql::params::manage_postgresql_conf_perms,
+  Boolean $manage_selinux                          = $postgresql::params::manage_selinux,
+  $module_workdir                                  = $postgresql::params::module_workdir,
 
-  $manage_datadir             = $postgresql::params::manage_datadir,
-  $manage_logdir              = $postgresql::params::manage_logdir,
-  $manage_xlogdir             = $postgresql::params::manage_xlogdir,
-  $password_encryption        = $postgresql::params::password_encryption,
-  $extra_systemd_config       = $postgresql::params::extra_systemd_config,
+  $manage_datadir                                  = $postgresql::params::manage_datadir,
+  $manage_logdir                                   = $postgresql::params::manage_logdir,
+  $manage_xlogdir                                  = $postgresql::params::manage_xlogdir,
+  $password_encryption                             = $postgresql::params::password_encryption,
+  $extra_systemd_config                            = $postgresql::params::extra_systemd_config,
 
   Hash[String, Hash] $roles         = {},
   Hash[String, Any] $config_entries = {},

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,29 +1,31 @@
 # @api private
 class postgresql::server::config {
-  $ip_mask_deny_postgres_user = $postgresql::server::ip_mask_deny_postgres_user
-  $ip_mask_allow_all_users    = $postgresql::server::ip_mask_allow_all_users
-  $listen_addresses           = $postgresql::server::listen_addresses
-  $port                       = $postgresql::server::port
-  $ipv4acls                   = $postgresql::server::ipv4acls
-  $ipv6acls                   = $postgresql::server::ipv6acls
-  $pg_hba_conf_path           = $postgresql::server::pg_hba_conf_path
-  $pg_ident_conf_path         = $postgresql::server::pg_ident_conf_path
-  $postgresql_conf_path       = $postgresql::server::postgresql_conf_path
-  $recovery_conf_path         = $postgresql::server::recovery_conf_path
-  $pg_hba_conf_defaults       = $postgresql::server::pg_hba_conf_defaults
-  $user                       = $postgresql::server::user
-  $group                      = $postgresql::server::group
-  $version                    = $postgresql::server::_version
-  $manage_pg_hba_conf         = $postgresql::server::manage_pg_hba_conf
-  $manage_pg_ident_conf       = $postgresql::server::manage_pg_ident_conf
-  $manage_recovery_conf       = $postgresql::server::manage_recovery_conf
-  $datadir                    = $postgresql::server::datadir
-  $logdir                     = $postgresql::server::logdir
-  $service_name               = $postgresql::server::service_name
-  $log_line_prefix            = $postgresql::server::log_line_prefix
-  $timezone                   = $postgresql::server::timezone
-  $password_encryption        = $postgresql::server::password_encryption
-  $extra_systemd_config       = $postgresql::server::extra_systemd_config
+  $ip_mask_deny_postgres_user   = $postgresql::server::ip_mask_deny_postgres_user
+  $ip_mask_allow_all_users      = $postgresql::server::ip_mask_allow_all_users
+  $listen_addresses             = $postgresql::server::listen_addresses
+  $port                         = $postgresql::server::port
+  $ipv4acls                     = $postgresql::server::ipv4acls
+  $ipv6acls                     = $postgresql::server::ipv6acls
+  $pg_hba_conf_path             = $postgresql::server::pg_hba_conf_path
+  $pg_ident_conf_path           = $postgresql::server::pg_ident_conf_path
+  $postgresql_conf_path         = $postgresql::server::postgresql_conf_path
+  $postgresql_conf_mode         = $postgresql::server::postgresql_conf_mode
+  $recovery_conf_path           = $postgresql::server::recovery_conf_path
+  $pg_hba_conf_defaults         = $postgresql::server::pg_hba_conf_defaults
+  $user                         = $postgresql::server::user
+  $group                        = $postgresql::server::group
+  $version                      = $postgresql::server::_version
+  $manage_pg_hba_conf           = $postgresql::server::manage_pg_hba_conf
+  $manage_pg_ident_conf         = $postgresql::server::manage_pg_ident_conf
+  $manage_recovery_conf         = $postgresql::server::manage_recovery_conf
+  $manage_postgresql_conf_perms = $postgresql::server::manage_postgresql_conf_perms
+  $datadir                      = $postgresql::server::datadir
+  $logdir                       = $postgresql::server::logdir
+  $service_name                 = $postgresql::server::service_name
+  $log_line_prefix              = $postgresql::server::log_line_prefix
+  $timezone                     = $postgresql::server::timezone
+  $password_encryption          = $postgresql::server::password_encryption
+  $extra_systemd_config         = $postgresql::server::extra_systemd_config
 
   if ($manage_pg_hba_conf == true) {
     # Prepare the main pg_hba file
@@ -97,6 +99,15 @@ class postgresql::server::config {
       postgresql::server::pg_hba_rule { $key:
         * => $attrs,
       }
+    }
+  }
+
+  if $manage_postgresql_conf_perms {
+    file { $postgresql_conf_path:
+      ensure => file,
+      owner  => $user,
+      group  => $group,
+      mode   => $postgresql_conf_mode,
     }
   }
 

--- a/spec/acceptance/server/config_entry_spec.rb
+++ b/spec/acceptance/server/config_entry_spec.rb
@@ -5,7 +5,7 @@ describe 'postgresql::server::config_entry' do
     let(:pp_test) do
       <<-MANIFEST
       class { 'postgresql::server':
-        postgresql_conf_path => '/tmp/postgresql.conf',
+        postgresql_conf_path => '/etc/postgresql-puppet.conf',
       }
 
       postgresql::server::config_entry { 'unix_socket_directories':
@@ -16,7 +16,7 @@ describe 'postgresql::server::config_entry' do
 
     it 'is expected to run idempotently' do
       idempotent_apply(pp_test)
-      expect(run_shell('cat /tmp/postgresql.conf').stdout).to match "unix_socket_directories = '/var/socket/, /root/'"
+      expect(run_shell('cat /etc/postgresql-puppet.conf').stdout).to match "unix_socket_directories = '/var/socket/, /root/'"
     end
   end
 end


### PR DESCRIPTION
This adds a parameter (defaulting to true) to manage the postgresql_conf_path file resource. The actual content isn't managed because that's what postgresql::server::config_entry is for. However, managing the file ensures the correct permissions.

It also provides a workaround for [PUP-10548](https://tickets.puppetlabs.com/browse/PUP-10548) when using Red Hat SCL for packages when the correct SELinux file context isn't present.  Without managing the file, an admin will need to either make sure the package is present before running Puppet, manage the file via another module or manually set the file context after Puppet ran. With this workaround, Puppet will converge on the second run and actually start PostgreSQL.