### PR TITLE
Also perform systemd daemon-reload on Puppet 6.1+

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -217,8 +217,9 @@ class postgresql::server::config {
   # Gentoo also supports drop-in files.
   if $facts['os']['family'] in ['RedHat', 'Gentoo'] and $facts['service_provider'] == 'systemd' {
     # While Puppet 6.1 and newer can do a daemon-reload if needed, systemd
-    # doesn't appear to report that correctly. This is probably because its
-    # unit file is actually removed.
+    # doesn't appear to report that correctly in all cases.
+    # One such case seems to be when an overriding unit file is removed from /etc
+    # and the original one from /lib *should* be used again.
     #
     # This can be removed when Puppet < 6.1 support is dropped *and* the file
     # old-systemd-override is removed.

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -216,14 +216,6 @@ class postgresql::server::config {
   # RHEL 7 and 8 both support drop-in files for systemd units.  The old include directive is deprecated and may be removed in future systemd releases.
   # Gentoo also supports drop-in files.
   if $facts['os']['family'] in ['RedHat', 'Gentoo'] and $facts['service_provider'] == 'systemd' {
-      # Template uses:
-      # - $facts['os']['name']
-      # - $facts['os']['release']['major']
-      # - $service_name
-      # - $port
-      # - $datadir
-      # - @extra_systemd_config
-
     # While Puppet 6.1 and newer can do a daemon-reload if needed, systemd
     # doesn't appear to report that correctly. This is probably because its
     # unit file is actually removed.
@@ -244,7 +236,6 @@ class postgresql::server::config {
           group  => root,
           notify => [Exec['restart-systemd'], Class['postgresql::server::service']],
           before => Class['postgresql::server::reload'],
-
       ;
 
       'systemd-conf-dir':
@@ -252,6 +243,13 @@ class postgresql::server::config {
           path   => "/etc/systemd/system/${service_name}.service.d",
       ;
 
+      # Template uses:
+      # - $facts['os']['name']
+      # - $facts['os']['release']['major']
+      # - $service_name
+      # - $port
+      # - $datadir
+      # - $extra_systemd_config
       'systemd-override':
           path    => "/etc/systemd/system/${service_name}.service.d/${service_name}.conf",
           content => template('postgresql/systemd-override.erb'),


### PR DESCRIPTION
The way daemon-reload is implemented in Puppet 6.1 is by calling

```
systemctl show --property=NeedDaemonReload -- $SERVICE
```

If that returns yes then it performs systemctl daemon-reload. However, this
doesn't work reliable because of the particular case.

```console
# systemctl show --property=NeedDaemonReload -- postgresql
Failed to get properties: Access denied
```

This is probably because the original unit file is removed.