### PR TITLE
Use non-deprecation password function in acceptance tests

### DIFF
--- a/spec/acceptance/overridden_settings_spec.rb
+++ b/spec/acceptance/overridden_settings_spec.rb
@@ -8,7 +8,7 @@ describe 'postgresql::server' do
     class { 'postgresql::server':
       roles          => {
         'testusername' => {
-          password_hash => postgresql_password('testusername', 'supersecret'),
+          password_hash => postgresql::postgresql_password('testusername', 'supersecret'),
           createdb      => true,
         },
       },

--- a/spec/acceptance/postgresql_conn_validator_spec.rb
+++ b/spec/acceptance/postgresql_conn_validator_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql_conn_validator' do
         postgres_password => 'space password',
       }->
       postgresql::server::role { 'testuser':
-        password_hash => postgresql_password('testuser','test1'),
+        password_hash => postgresql::postgresql_password('testuser','test1'),
       }->
       postgresql::server::database { 'testdb':
         owner   => 'testuser',

--- a/spec/acceptance/server/grant_role_spec.rb
+++ b/spec/acceptance/server/grant_role_spec.rb
@@ -26,7 +26,7 @@ describe 'postgresql::server::grant_role:' do
       }
 
       postgresql::server::role { $user:
-        password_hash => postgresql_password($user, $password),
+        password_hash => postgresql::postgresql_password($user, $password),
       }
 
       postgresql::server::database { $db:
@@ -80,7 +80,7 @@ describe 'postgresql::server::grant_role:' do
       }
 
       postgresql::server::role { $user:
-        password_hash => postgresql_password($user, $password),
+        password_hash => postgresql::postgresql_password($user, $password),
       }
 
       postgresql::server::database { $db:

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -15,7 +15,7 @@ describe 'postgresql::server::grant:' do
       class { 'postgresql::server': }
 
       postgresql::server::role { $owner:
-        password_hash => postgresql_password($owner, $password),
+        password_hash => postgresql::postgresql_password($owner, $password),
       }
 
       # Since we are not testing pg_hba or any of that, make a local user for ident auth

--- a/spec/acceptance/server/reassign_owned_by_spec.rb
+++ b/spec/acceptance/server/reassign_owned_by_spec.rb
@@ -17,7 +17,7 @@ describe 'postgresql::server::reassign_owned_by:' do
       class { 'postgresql::server': }
 
       postgresql::server::role { $old_owner:
-        password_hash => postgresql_password($old_owner, $password),
+        password_hash => postgresql::postgresql_password($old_owner, $password),
       }
 
       # Since we are not testing pg_hba or any of that, make a local user for ident auth

--- a/spec/acceptance/server/schema_spec.rb
+++ b/spec/acceptance/server/schema_spec.rb
@@ -21,7 +21,7 @@ describe 'postgresql::server::schema:' do
       }
 
       postgresql::server::role { $user:
-        password_hash => postgresql_password($user, $password),
+        password_hash => postgresql::postgresql_password($user, $password),
       }
 
       postgresql::server::database { $db:

--- a/spec/acceptance/sql_task_spec.rb
+++ b/spec/acceptance/sql_task_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql task' do
         class { 'postgresql::server': } ->
         postgresql::server::db { 'spec1':
           user     => 'root1',
-          password => postgresql_password('root1', 'password'),
+          password => postgresql::postgresql_password('root1', 'password'),
         }
     MANIFEST
 


### PR DESCRIPTION
700d2c5bb54b7ea91d518de96e2c7a22318d0afa claimed to complete the work that c3b06d6093b0aab210ec06b11e92a731c608fccd started, but didn't migrate the acceptance tests. This avoids deprecation warnings in the output.