### PR TITLE
(maint) updated defaults for rhel7 policycoreutils

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -128,6 +128,7 @@ class postgresql::server::config {
           $package_name = $facts['os']['release']['major'] ? {
             '5'     => 'policycoreutils',
             '6'     => 'policycoreutils-python',
+            '7'     => 'policycoreutils-python',
             default => 'policycoreutils-python-utils',
           }
         }

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -28,12 +28,12 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
-      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+      is_expected.to contain_package('policycoreutils-python') .with(ensure: 'present')
 
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
         .that_comes_before('Postgresql::Server::Config_entry[port]')
-        .that_requires('Package[policycoreutils-python-utils]')
+        .that_requires('Package[policycoreutils-python]')
     end
 
     it 'has the correct systemd-override file' do


### PR DESCRIPTION
Request for a review
Updated defaults for rhel7 for the policycoreutils package
The tests are failing with the following error

`puppet apply manifest_20201124_2335_k9rka1.pp --trace --detailed-exitcodes`
====== Start output of Puppet apply with unexpected changes ======
�[1;31mError: Execution of '/bin/yum -d 0 -e 0 -y install policycoreutils-python-utils' returned 1: Error: Nothing to do
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/execution.rb:286:in `execute'`
