### PR TITLE
Fix postgresql::sql task when password is not set

### DIFF
--- a/tasks/sql.rb
+++ b/tasks/sql.rb
@@ -6,7 +6,8 @@ require 'open3'
 require 'puppet'
 
 def get(sql, database, user, port, password, host)
-  env_hash = { 'PGPASSWORD' => password } unless password.nil?
+  env_hash = {}
+  env_hash['PGPASSWORD'] = password unless password.nil?
   cmd_string = "psql -c \"#{sql}\""
   cmd_string += " --dbname=#{database}" unless database.nil?
   cmd_string += " --username=#{user}" unless user.nil?


### PR DESCRIPTION
When password is not set, `{ 'PGPASSWORD' => password } unless
password.nil?` evaluates to `nil`, setting `env_hash` to `nil`.

`nil` is then passed as the first argument of `Open3.capture3` which
result in an exception:

```
/opt/puppetlabs/puppet/lib/ruby/2.7.0/open3.rb:213:in `spawn': no implicit conversion of nil into String (TypeError)
	from /opt/puppetlabs/puppet/lib/ruby/2.7.0/open3.rb:213:in `popen_run'
	from /opt/puppetlabs/puppet/lib/ruby/2.7.0/open3.rb:101:in `popen3'
	from /opt/puppetlabs/puppet/lib/ruby/2.7.0/open3.rb:281:in `capture3'
	from /opt/puppetlabs/mcollective/tasks-spool/899e9e0635bb53f1a09b4716548ff69f/files/sql.rb:13:in `get'
	from /opt/puppetlabs/mcollective/tasks-spool/899e9e0635bb53f1a09b4716548ff69f/files/sql.rb:27:in `<main>'
```

Make sure `env_hash` is always a hash to fix this issue.