### PR TITLE
Ensure port is a string in psql command

### DIFF
--- a/lib/puppet/provider/postgresql_psql/ruby.rb
+++ b/lib/puppet/provider/postgresql_psql/ruby.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:postgresql_psql).provide(:ruby) do
 
     command = [resource[:psql_path]]
     command.push('-d', resource[:db]) if resource[:db]
-    command.push('-p', resource[:port]) if resource[:port]
+    command.push('-p', resource[:port].to_s) if resource[:port]
     command.push('-t', '-X', '-c', sql)
 
     environment = fetch_environment


### PR DESCRIPTION
In 841187b0ec29726c0fe39ea2ad710a5ead42d2e0 a shell execution vulnerability was fixed by passing an array. In my environment (Debian 10, Ruby 2.5, Puppet 5) it was failing because port was an Integer and command execution only allows Strings. This explicitly converts the port to a string.

Fixes: 841187b0ec29726c0fe39ea2ad710a5ead42d2e0