### PR TITLE
MODULES-11047 - Allow managing rights for PUBLIC role

### DIFF
--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -240,7 +240,7 @@ describe 'postgresql::server::grant', type: :define do
     it { is_expected.to contain_postgresql__server__role('test') }
     it do
       is_expected.to contain_postgresql_psql('grant:test')
-        .with_command(%r{GRANT ALL ON TABLE "myschema"."mytable" TO\s* "PUBLIC"}m)
+        .with_command(%r{GRANT ALL ON TABLE "myschema"."mytable" TO\s* PUBLIC}m)
         .with_unless(%r{SELECT 1 WHERE has_table_privilege\('public',\s*'myschema.mytable', 'INSERT'\)}m)
     end
   end


### PR DESCRIPTION
Following [the feature request](https://tickets.puppetlabs.com/browse/MODULES-11047), this PR allow to use "PUBLIC" as a role for grants, which will not be quoted in the final query.