### PR TITLE
(maint) Updating changelog generator config

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,0 @@
-user=puppetlabs
-project=puppetlabs-postgresql
-since_tag=5.3.0

--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
       "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.1.0",
+  "pdk-version": "2.1.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g03daa92"
+  "template-ref": "tags/2.1.1-0-g03daa92"
 }


### PR DESCRIPTION
Following discussion, with the HISTORY.md file formatting (## 5.3.0) the changelog generator is clever enough to pick it up as the since_tag therefore the only change made here is to remove and `.github_changelog_generator` file.