### PR TITLE
Fix use of Sensitive on unless parameter for postgresql::server::role

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -133,7 +133,7 @@ define postgresql::server::role (
       }
       postgresql_psql { "ALTER ROLE ${username} ENCRYPTED PASSWORD ****":
         command     => Sensitive("ALTER ROLE \"${username}\" ${password_sql}"),
-        unless      => Sensitive("SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'"),
+        unless      => "SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
         sensitive   => true,
       }
     }


### PR DESCRIPTION
I have Puppet modules that are failing acceptance tests with Puppet 7 with this warning:

```
  Warning: /Postgresql_psql[ALTER ROLE sa ENCRYPTED PASSWORD ****]: Unable to mark 'unless' as sensitive: unless is a parameter and not a property, and cannot be automatically redacted.
```