### PR TITLE
(MODULES-10957) Override the set_sensitive_parameters method

### DIFF
--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -145,4 +145,15 @@ Puppet::Type.newtype(:postgresql_psql) do
   def refresh
     property(:command).sync if should_run_sql(true)
   end
+
+  private
+
+  def set_sensitive_parameters(sensitive_parameters)
+    # Respect sensitive commands
+    if sensitive_parameters.include?(:unless)
+      sensitive_parameters.delete(:unless)
+      parameter(:unless).sensitive = true
+    end
+    super(sensitive_parameters)
+  end
 end


### PR DESCRIPTION
Fix for the following warning message

`Warning: /Postgresql_psql[ALTER ROLE testuser ENCRYPTED PASSWORD ****]: Unable to mark 'unless' as sensitive: unless is a parameter and not a property, and cannot be automatically redacted.`

Override the set_sensitive_parameters method and mark the parameter as sensitive.