### PR TITLE
Clean up globals logic to support CentOS 8 stream

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -204,10 +204,7 @@ class postgresql::globals (
       },
       default => undef,
     },
-    'Archlinux' => $facts['os']['name'] ? {
-      /Archlinux/ => '9.2',
-      default => '9.2',
-    },
+    'Archlinux' => '9.2',
     'Gentoo' => '9.5',
     'FreeBSD' => '93',
     'OpenBSD' => $facts['os']['release']['full'] ? {

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -159,7 +159,7 @@ class postgresql::globals (
   # class.
   $default_version = $facts['os']['family'] ? {
     /^(RedHat|Linux)/ => $facts['os']['name'] ? {
-      'Fedora' => $facts['os']['release']['full'] ? {
+      'Fedora' => $facts['os']['release']['major'] ? {
         /^(32|33)$/    => '12',
         /^(31)$/       => '11.6',
         /^(30)$/       => '11.2',
@@ -174,24 +174,24 @@ class postgresql::globals (
         default        => undef,
       },
       'Amazon' => '9.2',
-      default => $facts['os']['release']['full'] ? {
-        /^8\./ => '10',
-        /^7\./ => '9.2',
-        /^6\./ => '8.4',
-        /^5\./ => '8.1',
+      default => $facts['os']['release']['major'] ? {
+        '8'     => '10',
+        '7'     => '9.2',
+        '6'     => '8.4',
+        '5'     => '8.1',
         default => undef,
       },
     },
     'Debian' => $facts['os']['name'] ? {
-      'Debian' => $facts['os']['release']['full'] ? {
-        /^(squeeze|6\.)/ => '8.4',
-        /^(wheezy|7\.)/  => '9.1',
-        /^(jessie|8\.)/  => '9.4',
-        /^(stretch|9\.)/ => '9.6',
-        /^(buster|10\.)/ => '11',
+      'Debian' => $facts['os']['release']['major'] ? {
+        '6'     => '8.4',
+        '7'     => '9.1',
+        '8'     => '9.4',
+        '9'     => '9.6',
+        '10'    => '11',
         default => undef,
       },
-      'Ubuntu' => $facts['os']['release']['full'] ? {
+      'Ubuntu' => $facts['os']['release']['major'] ? {
         /^(10.04|10.10|11.04)$/ => '8.4',
         /^(11.10|12.04|12.10|13.04|13.10)$/ => '9.1',
         /^(14.04)$/ => '9.3',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,7 +90,7 @@ class postgresql::params inherits postgresql::globals {
 
         # RHEL 5 uses SysV init, RHEL 6 uses upstart.  RHEL 7 and 8 both use systemd.
         'RedHat', 'CentOS', 'Scientific', 'OracleLinux': {
-          if $facts['os']['release']['full'] =~ /^[78].*/ {
+          if $facts['os']['release']['major'] in ['7', '8'] {
             $service_reload = "systemctl reload ${service_name}"
             $service_status = "systemctl status ${service_name}"
           } else {
@@ -113,7 +113,7 @@ class postgresql::params inherits postgresql::globals {
 
       if $postgresql::globals::postgis_package_name {
         $postgis_package_name = $postgresql::globals::postgis_package_name
-      } elsif $facts['os']['release']['full'] =~ /^5\./ {
+      } elsif $facts['os']['release']['major'] == '5' {
         $postgis_package_name = 'postgis'
       } elsif $postgis_version and versioncmp($postgis_version, '2') < 0 {
         $postgis_package_name = "postgis${package_version}"
@@ -175,7 +175,7 @@ class postgresql::params inherits postgresql::globals {
 
       $client_package_name    = pick($client_package_name, "postgresql-client-${version}")
       $server_package_name    = pick($server_package_name, "postgresql-${version}")
-      if $facts['os']['name'] == 'Debian' and $facts['os']['release']['full'] =~ /^10/ and $postgresql::globals::manage_package_repo != true {
+      if $facts['os']['name'] == 'Debian' and $facts['os']['release']['major'] == '10' and $postgresql::globals::manage_package_repo != true {
         $contrib_package_name = pick($contrib_package_name, 'postgresql-contrib')
       } else {
         $contrib_package_name = pick($contrib_package_name, "postgresql-contrib-${version}")
@@ -189,8 +189,8 @@ class postgresql::params inherits postgresql::globals {
       }
       $devel_package_name     = pick($devel_package_name, 'libpq-dev')
       $java_package_name = $facts['os']['name'] ? {
-        'Debian' => $facts['os']['release']['full'] ? {
-          /^6/    => pick($java_package_name, 'libpg-java'),
+        'Debian' => $facts['os']['release']['major'] ? {
+          '6'     => pick($java_package_name, 'libpg-java'),
           default => pick($java_package_name, 'libpostgresql-jdbc-java'),
         },
         default  => pick($java_package_name, 'libpostgresql-jdbc-java'),
@@ -203,10 +203,10 @@ class postgresql::params inherits postgresql::globals {
       $bindir                 = pick($bindir, "/usr/lib/postgresql/${version}/bin")
       $datadir                = pick($datadir, "/var/lib/postgresql/${version}/main")
       $confdir                = pick($confdir, "/etc/postgresql/${version}/main")
-      if $facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['full'], '8.0') >= 0 {
+      if $facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '8') >= 0 {
         # Jessie uses systemd
         $service_status = pick($service_status, "/usr/sbin/service ${service_name}@*-main status")
-      } elsif $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '15.04') >= 0 {
+      } elsif $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '15.04') >= 0 {
         # Ubuntu releases since vivid use systemd
         $service_status = pick($service_status, "/usr/sbin/service ${service_name} status")
       } else {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -186,7 +186,7 @@ class postgresql::server::config {
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
   # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
-  if ($facts['os']['family'] == 'RedHat') and ($facts['os']['release']['full'] !~ /^7|^8/) and ($facts['os']['name'] != 'Fedora') {
+  if ($facts['os']['family'] == 'RedHat') and ($facts['os']['release']['major'] !~ /^(7|8)$/) and ($facts['os']['name'] != 'Fedora') {
     file { '/etc/sysconfig/pgsql/postgresql':
       ensure  => file,
       replace => false,

--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -97,7 +97,7 @@ define postgresql::server::config_entry (
   # a systemd override for the port or update the sysconfig file, but this
   # is managed for us in postgresql::server::config.
   if $facts['os']['name'] == 'Debian' or $facts['os']['name'] == 'Ubuntu' {
-    if $name == 'port' and ( $facts['os']['release']['full'] =~ /^6/ or $facts['os']['release']['full'] =~ /^10\.04/ ) {
+    if $name == 'port' and $facts['os']['release']['major'] in ['6', '10.04'] {
       exec { "postgresql_stop_${name}":
         command => "service ${postgresql::server::service_name} stop",
         onlyif  => "service ${postgresql::server::service_name} status",
@@ -117,7 +117,7 @@ define postgresql::server::config_entry (
     }
   }
   if $facts['os']['family'] == 'RedHat' {
-    if ! ($facts['os']['release']['full'] =~ /^7|^8/ or $facts['os']['name'] == 'Fedora') {
+    if ! ($facts['os']['release']['major'] in ['7', '8'] or $facts['os']['name'] == 'Fedora') {
       if $name == 'port' {
         # We need to force postgresql to stop before updating the port
         # because puppet becomes confused and is unable to manage the

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -149,7 +149,7 @@ class postgresql::server::initdb {
     # The package will take care of this for us the first time, but if we
     # ever need to init a new db we need to copy these files explicitly
     if $facts['os']['name'] == 'Debian' or $facts['os']['name'] == 'Ubuntu' {
-      if $facts['os']['release']['full'] =~ /^6/ or $facts['os']['release']['full'] =~ /^7/ or $facts['os']['release']['full'] =~ /^10\.04/ or $facts['os']['release']['full'] =~ /^12\.04/ {
+      if $facts['os']['release']['major'] in ['6', '7', '10.04', '12.04'] {
         file { 'server.crt':
           ensure  => file,
           path    => "${datadir}/server.crt",

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::client', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
     }
   end

--- a/spec/unit/classes/globals_spec.rb
+++ b/spec/unit/classes/globals_spec.rb
@@ -44,7 +44,7 @@ describe 'postgresql::globals', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '7.1' },
+          release: { 'full' => '7.1', 'major' => '7' },
         },
         osfamily: 'RedHat',
       }

--- a/spec/unit/classes/lib/devel_spec.rb
+++ b/spec/unit/classes/lib/devel_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::lib::devel', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
     }
   end
@@ -37,7 +37,7 @@ describe 'postgresql::lib::devel', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '6.3' },
+          release: { 'full' => '6.3', 'major' => '6' },
         },
       }
     end
@@ -51,7 +51,7 @@ describe 'postgresql::lib::devel', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '6.3' },
+          release: { 'full' => '6.3', 'major' => '6' },
         },
       }
     end

--- a/spec/unit/classes/lib/java_spec.rb
+++ b/spec/unit/classes/lib/java_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::lib::java', type: :class do
         os: {
           family: 'Debian',
           name: 'Debian',
-          release: { 'full' => '8.0' },
+          release: { 'full' => '8.0', 'major' => '8' },
         },
       }
     end
@@ -27,7 +27,7 @@ describe 'postgresql::lib::java', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '6.4' },
+          release: { 'full' => '6.4', 'major' => '6' },
         },
       }
     end

--- a/spec/unit/classes/lib/perl_spec.rb
+++ b/spec/unit/classes/lib/perl_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::lib::perl', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '6.4' },
+          release: { 'full' => '6.4', 'major' => '6' },
         },
       }
     end
@@ -26,7 +26,7 @@ describe 'postgresql::lib::perl', type: :class do
         os: {
           family: 'Debian',
           name: 'Debian',
-          release: { 'full' => '8.0' },
+          release: { 'full' => '8.0', 'major' => '8' },
         },
       }
     end

--- a/spec/unit/classes/lib/pgdocs_spec.rb
+++ b/spec/unit/classes/lib/pgdocs_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::lib::docs', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '6.4' },
+          release: { 'full' => '6.4', 'major' => '6' },
         },
       }
     end

--- a/spec/unit/classes/lib/python_spec.rb
+++ b/spec/unit/classes/lib/python_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::lib::python', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '6.4' },
+          release: { 'full' => '6.4', 'major' => '6' },
         },
       }
     end
@@ -26,7 +26,7 @@ describe 'postgresql::lib::python', type: :class do
         os: {
           family: 'Debian',
           name: 'Debian',
-          release: { 'full' => '8.0' },
+          release: { 'full' => '8.0', 'major' => '8' },
         },
       }
     end

--- a/spec/unit/classes/params_spec.rb
+++ b/spec/unit/classes/params_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::params', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
     }
   end

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server::contrib', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/classes/server/initdb_spec.rb
+++ b/spec/unit/classes/server/initdb_spec.rb
@@ -11,7 +11,7 @@ describe 'postgresql::server::initdb', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '6.0' },
+          release: { 'full' => '6.0', 'major' => '6' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',
@@ -51,7 +51,7 @@ describe 'postgresql::server::initdb', type: :class do
         os: {
           family: 'RedHat',
           name: 'Amazon',
-          release: { 'full' => '1.0' },
+          release: { 'full' => '1.0', 'major' => '1' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',
@@ -83,7 +83,7 @@ describe 'postgresql::server::initdb', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '6.0' },
+          release: { 'full' => '6.0', 'major' => '6' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',
@@ -114,7 +114,7 @@ describe 'postgresql::server::initdb', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '6.0' },
+          release: { 'full' => '6.0', 'major' => '6' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',
@@ -144,7 +144,7 @@ describe 'postgresql::server::initdb', type: :class do
         os: {
           family: 'RedHat',
           name: 'CentOS',
-          release: { 'full' => '6.0' },
+          release: { 'full' => '6.0', 'major' => '6' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',

--- a/spec/unit/classes/server/plperl_spec.rb
+++ b/spec/unit/classes/server/plperl_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::plperl', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/classes/server/plpython_spec.rb
+++ b/spec/unit/classes/server/plpython_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::plpython', type: :class do
       os: {
         family: 'RedHat',
         name: 'CentOS',
-        release: { 'full' => '6.8' },
+        release: { 'full' => '6.8', 'major' => '6' },
         selinux: { 'enabled' => true },
       },
       kernel: 'Linux',

--- a/spec/unit/classes/server/postgis_spec.rb
+++ b/spec/unit/classes/server/postgis_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server::postgis', type: :class do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/config_entry_spec.rb
+++ b/spec/unit/defines/server/config_entry_spec.rb
@@ -43,7 +43,7 @@ describe 'postgresql::server::config_entry', type: :define do
           os: {
             family: 'RedHat',
             name: 'RedHat',
-            release: { 'full' => '6.4' },
+            release: { 'full' => '6.4', 'major' => '6' },
             selinux: { 'enabled' => true },
           },
           kernel: 'Linux',
@@ -115,7 +115,7 @@ describe 'postgresql::server::config_entry', type: :define do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { 'full' => '7.0' },
+          release: { 'full' => '7.0', 'major' => '7' },
           selinux: { 'enabled' => true },
         },
         kernel: 'Linux',

--- a/spec/unit/defines/server/database_grant_spec.rb
+++ b/spec/unit/defines/server/database_grant_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::database_grant', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/database_spec.rb
+++ b/spec/unit/defines/server/database_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::database', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/db_spec.rb
+++ b/spec/unit/defines/server/db_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::db', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -13,7 +13,7 @@ describe 'postgresql::server::extension', type: :define do # rubocop:disable RSp
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',
@@ -130,7 +130,7 @@ describe 'postgresql::server::extension', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '6.0' },
+        release: { 'full' => '6.0', 'major' => '6' },
       },
       kernel: 'Linux',
       id: 'root',
@@ -164,7 +164,7 @@ describe 'postgresql::server::extension', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '6.0' },
+        release: { 'full' => '6.0', 'major' => '6' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server::grant_role', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::grant', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/pg_hba_rule_spec.rb
+++ b/spec/unit/defines/server/pg_hba_rule_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::pg_hba_rule', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/pg_ident_rule_spec.rb
+++ b/spec/unit/defines/server/pg_ident_rule_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::pg_ident_rule', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/reassign_owned_by_spec.rb
+++ b/spec/unit/defines/server/reassign_owned_by_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::reassign_owned_by', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/recovery_spec.rb
+++ b/spec/unit/defines/server/recovery_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::recovery', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::role', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/schema_spec.rb
+++ b/spec/unit/defines/server/schema_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::schema', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/table_grant_spec.rb
+++ b/spec/unit/defines/server/table_grant_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::table_grant', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/server/tablespace_spec.rb
+++ b/spec/unit/defines/server/tablespace_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::server::tablespace', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
       kernel: 'Linux',
       id: 'root',

--- a/spec/unit/defines/validate_db_connection_spec.rb
+++ b/spec/unit/defines/validate_db_connection_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::validate_db_connection', type: :define do
       os: {
         family: 'Debian',
         name: 'Debian',
-        release: { 'full' => '8.0' },
+        release: { 'full' => '8.0', 'major' => '8' },
       },
     }
   end


### PR DESCRIPTION
This is a code simplification for distributions that don't change the 
PostgreSQL version in a major release. As a bonus fact, it adds support for
CentOS 8 Stream which identifies itself without a minor version.

For completeness, the OS facts from CentOS 8 Stream:

```console
# facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "CentOS",
  release => {
    full => "8",
    major => "8"
  },
  selinux => {
    enabled => false
  }
}
```

This is an alternative to https://github.com/puppetlabs/puppetlabs-postgresql/pull/1222.