### PR TITLE
Do not add version component to repo definition

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -17,7 +17,7 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
   -> apt::source { 'apt.postgresql.org':
     location => $_baseurl,
     release  => "${facts['os']['distro']['codename']}-pgdg",
-    repos    => "main ${postgresql::repo::version}",
+    repos    => 'main',
     key      => {
       id     => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
       source => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',


### PR DESCRIPTION
According to the [official documentation](https://www.postgresql.org/download/linux/ubuntu/) there is no need to add version component to repository line.

There are no predefined list of allowed components names, but some tools, like `command-not-found`, manage they own list and do not expect to meet something like `13` in component name. Source code [here](https://salsa.debian.org/jak/command-not-found/-/blob/master/CommandNotFound/db/creator.py#L18) This causes exception like this while `apt update`

```
Traceback (most recent call last):
  File "/usr/lib/cnf-update-db", line 26, in <module>
    col.create(db)
  File "/usr/share/command-not-found/CommandNotFound/db/creator.py", line 94, in create
    self._fill_commands(con)
  File "/usr/share/command-not-found/CommandNotFound/db/creator.py", line 132, in _fill_commands
    self._parse_single_contents_file(con, f, fp.stdout)
  File "/usr/share/command-not-found/CommandNotFound/db/creator.py", line 274, in _parse_single_contents_file
    priority = component_priorities[component]
KeyError: '13'
```

Strictly speaking this is not the direct problem of this module, but my suggestion is to align behaviour of puppet module with official PostgreSQL documentation. 

