### PR TITLE
[IAC-1735] - update spec tests

### DIFF
--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -44,10 +44,6 @@ def param(type, title, param)
   param_value(catalogue, type, title, param)
 end
 
-def postgresql_version
-  '9.6'
-end
-
 shared_examples 'postgresql_password function' do
   it { is_expected.not_to eq(nil) }
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -44,6 +44,10 @@ def param(type, title, param)
   param_value(catalogue, type, title, param)
 end
 
+def postgresql_version
+  '9.6'
+end
+
 shared_examples 'postgresql_password function' do
   it { is_expected.not_to eq(nil) }
 

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -32,7 +32,7 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
-      is_expected.to contain_package('policycoreutils-python') .with(ensure: 'present')
+      is_expected.to contain_package('policycoreutils-python').with(ensure: 'installed')
 
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
@@ -141,7 +141,7 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
-      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+      is_expected.to contain_package('policycoreutils-python-utils').with(ensure: 'installed')
 
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
@@ -214,7 +214,7 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
-      is_expected.to contain_package('policycoreutils-python-utils') .with(ensure: 'present')
+      is_expected.to contain_package('policycoreutils-python-utils').with(ensure: 'installed')
 
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')
@@ -282,7 +282,7 @@ describe 'postgresql::server::config', type: :class do
     end
 
     it 'has SELinux port defined' do
-      is_expected.to contain_package('policycoreutils') .with(ensure: 'present')
+      is_expected.to contain_package('policycoreutils').with(ensure: 'installed')
 
       is_expected.to contain_exec('/usr/sbin/semanage port -a -t postgresql_port_t -p tcp 5432')
         .with(unless: '/usr/sbin/semanage port -l | grep -qw 5432')

--- a/spec/unit/defines/server/default_privileges_spec.rb
+++ b/spec/unit/defines/server/default_privileges_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spec_helper_acceptance'
 
 describe 'postgresql::server::default_privileges', type: :define do
   let :facts do

--- a/spec/unit/defines/server/extension_spec.rb
+++ b/spec/unit/defines/server/extension_spec.rb
@@ -54,7 +54,7 @@ describe 'postgresql::server::extension', type: :define do # rubocop:disable RSp
 
     it {
       is_expected.to contain_package('postgis')
-        .with(ensure: 'present', name: 'postgis').that_comes_before('Postgresql_psql[template_postgis: CREATE EXTENSION "postgis"]')
+        .with(ensure: 'installed', name: 'postgis').that_comes_before('Postgresql_psql[template_postgis: CREATE EXTENSION "postgis"]')
     }
   end
 
@@ -86,7 +86,7 @@ describe 'postgresql::server::extension', type: :define do # rubocop:disable RSp
 
       it {
         is_expected.to contain_package('postgis')
-          .with(ensure: 'present', name: 'postgis').that_requires('Postgresql_psql[template_postgis: DROP EXTENSION "postgis"]')
+          .with(ensure: 'installed', name: 'postgis').that_requires('Postgresql_psql[template_postgis: DROP EXTENSION "postgis"]')
       }
     end
   end


### PR DESCRIPTION
The tests related to classes or defines which are using `ensure_packages` function from `stdlib` needs to be updated accordingly to this PR https://github.com/puppetlabs/puppetlabs-stdlib/pull/1196