### PR TITLE
Handle db, database_grant and table_grant from class postgresql::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ postgresql::server::db { 'mydatabasename':
 }
 ```
 
+Or with hiera, include `postgresql::server` then configure your yaml configuration:
+
+```puppet
+include postgresql::server
+```
+
+```yaml
+postgresql::server::dbs:
+  "mydatabasename":
+    user: "mydatabaseuser"
+    password: "mypassword"
+```
+
+Note: `password` can be plaintext. It will be hashed.
+
 ### Manage users, roles, and permissions
 
 To manage users, roles, and permissions:
@@ -112,6 +127,33 @@ postgresql::server::table_grant { 'my_table of test2':
 ```
 
 This example grants **all** privileges on the test1 database and on the `my_table` table of the test2 database to the specified user or group. After the values are added into the PuppetDB config file, this database would be ready for use.
+
+You can configure it with hiera as well, including postgresql::server in puppet first:
+
+```puppet
+include postgresql::server
+```
+
+```yaml
+postgresql::server::roles:
+  "marmot":
+    password_hash: "mypasswd"
+
+postgresql::server::database_grants:
+  "test1":
+    privilege: "ALL"
+    db: "test1"
+    role: "marmot"
+
+postgresql::server::table_grants:
+  "my_table of test2":
+    privilege: "ALL"
+    table: "my_table"
+    db: "test2"
+    role: "marmot"
+```
+
+Note: `password_hash` can be plaintext. It will be hashed.
 
 ### Manage ownership of DB objects
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -74,6 +74,9 @@
 # @param manage_logdir Set to false if you have file{ $logdir: } already defined
 # @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
 #
+# @param dbs Specifies a hash from which to generate postgresql::server::db resources.
+# @param database_grants Specifies a hash from which to generate postgresql::server::database_grant resources.
+# @param table_grants Specifies a hash from which to generate postgresql::server::table_grant resources.
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
@@ -148,9 +151,12 @@ class postgresql::server (
   $password_encryption                             = $postgresql::params::password_encryption,
   $extra_systemd_config                            = $postgresql::params::extra_systemd_config,
 
-  Hash[String, Hash] $roles         = {},
-  Hash[String, Any] $config_entries = {},
-  Hash[String, Hash] $pg_hba_rules  = {},
+  Hash[String, Hash] $dbs             = {},
+  Hash[String, Hash] $roles           = {},
+  Hash[String, Hash] $database_grants = {},
+  Hash[String, Hash] $table_grants    = {},
+  Hash[String, Any] $config_entries   = {},
+  Hash[String, Hash] $pg_hba_rules    = {},
 
   #Deprecated
   $version                    = undef,
@@ -182,6 +188,24 @@ class postgresql::server (
   -> Class['postgresql::server::config']
   -> Class['postgresql::server::service']
   -> Class['postgresql::server::passwd']
+
+  $dbs.each |$db_name, $db| {
+    postgresql::server::db { $db_name:
+      * => $db,
+    }
+  }
+
+  $database_grants.each |$database_grant_name, $database_grant| {
+    postgresql::server::database_grant { $database_grant_name:
+      * => $database_grant,
+    }
+  }
+
+  $table_grants.each |$table_grant_name, $table_grant| {
+    postgresql::server::table_grant { $table_grant_name:
+      * => $table_grant,
+    }
+  }
 
   $roles.each |$rolename, $role| {
     postgresql::server::role { $rolename:


### PR DESCRIPTION
Greetings.

In this submission I add the ability to declare **databases** and **grants** from `postgresql::server` (**roles**, **config entries** and **pg_hba** were already handled).
So we may only include `postgresql::server`, then with hiera we can control major tasks of the module without calling any defined resources.