### PR TITLE
(IAC-1136) Back out CentOS 8 tests on TravisCI

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -16,7 +16,6 @@
     - ---travis_el
     - travis_deb
     - travis_el7
-    - travis_el8
     complex:
     - collection:
         puppet_collection:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,17 +72,6 @@ jobs:
       services: docker
       stage: acceptance
     - before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el8]'"
-      - "bundle exec rake 'litmus:install_agent[puppet5]'"
-      - "bundle exec rake litmus:install_module"
-      env:
-        PLATFORMS: travis_el8_puppet5
-        BUNDLE_WITH: system_tests
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    - before_script:
       - "bundle exec rake 'litmus:provision_list[travis_deb]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
@@ -99,17 +88,6 @@ jobs:
       - "bundle exec rake litmus:install_module"
       env:
         PLATFORMS: travis_el7_puppet6
-        BUNDLE_WITH: system_tests
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    - before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el8]'"
-      - "bundle exec rake 'litmus:install_agent[puppet6]'"
-      - "bundle exec rake litmus:install_module"
-      env:
-        PLATFORMS: travis_el8_puppet6
         BUNDLE_WITH: system_tests
       rvm: 2.5.7
       script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]

--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,7 @@
       "version_requirement": ">= 5.5.10 < 8.0.0"
     }
   ],
-  "pdk-version": "1.19.0.pre (47)",
-  "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
+  "pdk-version": "1.18.1",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#main",
   "template-ref": "heads/main-0-g1862b96"
 }


### PR DESCRIPTION
Disabling tests for centos 8 on TravisCI due to timeout issue.