### PR TITLE
Use Puppet-Datatype Sensitive for Passwords

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,9 @@
 ---
 ".gitlab-ci.yml":
   delete: true
+.puppet-lint.rc:
+  extra_disabled_lint_checks:
+    - 140chars-check
 appveyor.yml:
   delete: true
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -863,7 +863,7 @@ The following parameters are available in the `postgresql::server` class:
 
 ##### <a name="postgres_password"></a>`postgres_password`
 
-Data type: `Any`
+Data type: `Variant[String, Sensitive[String]]`
 
 Sets the password for the postgres user to your specified value. By default, this setting uses the superuser account in the Postgres database, with a user called postgres and no password.
 
@@ -1646,7 +1646,7 @@ User to create and assign access to the database upon creation. Mandatory.
 
 ##### <a name="password"></a>`password`
 
-Data type: `Any`
+Data type: `Variant[String, Sensitive[String]]`
 
 Required Sets the password for the created user.
 
@@ -2571,7 +2571,7 @@ Default value: ``true``
 
 ##### <a name="password_hash"></a>`password_hash`
 
-Data type: `Any`
+Data type: `Variant[String, Sensitive[String]]`
 
 Sets the hash to use during password creation.
 
@@ -2713,7 +2713,7 @@ Create a new schema.
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 postgresql::server::schema {'private':
@@ -2944,7 +2944,7 @@ Default value: ``undef``
 
 ##### <a name="database_password"></a>`database_password`
 
-Data type: `Any`
+Data type: `Variant[String, Sensitive[String]]`
 
 Specifies the password to connect with.
 
@@ -3105,6 +3105,8 @@ Hash of environment variables for connection to a db.
 The name of the database you are trying to validate a connection with.
 
 ##### <a name="db_password"></a>`db_password`
+
+Data type: `Variant[String, Sensitive[String]]`
 
 The password required to access the target PostgreSQL database.
 
@@ -3319,7 +3321,7 @@ This function pull default values from the `params` class  or `globals` class if
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 postgresql::default('variable')
@@ -3333,7 +3335,7 @@ Returns: `Any`
 
 ##### Examples
 
-###### 
+######
 
 ```puppet
 postgresql::default('variable')
@@ -3369,7 +3371,7 @@ Type: Ruby 4.x API
 
 This function returns the postgresql password hash from the clear text username / password
 
-#### `postgresql::postgresql_password(Variant[String[1],Integer] $username, Variant[String[1],Integer] $password)`
+#### `postgresql::postgresql_password(Variant[String[1],Integer] $username, Variant[String[1], Sensitive[String[1]], Integer] $password)`
 
 The postgresql::postgresql_password function.
 
@@ -3386,6 +3388,12 @@ The clear text `username`
 Data type: `Variant[String[1],Integer]`
 
 The clear text `password`
+
+##### `sensitive`
+
+Data type: `Boolean`
+
+If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
 
 ### <a name="postgresql_escape"></a>`postgresql_escape`
 

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -6,15 +6,25 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   #   The clear text `username`
   # @param password
   #   The clear text `password`
+  # @param sensitive
+  #   If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
   #
-  # @return [String]
+  # @return
   #   The postgresql password hash from the clear text username / password.
   dispatch :default_impl do
-    param 'Variant[String[1],Integer]', :username
-    param 'Variant[String[1],Integer]', :password
+    required_param 'Variant[String[1], Integer]', :username
+    required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
+    optional_param 'Boolean', :sensitive
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def default_impl(username, password)
-    'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)
+  def default_impl(username, password, sensitive = false)
+    password = password.unwrap if password.respond_to?(:unwrap)
+    result_string = 'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)
+    if sensitive
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(result_string)
+    else
+      result_string
+    end
   end
 end

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -83,7 +83,7 @@
 # @param extra_systemd_config Adds extra config to systemd config file, can for instance be used to add extra openfiles. This can be a multi line string
 #
 class postgresql::server (
-  $postgres_password                               = undef,
+  Optional[Variant[String[1], Sensitive[String[1]], Integer]] $postgres_password = undef,
 
   $package_name                                    = $postgresql::params::server_package_name,
   $package_ensure                                  = $postgresql::params::package_ensure,

--- a/manifests/server/db.pp
+++ b/manifests/server/db.pp
@@ -1,5 +1,5 @@
 # @summary Define for conveniently creating a role, database and assigning the correctpermissions.
-# 
+#
 # @param user User to create and assign access to the database upon creation. Mandatory.
 # @param password Required Sets the password for the created user.
 # @param comment Defines a comment to be stored about the database using the PostgreSQL COMMENT command.
@@ -13,7 +13,7 @@
 # @param owner Sets a user as the owner of the database.
 define postgresql::server::db (
   $user,
-  $password,
+  Variant[String, Sensitive[String]] $password,
   $comment    = undef,
   $dbname     = $title,
   $encoding   = $postgresql::server::encoding,

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -144,7 +144,7 @@ define postgresql::server::default_privileges (
     psql_group       => $group,
     psql_path        => $psql_path,
     unless           => $unless_cmd,
-    environment      => "PGOPTIONS=--client-min-messages=error"
+    environment      => 'PGOPTIONS=--client-min-messages=error'
   }
 
   if($role != undef and defined(Postgresql::Server::Role[$role])) {

--- a/manifests/server/passwd.pp
+++ b/manifests/server/passwd.pp
@@ -1,6 +1,11 @@
 # @api private
 class postgresql::server::passwd {
-  $postgres_password = $postgresql::server::postgres_password
+  $postgres_password = if $postgresql::server::postgres_password =~ Sensitive {
+    $postgresql::server::postgres_password.unwrap
+  } else {
+    $postgresql::server::postgres_password
+  }
+
   $user              = $postgresql::server::user
   $group             = $postgresql::server::group
   $psql_path         = $postgresql::server::psql_path

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -20,30 +20,56 @@ describe 'postgresql::server::role', type: :define do
     'test'
   end
 
-  let :params do
-    {
-      password_hash: 'new-pa$s',
-    }
-  end
-
   let :pre_condition do
     "class {'postgresql::server':}"
   end
 
-  it { is_expected.to contain_postgresql__server__role('test') }
-  it 'has create role for "test" user with password as ****' do
-    is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****')
-      .with('command'     => 'Sensitive [value redacted]',
-            'sensitive'   => 'true',
-            'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
-            'port'        => '5432')
+  context 'with Password Datatype String' do
+    let :params do
+      {
+        password_hash: 'new-pa$s',
+      }
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'has create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****')
+        .with('command'     => 'Sensitive [value redacted]',
+              'sensitive'   => 'true',
+              'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+              'port'        => '5432')
+    end
+    it 'has alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
+        .with('command'     => 'Sensitive [value redacted]',
+              'sensitive'   => 'true',
+              'unless'      => 'Sensitive [value redacted]',
+              'port'        => '5432')
+    end
   end
-  it 'has alter role for "test" user with password as ****' do
-    is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
-      .with('command'     => 'Sensitive [value redacted]',
-            'sensitive'   => 'true',
-            'unless'      => 'Sensitive [value redacted]',
-            'port'        => '5432')
+
+  context 'with Password Datatype Sensitive[String]' do
+    let :params do
+      {
+        password_hash: sensitive('new-pa$s'),
+      }
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'has create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****')
+        .with('command'     => 'Sensitive [value redacted]',
+              'sensitive'   => 'true',
+              'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+              'port'        => '5432')
+    end
+    it 'has alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
+        .with('command'     => 'Sensitive [value redacted]',
+              'sensitive'   => 'true',
+              'unless'      => 'Sensitive [value redacted]',
+              'port'        => '5432')
+    end
   end
 
   context 'with specific db connection settings - default port' do


### PR DESCRIPTION
- add Parameter "sensitive" to Function postgresql_password to decide if its Returnvalue should be of Datatype Sensitive
- let defined Type postgresql::server::role accept Datatype Sensitive for $password_hash
- let defined Type postgresql::server::db accept Datatype Sensitive for $password
- let Class postgresql::server accept Datatype Sensitive for $postgres_password
- let defined Type postgresql::validate_db_connection accept Sensitive for $database_password