### PR TITLE
Support setting default_privileges on all schemas

### DIFF
--- a/spec/acceptance/server/default_privileges_spec.rb
+++ b/spec/acceptance/server/default_privileges_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server::default_privileges:' do
 
   # Check that the default privileges were revoked
   let(:check_command) do
-    "SELECT * FROM pg_default_acl a JOIN pg_namespace b ON a.defaclnamespace = b.oid WHERE '#{user}=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r';"
+    "SELECT * FROM pg_default_acl a LEFT JOIN pg_namespace b ON a.defaclnamespace = b.oid WHERE '#{user}=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r';"
   end
 
   let(:pp_one) do
@@ -167,6 +167,67 @@ describe 'postgresql::server::default_privileges:' do
     MANIFEST
   end
 
+  let(:all_schemas_check_command) do
+    "SELECT * FROM pg_default_acl a WHERE '#{user}=arwdDxt' = ANY (defaclacl) AND defaclnamespace = 0 and defaclobjtype = 'r';"
+  end
+
+  let(:pp_unset_schema) do
+    <<-MANIFEST.unindent
+      $db = #{db}
+      $user = #{user}
+      $group = #{group}
+      $password = #{password}
+
+      class { 'postgresql::server': }
+
+      postgresql::server::role { $user:
+        password_hash => postgresql::postgresql_password($user, $password),
+      }
+
+      postgresql::server::database { $db:
+        require => Postgresql::Server::Role[$user],
+      }
+
+      # Set default privileges on tables
+      postgresql::server::default_privileges { "alter default privileges grant all on tables to ${user}":
+        db          => $db,
+        role        => $user,
+        privilege   => 'ALL',
+        object_type => 'TABLES',
+        schema      => '',
+        require     => Postgresql::Server::Database[$db],
+      }
+    MANIFEST
+  end
+  let(:pp_unset_schema_revoke) do
+    <<-MANIFEST
+      $db = #{db}
+      $user = #{user}
+      $group = #{group}
+      $password = #{password}
+
+      class { 'postgresql::server': }
+
+      postgresql::server::role { $user:
+        password_hash => postgresql::postgresql_password($user, $password),
+      }
+      postgresql::server::database { $db:
+        require => Postgresql::Server::Role[$user],
+      }
+
+      # Removes default privileges on tables
+      postgresql::server::default_privileges { "alter default privileges revoke all on tables for ${user}":
+        db          => $db,
+        role        => $user,
+        privilege   => 'ALL',
+        object_type => 'TABLES',
+        schema      => '',
+        ensure      => 'absent',
+        require     => Postgresql::Server::Database[$db],
+      }
+    MANIFEST
+  end
+
   it 'grants default privileges to an user' do
     if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.6')
       idempotent_apply(pp_one)
@@ -208,6 +269,29 @@ describe 'postgresql::server::default_privileges:' do
 
       psql("--command=\"SET client_min_messages = 'error'; #{target_check_command}\" --db=#{db}", user) do |r|
         expect(r.stdout).to match(%r{^\(0 rows\)$})
+        expect(r.stderr).to eq('')
+      end
+    end
+  end
+
+  it 'grants default privileges on all schemas to a user' do
+    if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.6')
+      idempotent_apply(pp_unset_schema)
+
+      psql("--command=\"SET client_min_messages = 'error';#{all_schemas_check_command}\" --db=#{db}") do |r|
+        expect(r.stdout).to match(%r{\(1 row\)})
+        expect(r.stderr).to eq('')
+      end
+    end
+  end
+
+  it 'revokes default privileges on all schemas for a user' do
+    if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.6')
+      apply_manifest(pp_unset_schema, catch_failures: true)
+      apply_manifest(pp_unset_schema_revoke, expect_changes: true)
+
+      psql("--command=\"SET client_min_messages = 'error';#{all_schemas_check_command}\" --db=#{db}") do |r|
+        expect(r.stdout).to match(%r{\(0 rows\)})
         expect(r.stderr).to eq('')
       end
     end

--- a/spec/unit/defines/server/default_privileges_spec.rb
+++ b/spec/unit/defines/server/default_privileges_spec.rb
@@ -112,7 +112,7 @@ describe 'postgresql::server::default_privileges', type: :define do
         # rubocop:disable Layout/LineLength
         is_expected.to contain_postgresql_psql('default_privileges:test')
           .with_command('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "test"')
-          .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
+          .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
         # rubocop:enable Layout/LineLength
       end
     end
@@ -222,7 +222,33 @@ describe 'postgresql::server::default_privileges', type: :define do
       # rubocop:disable Layout/LineLength
       is_expected.to contain_postgresql_psql('default_privileges:test')
         .with_command('ALTER DEFAULT PRIVILEGES IN SCHEMA my_schema GRANT ALL ON TABLES TO "test"')
-        .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname = 'my_schema' and defaclobjtype = 'r')")
+        .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname = 'my_schema' and defaclobjtype = 'r')")
+      # rubocop:enable Layout/LineLength
+    end
+  end
+
+  context 'with unset schema name' do
+    let :params do
+      {
+        db: 'test',
+        role: 'test',
+        privilege: 'all',
+        object_type: 'tables',
+        schema: ''
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server':}"
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_postgresql__server__default_privileges('test') }
+    it do
+      # rubocop:disable Layout/LineLength
+      is_expected.to contain_postgresql_psql('default_privileges:test')
+        .with_command('ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO "test"')
+        .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname IS NULL and defaclobjtype = 'r')")
       # rubocop:enable Layout/LineLength
     end
   end
@@ -278,7 +304,7 @@ describe 'postgresql::server::default_privileges', type: :define do
       # rubocop:disable Layout/LineLength
       is_expected.to contain_postgresql_psql('default_privileges:test')
         .with_command('ALTER DEFAULT PRIVILEGES FOR ROLE target IN SCHEMA public GRANT ALL ON TABLES TO "test"')
-        .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt/target' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
+        .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt/target' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
       # rubocop:enable Layout/LineLength
     end
   end


### PR DESCRIPTION
The Postgres default is for the absent specification of a schema name
when altering default privileges to apply to all schemas.
Support that behaviour, but keep the current default behaviour for
an unset schema parameter.

This means that the behaviour doesn't match up with the postgres specification - a better match would be if leaving the `schema` parameter unset also left off the `IN SCHEMA` clause, but this would break backwards compatibility.