### PR TITLE
Fix warning introduced in #1240 (08a1752)

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -133,7 +133,7 @@ define postgresql::server::role (
       }
       postgresql_psql { "ALTER ROLE ${username} ENCRYPTED PASSWORD ****":
         command     => Sensitive("ALTER ROLE \"${username}\" ${password_sql}"),
-        unless      => Sensitive("SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'"),
+        unless      => "SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
         sensitive   => true,
       }
     }

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -42,7 +42,7 @@ describe 'postgresql::server::role', type: :define do
     is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
       .with('command'     => 'Sensitive [value redacted]',
             'sensitive'   => 'true',
-            'unless'      => 'Sensitive [value redacted]',
+            'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
             'port'        => '5432')
   end
 
@@ -74,7 +74,8 @@ describe 'postgresql::server::role', type: :define do
     it 'has alter role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
         .with('command' => 'Sensitive [value redacted]', 'sensitive' => 'true',
-              'unless'  => 'Sensitive [value redacted]', 'port' => '5432',
+              'unless'  => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+              'port'    => '5432',
               'connect_settings' => { 'PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1',
                                       'PGUSER' => 'login-user', 'PGPASSWORD' => 'login-pass' })
     end
@@ -107,7 +108,7 @@ describe 'postgresql::server::role', type: :define do
     it 'has alter role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
         .with('command' => 'Sensitive [value redacted]', 'sensitive' => 'true',
-              'unless'  => 'Sensitive [value redacted]',
+              'unless'  => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
               'connect_settings' => { 'PGHOST' => 'postgres-db-server', 'DBVERSION' => '9.1',
                                       'PGPORT' => '1234', 'PGUSER' => 'login-user', 'PGPASSWORD' => 'login-pass' })
     end


### PR DESCRIPTION
`unless` does not accept a Sensitive parameter, and passing one result in a warning being output:

```
(/Postgresql_psql[ALTER ROLE puppetdb ENCRYPTED PASSWORD ****]) Unable to mark 'unless' as sensitive: unless is a parameter and not a property, and cannot be automatically redacted.
```

This is not really an issue here since this query is not displayed in the logs, even in debug mode.