### PR TITLE
Add DNF module management

### DIFF
--- a/manifests/dnfmodule.pp
+++ b/manifests/dnfmodule.pp
@@ -1,0 +1,20 @@
+# @summary Manage the DNF module
+#
+# On EL8 and Fedora DNF can manage modules. This is a method of providing
+# multiple versions on the same OS. Only one DNF module can be active at the
+# same time.
+#
+# @api private
+class postgresql::dnfmodule (
+  String[1] $ensure = 'installed',
+  String[1] $module = 'postgresql',
+) {
+  package { 'postgresql dnf module':
+    ensure      => $ensure,
+    name        => $module,
+    enable_only => true,
+    provider    => 'dnfmodule',
+  }
+
+  Package['postgresql dnf module'] -> Package<|tag == 'puppetlabs-postgresql'|>
+}

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -86,6 +86,10 @@
 # @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
 #
 # @param manage_package_repo Sets up official PostgreSQL repositories on your host if set to true.
+# @param manage_dnf_module
+#   Manage the DNF module. This only makes sense on distributions that use DNF
+#   package manager, such as EL8 or Fedora. It also requires Puppet 5.5.20+ or
+#   Puppet 6.15.0+ since they ship the dnfmodule provider.
 # @param module_workdir Specifies working directory under which the psql command should be executed. May need to specify if '/tmp' is on volume mounted with noexec option.
 #
 #
@@ -153,6 +157,7 @@ class postgresql::globals (
   $manage_selinux                                  = undef,
 
   $manage_package_repo                             = undef,
+  Boolean $manage_dnf_module                       = false,
   $module_workdir                                  = undef,
 ) {
   # We are determining this here, because it is needed by the package repo
@@ -263,6 +268,12 @@ class postgresql::globals (
       version => $globals_version,
       proxy   => $repo_proxy,
       baseurl => $repo_baseurl,
+    }
+  }
+
+  if $manage_dnf_module {
+    class { 'postgresql::dnfmodule':
+      ensure => $globals_version,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class postgresql::params inherits postgresql::globals {
       $version_parts      = split($version, '[.]')
       $package_version    = "${version_parts[0]}${version_parts[1]}"
 
-      if $version == $postgresql::globals::default_version and $facts['os']['name'] != 'Amazon' {
+      if $version == $postgresql::globals::default_version and $facts['os']['name'] != 'Amazon' or $postgresql::globals::manage_dnf_module {
         $client_package_name    = pick($client_package_name, 'postgresql')
         $server_package_name    = pick($server_package_name, 'postgresql-server')
         $contrib_package_name   = pick($contrib_package_name,'postgresql-contrib')

--- a/spec/unit/classes/client_spec.rb
+++ b/spec/unit/classes/client_spec.rb
@@ -43,6 +43,18 @@ describe 'postgresql::client', type: :class do
     end
   end
 
+  describe 'with manage_dnf_module true' do
+    let(:pre_condition) do
+      <<-PUPPET
+      class { 'postgresql::globals':
+        manage_dnf_module => true,
+      }
+      PUPPET
+    end
+
+    it { is_expected.to contain_package('postgresql dnf module').that_comes_before('Package[postgresql-client]') }
+  end
+
   describe 'with client package name explicitly set undef' do
     let :params do
       {

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -35,6 +35,47 @@ describe 'postgresql::server', type: :class do
     end
   end
 
+  describe 'with manage_dnf_module true' do
+    let(:facts) do
+      {
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '8.3', 'major' => '8' },
+          selinux: {
+            enabled: true,
+          }
+        },
+        osfamily: 'RedHat',
+      }
+    end
+
+    let(:pre_condition) do
+      <<-PUPPET
+      class { 'postgresql::globals':
+        manage_dnf_module => true,
+      }
+      PUPPET
+    end
+
+    it { is_expected.to contain_package('postgresql dnf module').with_ensure('10').that_comes_before('Package[postgresql-server]') }
+    it { is_expected.to contain_package('postgresql-server').with_name('postgresql-server') }
+
+    describe 'with version set' do
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'postgresql::globals':
+          manage_dnf_module => true,
+          version           => '12',
+        }
+        PUPPET
+      end
+
+      it { is_expected.to contain_package('postgresql dnf module').with_ensure('12').that_comes_before('Package[postgresql-server]') }
+      it { is_expected.to contain_package('postgresql-server').with_name('postgresql-server') }
+    end
+  end
+
   describe 'service_ensure => running' do
     let(:params) do
       {


### PR DESCRIPTION
On EL8 and Fedora DNF can manage modules. This is a method of providing multiple versions on the same OS. Only one DNF module can be active at the same time.