### PR TITLE
Set default PostgresQL version for FreeBSD

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -209,7 +209,7 @@ class postgresql::globals (
       default => '9.2',
     },
     'Gentoo' => '9.5',
-    'FreeBSD' => '93',
+    'FreeBSD' => '12',
     'OpenBSD' => $facts['os']['release']['full'] ? {
       /5\.6/ => '9.3',
       /5\.[7-9]/ => '9.4',


### PR DESCRIPTION
FreeBSD uses Postgresql 12 by default
Ref: https://svnweb.freebsd.org/ports/branches/2021Q1/Mk/bsd.default-versions.mk?revision=560000&view=markup#l100