### PR TITLE
(bug) reload the service after the deletion of old unit file

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -229,6 +229,7 @@ class postgresql::server::config {
         command     => 'systemctl daemon-reload',
         refreshonly => true,
         path        => '/bin:/usr/bin:/usr/local/bin',
+        before      => Class['postgresql::server::service'],
       }
       $systemd_notify = [Exec['restart-systemd'], Class['postgresql::server::service']]
     }


### PR DESCRIPTION
Bug Details
Problem reported on Puppet version 6.20, OS Centos 8

Proposed solution
Issue systemctl daemon-reload first, after the deletion of old unit file followed by the restart newly configured service.

Create separate file resource for deleting old unit file and specifying the ordering to make sure it deletes the files first, then daemon- reload followed by service start

Puppet agent 5 Results
`Notice: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]/ensure: removed
Info: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: Scheduling refresh of Exec[restart-systemd]
Debug: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: The container Class[Postgresql::Server::Config] will propagate my refresh event
Info: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: Scheduling refresh of Class[Postgresql::Server::Service]
Debug: /Stage[main]/Postgresql::Server::Config/Exec[restart-systemd]: 'systemctl daemon-reload' won't be executed because of failed check 'refreshonly'
Debug: Exec[restart-systemd](provider=posix): Executing 'systemctl daemon-reload'
Debug: Executing: 'systemctl daemon-reload'
Notice: /Stage[main]/Postgresql::Server::Config/Exec[restart-systemd]: Triggered 'refresh' from 1 event
Debug: /Stage[main]/Postgresql::Server::Config/Exec[restart-systemd]: The container Class[Postgresql::Server::Config] will propagate my refresh event
Debug: Prefetching parsed resources for postgresql_conf
Debug: Class[Postgresql::Server::Config]: The container Stage[main] will propagate my refresh event
Debug: Class[Postgresql::Server::Config]: The container Class[Postgresql::Server] will propagate my refresh event
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Anchor[postgresql::server::service::begin]
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Service[postgresqld]
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Anchor[postgresql::server::service::end]
Notice: /Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]: Triggered 'refresh' from 1 event
Debug: /Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]: The container Class[Postgresql::Server::Service] will propagate my refresh event
Debug: Executing: 'systemctl status postgresql'
Debug: Executing: '/usr/bin/systemctl is-enabled -- postgresql'
Debug: Executing: 'systemctl status postgresql'
Debug: Executing: '/usr/bin/systemctl restart -- postgresql'
Notice: /Stage[main]/Postgresql::Server::Service/Service[postgresqld]: Triggered 'refresh' from 1 event
Debug: /Stage[main]/Postgresql::Server::Service/Service[postgresqld]: The container Class[Postgresql::Server::Service] will propagate my refresh event
Debug: PostgresqlValidator.attempt_connection: Attempting connection to postgres
Debug: PostgresqlValidator.attempt_connection:  /usr/bin/psql --tuples-only --quiet --no-psqlrc --port 5432 --dbname postgres --command 'SELECT 1'
Debug: Executing with uid=postgres: ' /usr/bin/psql --tuples-only --quiet --no-psqlrc --port 5432 --dbname postgres --command 'SELECT 1' '
Debug: PostgresqlValidator.attempt_connection: Connection to postgres successful!`

puppet agent 6 Results
`Debug: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: Removing existing file for replacement with absent
Notice: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]/ensure: removed
Debug: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: The container Class[Postgresql::Server::Config] will propagate my refresh event
Info: /Stage[main]/Postgresql::Server::Config/File[old-systemd-override]: Scheduling refresh of Class[Postgresql::Server::Service]
Debug: Prefetching parsed resources for postgresql_conf
Debug: Class[Postgresql::Server::Config]: The container Stage[main] will propagate my refresh event
Debug: Class[Postgresql::Server::Config]: The container Class[Postgresql::Server] will propagate my refresh event
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Anchor[postgresql::server::service::begin]
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Service[postgresqld]
Info: Class[Postgresql::Server::Service]: Scheduling refresh of Anchor[postgresql::server::service::end]
Notice: /Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]: Triggered 'refresh' from 1 event
Debug: /Stage[main]/Postgresql::Server::Service/Anchor[postgresql::server::service::begin]: The container Class[Postgresql::Server::Service] will propagate my refresh event
Debug: Executing: 'systemctl status postgresql'
Debug: Executing: '/usr/bin/systemctl is-enabled -- postgresql'
Debug: Executing: 'systemctl status postgresql'
Debug: Executing: '/usr/bin/systemctl show --property=NeedDaemonReload -- postgresql'
Debug: Executing: '/usr/bin/systemctl restart -- postgresql'
Notice: /Service[postgresqld]: Triggered 'refresh' from 1 event
Debug: /Service[postgresqld]: The container Class[Postgresql::Server::Service] will propagate my refresh event
Debug: PostgresqlValidator.attempt_connection: Attempting connection to postgres
Debug: PostgresqlValidator.attempt_connection:  /usr/bin/psql --tuples-only --quiet --no-psqlrc --port 5432 --dbname postgres --command 'SELECT 1'
Debug: Executing with uid=postgres: ' /usr/bin/psql --tuples-only --quiet --no-psqlrc --port 5432 --dbname postgres --command 'SELECT 1' '
Debug: PostgresqlValidator.attempt_connection: Connection to postgres successful!`
