### PR TITLE
Support CentOS 8 Stream

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -175,11 +175,11 @@ class postgresql::globals (
       },
       'Amazon' => '9.2',
       default => $facts['os']['release']['full'] ? {
-        /^8\./ => '10',
-        /^7\./ => '9.2',
-        /^6\./ => '8.4',
-        /^5\./ => '8.1',
-        default => undef,
+        /^8(\.|$)/ => '10',
+        /^7\./     => '9.2',
+        /^6\./     => '8.4',
+        /^5\./     => '8.1',
+        default    => undef,
       },
     },
     'Debian' => $facts['os']['name'] ? {


### PR DESCRIPTION
CentOS 8 Stream identifies itself without a minor version. This modifies the default to handle this. For completeness, the OS facts:

```console
# facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "CentOS",
  release => {
    full => "8",
    major => "8"
  },
  selinux => {
    enabled => false
  }
}
```

This is the first thing I found. I have not yet done a real test myself so for now this is a draft.