### PR TITLE
Fix changing default encoding

### DIFF
--- a/manifests/server/late_initdb.pp
+++ b/manifests/server/late_initdb.pp
@@ -1,0 +1,39 @@
+# @summary Manage the default encoding when database initialization is managed by the package
+#
+# @api private
+class postgresql::server::late_initdb {
+  assert_private()
+
+  $encoding       = $postgresql::server::encoding
+  $user           = $postgresql::server::user
+  $group          = $postgresql::server::group
+  $psql_path      = $postgresql::server::psql_path
+  $port           = $postgresql::server::port
+  $module_workdir = $postgresql::server::module_workdir
+
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+    cwd        => $module_workdir,
+  }
+
+  # [workaround]
+  # by default pg_createcluster encoding derived from locale
+  # but it do does not work by installing postgresql via puppet because puppet
+  # always override LANG to 'C'
+  postgresql_psql { "Set template1 encoding to ${encoding}":
+    command => "UPDATE pg_database
+      SET datistemplate = FALSE
+      WHERE datname = 'template1'
+      ;
+      UPDATE pg_database
+      SET encoding = pg_char_to_encoding('${encoding}'), datistemplate = TRUE
+      WHERE datname = 'template1'",
+    unless  => "SELECT datname FROM pg_database WHERE
+      datname = 'template1' AND encoding = pg_char_to_encoding('${encoding}')",
+    before  => Anchor['postgresql::server::service::end']
+  }
+}


### PR DESCRIPTION
Starting with 79fa35591e099a7b6981b873b930b943e5dc1827 it is not
possible to set a custom encoding on systems where initdb is not needed
(e.g. Debian).  The autorequire introduce a circular dependency:

```
dependency cycles found: (Anchor[postgresql::server::service::begin] =>
                          Postgresql_psql[Set template1 encoding to UTF-8] =>
                          Class[Postgresql::Server::Initdb] =>
                          Postgresql_conf[listen_addresses] =>
                          Class[Postgresql::Server::Service] =>
                          Anchor[postgresql::server::service::begin])
```

Move the relevant code from postgresql::server::initdb to
postgresql::server::late_initdb and include it when applicable so that
the postgresql_psql command gets run after the service has started up.