### PR TITLE
(MODULES-11069) add default version for fedora 34

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -167,6 +167,7 @@ class postgresql::globals (
   $default_version = $facts['os']['family'] ? {
     /^(RedHat|Linux)/ => $facts['os']['name'] ? {
       'Fedora' => $facts['os']['release']['major'] ? {
+        /^(34)$/       => '13',
         /^(32|33)$/    => '12',
         /^(31)$/       => '11.6',
         /^(30)$/       => '11.2',


### PR DESCRIPTION
Simply adding PostgreSQL 13 as default version for Fedora 34 worked for me.

Related jira ticket: https://tickets.puppetlabs.com/browse/MODULES-11069