### PR TITLE
Change - Use systemd drop-in directory for unit overrides

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -216,7 +216,12 @@ class postgresql::server::config {
       # - $datadir
       # - @extra_systemd_config
 
-    if (versioncmp($facts['puppetversion'], '5.0.0') <= 0) {
+    if (versioncmp($facts['puppetversion'], '6.1.0') < 0) {
+      exec { 'restart-systemd':
+        command     => 'systemctl daemon-reload',
+        refreshonly => true,
+        path        => '/bin:/usr/bin:/usr/local/bin',
+      }
       $systemd_notify = [Exec['restart-systemd'], Class['postgresql::server::service']]
     }
     else {

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -316,7 +316,6 @@ describe 'postgresql::server::config', type: :class do
           },
           selinux: { 'enabled' => true },
         },
-        concat_basedir: tmpfilename('server'),
         kernel: 'Linux',
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -354,7 +354,6 @@ describe 'postgresql::server::config', type: :class do
           },
           selinux: { 'enabled' => true },
         },
-        concat_basedir: tmpfilename('server'),
         kernel: 'Linux',
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -18,12 +18,14 @@ describe 'postgresql::server::config', type: :class do
           'hardware'     => 'x86_64',
           'name'         => 'CentOS',
           'release'      => {
-            'full'  => '7.6.1810',
+            'full'  => '7.9.2009',
             'major' => '7',
-            'minor' => '6',
+            'minor' => '9',
           },
           selinux: { 'enabled' => true },
         },
+        operatingsystemrelease: '7.9.2009',
+        service_provider: 'systemd',
       }
     end
 
@@ -36,15 +38,55 @@ describe 'postgresql::server::config', type: :class do
         .that_requires('Package[policycoreutils-python-utils]')
     end
 
-    it 'has the correct systemd-override file' do
-      is_expected.to contain_file('systemd-override').with(
-        ensure: 'file', path: '/etc/systemd/system/postgresql.service',
-        owner: 'root', group: 'root'
-      )
+    it 'removes the old systemd-override file' do
+      is_expected.to contain_file('old-systemd-override')
+        .with(ensure: 'absent', path: '/etc/systemd/system/postgresql.service')
     end
-    it 'has the correct systemd-override file #content' do
+
+    it 'has the correct systemd-override drop file' do
+      is_expected.to contain_file('systemd-override').with(
+        ensure: 'file', path: '/etc/systemd/system/postgresql.service.d/postgresql.conf',
+        owner: 'root', group: 'root'
+      ) .that_requires('File[systemd-conf-dir]')
+    end
+
+    it 'has the correct systemd-override file #regex' do
       is_expected.to contain_file('systemd-override') \
-        .with_content(%r{.include \/usr\/lib\/systemd\/system\/postgresql.service})
+        .with_content(%r{(?!^.include)})
+    end
+
+    context 'RHEL 7 host with Puppet 5' do
+      let(:facts) do
+        {
+          kernel: 'Linux',
+          id: 'root',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          selinux: true,
+          os: {
+            'architecture' => 'x86_64',
+            'family'       => 'RedHat',
+            'hardware'     => 'x86_64',
+            'name'         => 'CentOS',
+            'release'      => {
+              'full'  => '7.9.2009',
+              'major' => '7',
+              'minor' => '9',
+            },
+            selinux: { 'enabled' => true },
+          },
+          operatingsystemrelease: '7.9.2009',
+          puppetversion: '5.0.1',
+          service_provider: 'systemd',
+        }
+      end
+
+      it 'has systemctl restart command' do
+        is_expected.to contain_exec('restart-systemd').with(
+          command: 'systemctl daemon-reload',
+          refreshonly: true,
+          path: '/bin:/usr/bin:/usr/local/bin',
+        )
+      end
     end
 
     describe 'with manage_package_repo => true and a version' do
@@ -60,18 +102,92 @@ describe 'postgresql::server::config', type: :class do
 
       it 'has the correct systemd-override file' do
         is_expected.to contain_file('systemd-override').with(
-          ensure: 'file', path: '/etc/systemd/system/postgresql-9.4.service',
+          ensure: 'file', path: '/etc/systemd/system/postgresql-9.4.service.d/postgresql-9.4.conf',
           owner: 'root', group: 'root'
         )
       end
+
       it 'has the correct systemd-override file #regex' do
-        is_expected.to contain_file('systemd-override') \
-          .with_content(%r{.include \/usr\/lib\/systemd\/system\/postgresql-9.4.service})
+        is_expected.to contain_file('systemd-override') .without_content(%r{\.include})
       end
     end
   end
 
-  describe 'on Fedora 21' do
+  describe 'on Redhat 8' do
+    let(:facts) do
+      {
+        concat_basedir: tmpfilename('server'),
+        kernel: 'Linux',
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        selinux: true,
+        os: {
+          'architecture' => 'x86_64',
+          'family'       => 'RedHat',
+          'hardware'     => 'x86_64',
+          'name'         => 'RedHat',
+          'release'      => {
+            'full'  => '8.2.2004',
+            'major' => '8',
+            'minor' => '2',
+          },
+          selinux: { 'enabled' => true },
+        },
+        operatingsystem: 'RedHat',
+        operatingsystemrelease: '8.2.2004',
+        service_provider: 'systemd',
+      }
+    end
+
+    it 'has SELinux port defined' do
+      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+
+      is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
+        .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
+        .that_comes_before('Postgresql::Server::Config_entry[port]')
+        .that_requires('Package[policycoreutils-python-utils]')
+    end
+
+    it 'removes the old systemd-override file' do
+      is_expected.to contain_file('old-systemd-override')
+        .with(ensure: 'absent', path: '/etc/systemd/system/postgresql.service')
+    end
+
+    it 'has the correct systemd-override drop file' do
+      is_expected.to contain_file('systemd-override').with(
+        ensure: 'file', path: '/etc/systemd/system/postgresql.service.d/postgresql.conf',
+        owner: 'root', group: 'root'
+      ) .that_requires('File[systemd-conf-dir]')
+    end
+
+    it 'has the correct systemd-override file #regex' do
+      is_expected.to contain_file('systemd-override') .without_content(%r{\.include})
+    end
+
+    describe 'with manage_package_repo => true and a version' do
+      let(:pre_condition) do
+        <<-EOS
+          class { 'postgresql::globals':
+            manage_package_repo => true,
+            version => '9.4',
+          }->
+          class { 'postgresql::server': }
+        EOS
+      end
+
+      it 'has the correct systemd-override file' do
+        is_expected.to contain_file('systemd-override').with(
+          ensure: 'file', path: '/etc/systemd/system/postgresql-9.4.service.d/postgresql-9.4.conf',
+          owner: 'root', group: 'root'
+        )
+      end
+      it 'has the correct systemd-override file #regex' do
+        is_expected.to contain_file('systemd-override') .without_content(%r{\.include})
+      end
+    end
+  end
+
+  describe 'on Fedora 33' do
     let(:facts) do
       {
         kernel: 'Linux',
@@ -84,12 +200,15 @@ describe 'postgresql::server::config', type: :class do
           'hardware'     => 'x86_64',
           'name'         => 'Fedora',
           'release'      => {
-            'full'  => '21',
-            'major' => '21',
+            'full'  => '33',
+            'major' => '33',
+            'minor' => '33',
           },
           selinux: { 'enabled' => true },
         },
         operatingsystem: 'Fedora',
+        operatingsystemrelease: '33',
+        service_provider: 'systemd',
       }
     end
 
@@ -102,15 +221,20 @@ describe 'postgresql::server::config', type: :class do
         .that_requires('Package[policycoreutils-python-utils]')
     end
 
-    it 'has the correct systemd-override file' do
-      is_expected.to contain_file('systemd-override').with(
-        ensure: 'file', path: '/etc/systemd/system/postgresql.service',
-        owner: 'root', group: 'root'
-      )
+    it 'removes the old systemd-override file' do
+      is_expected.to contain_file('old-systemd-override')
+        .with(ensure: 'absent', path: '/etc/systemd/system/postgresql.service')
     end
+
+    it 'has the correct systemd-override drop file' do
+      is_expected.to contain_file('systemd-override').with(
+        ensure: 'file', path: '/etc/systemd/system/postgresql.service.d/postgresql.conf',
+        owner: 'root', group: 'root'
+      ) .that_requires('File[systemd-conf-dir]')
+    end
+
     it 'has the correct systemd-override file #regex' do
-      is_expected.to contain_file('systemd-override') \
-        .with_content(%r{.include \/lib\/systemd\/system\/postgresql.service})
+      is_expected.to contain_file('systemd-override') .without_content(%r{\.include})
     end
 
     describe 'with manage_package_repo => true and a version' do
@@ -118,7 +242,7 @@ describe 'postgresql::server::config', type: :class do
         <<-EOS
           class { 'postgresql::globals':
             manage_package_repo => true,
-            version => '9.4',
+            version => '13',
           }->
           class { 'postgresql::server': }
         EOS
@@ -126,13 +250,13 @@ describe 'postgresql::server::config', type: :class do
 
       it 'has the correct systemd-override file' do
         is_expected.to contain_file('systemd-override').with(
-          ensure: 'file', path: '/etc/systemd/system/postgresql-9.4.service',
+          ensure: 'file', path: '/etc/systemd/system/postgresql-13.service.d/postgresql-13.conf',
           owner: 'root', group: 'root'
         )
       end
+
       it 'has the correct systemd-override file #regex' do
-        is_expected.to contain_file('systemd-override') \
-          .with_content(%r{.include \/lib\/systemd\/system\/postgresql-9.4.service})
+        is_expected.to contain_file('systemd-override') .without_content(%r{\.include})
       end
     end
   end
@@ -143,7 +267,10 @@ describe 'postgresql::server::config', type: :class do
         os: {
           family: 'RedHat',
           name: 'Amazon',
-          release: { 'full' => '1.0' },
+          release: {
+            'full'  => '1.0',
+            'major' => '1',
+          },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',
@@ -160,47 +287,6 @@ describe 'postgresql::server::config', type: :class do
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
         .that_comes_before('Postgresql::Server::Config_entry[port]')
         .that_requires('Package[policycoreutils]')
-    end
-  end
-
-  describe 'on Gentoo' do
-    let(:pre_condition) do
-      <<-EOS
-        class { 'postgresql::globals':
-          version => '9.5',
-        }->
-        class { 'postgresql::server': }
-      EOS
-    end
-    let(:facts) do
-      {
-        os: {
-          family: 'Gentoo',
-          name: 'Gentoo',
-          release: { 'full' => 'unused' },
-          selinux: { 'enabled' => true },
-        },
-        osfamily: 'Gentoo',
-        kernel: 'Linux',
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        selinux: false,
-      }
-    end
-
-    it 'does not have SELinux port defined' do
-      is_expected.not_to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
-    end
-
-    it 'has the correct systemd-override file' do
-      is_expected.to contain_file('systemd-override').with(
-        ensure: 'file', path: '/etc/systemd/system/postgresql-9.5.service',
-        owner: 'root', group: 'root'
-      )
-    end
-    it 'has the correct systemd-override file #regex' do
-      is_expected.to contain_file('systemd-override') \
-        .with_content(%r{.include \/usr\/lib64\/systemd\/system\/postgresql-9.5.service})
     end
   end
 
@@ -224,13 +310,19 @@ describe 'postgresql::server::config', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '7.0' },
+          release: {
+            'full'  => '7.9.2009',
+            'major' => '7',
+            'minor' => '9',
+          },
           selinux: { 'enabled' => true },
         },
+        concat_basedir: tmpfilename('server'),
         kernel: 'Linux',
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         selinux: true,
+        service_provider: 'systemd',
       }
     end
 
@@ -239,6 +331,58 @@ describe 'postgresql::server::config', type: :class do
     end
     it 'has hba rule ipv4acls' do
       is_expected.to contain_postgresql__server__pg_hba_rule('postgresql class generated rule ipv4acls 0')
+    end
+  end
+
+  describe 'on Gentoo' do
+    let(:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          version => '9.5',
+        }->
+        class { 'postgresql::server': }
+      EOS
+    end
+
+    let(:facts) do
+      {
+        os: {
+          family: 'Gentoo',
+          name: 'Gentoo',
+          release: {
+            'full'  => 'unused',
+            'major' => 'unused',
+          },
+          selinux: { 'enabled' => true },
+        },
+        concat_basedir: tmpfilename('server'),
+        kernel: 'Linux',
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        selinux: false,
+        service_provider: 'systemd',
+      }
+    end
+
+    it 'does not have SELinux port defined' do
+      is_expected.not_to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
+    end
+
+    it 'removes the old systemd-override file' do
+      is_expected.to contain_file('old-systemd-override')
+        .with(ensure: 'absent', path: '/etc/systemd/system/postgresql-9.5.service')
+    end
+
+    it 'has the correct systemd-override drop file' do
+      is_expected.to contain_file('systemd-override').with(
+        ensure: 'file', path: '/etc/systemd/system/postgresql-9.5.service.d/postgresql-9.5.conf',
+        owner: 'root', group: 'root'
+      )
+    end
+
+    it 'has the correct systemd-override file #regex' do
+      is_expected.to contain_file('systemd-override') \
+        .with_content(%r{(?!^.include)})
     end
   end
 end

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -116,7 +116,6 @@ describe 'postgresql::server::config', type: :class do
   describe 'on Redhat 8' do
     let(:facts) do
       {
-        concat_basedir: tmpfilename('server'),
         kernel: 'Linux',
         id: 'root',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -6,7 +6,11 @@ describe 'postgresql::server::config_entry', type: :define do
       os: {
         family: 'RedHat',
         name: 'RedHat',
-        release: { 'full' => '6.4' },
+        release: {
+          'full'  => '6.4',
+          'major' => '6',
+          'minor' => '4',
+        },
         selinux: { 'enabled' => true },
       },
       kernel: 'Linux',
@@ -63,46 +67,24 @@ describe 'postgresql::server::config_entry', type: :define do
           os: {
             family: 'RedHat',
             name: 'RedHat',
-            release: { 'full' => '7.0' },
+            release: {
+              'full'  => '7.9.2009',
+              'major' => '7',
+              'minor' => '9',
+            },
             selinux: { 'enabled' => true },
           },
           kernel: 'Linux',
           id: 'root',
           path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
           selinux: true,
+          service_provider: 'systemd',
         }
       end
       let(:params) { { ensure: 'present', name: 'port_spec', value: '5432' } }
 
       it 'stops postgresql and changes the port #file' do
         is_expected.to contain_file('systemd-override')
-      end
-      it 'stops postgresql and changes the port #exec' do
-        is_expected.to contain_exec('restart-systemd')
-      end
-    end
-    context 'fedora 19' do
-      let :facts do
-        {
-          os: {
-            family: 'RedHat',
-            name: 'Fedora',
-            release: { 'full' => '19' },
-            selinux: { 'enabled' => true },
-          },
-          kernel: 'Linux',
-          id: 'root',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          selinux: true,
-        }
-      end
-      let(:params) { { ensure: 'present', name: 'port_spec', value: '5432' } }
-
-      it 'stops postgresql and changes the port #file' do
-        is_expected.to contain_file('systemd-override')
-      end
-      it 'stops postgresql and changes the port #exec' do
-        is_expected.to contain_exec('restart-systemd')
       end
     end
   end

--- a/templates/systemd-override.erb
+++ b/templates/systemd-override.erb
@@ -1,13 +1,9 @@
-<%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
-.include /usr/lib64/systemd/system/<%= @service_name %>.service
-<%- elsif scope.lookupvar('::operatingsystem') == 'Fedora' -%>
-.include /lib/systemd/system/<%= @service_name %>.service
-<% else -%>
+<%- if @os['name'] == 'Fedora' and @os['release']['major'] <= '31' -%>
 .include /usr/lib/systemd/system/<%= @service_name %>.service
 <% end -%>
 [Service]
 Environment=PGPORT=<%= @port %>
-<%- if scope.lookupvar('::osfamily') == 'Gentoo' -%>
+<%- if @os['family'] == 'Gentoo' -%>
 Environment=DATA_DIR=<%= @datadir %>
 <%- else -%>
 Environment=PGDATA=<%= @datadir %>


### PR DESCRIPTION
The .include directive has been deprecated and support for it may be removed in a future systemd release.  This fixes warnings issued by systemd which are shown as follows.

```
systemd[1]: /etc/systemd/system/postgresql-9.6.service:1: .include directives are deprecated, and support for them will be removed in a future version of systemd. Please use drop-in files instead.
```