### PR TITLE
pdksync - (IAC-1709) - Add Support for Debian 11

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -197,6 +197,7 @@ class postgresql::globals (
         '8'     => '9.4',
         '9'     => '9.6',
         '10'    => '11',
+        '11'    => '13',
         default => undef,
       },
       'Ubuntu' => $facts['os']['release']['major'] ? {

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
(IAC-1709) - Add Support for Debian 11
pdk version: `2.1.1` 
