### PR TITLE
Inline file contents in the catalog

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -26,10 +26,10 @@ class postgresql::client (
   }
 
   file { $validcon_script_path:
-    ensure => $file_ensure,
-    source => 'puppet:///modules/postgresql/validate_postgresql_connection.sh',
-    owner  => 0,
-    group  => 0,
-    mode   => '0755',
+    ensure  => $file_ensure,
+    content => file('postgresql/validate_postgresql_connection.sh'),
+    owner   => 0,
+    group   => 0,
+    mode    => '0755',
   }
 }

--- a/manifests/repo/yum_postgresql_org.pp
+++ b/manifests/repo/yum_postgresql_org.pp
@@ -5,11 +5,11 @@ class postgresql::repo::yum_postgresql_org inherits postgresql::repo {
   $gpg_key_path    = "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-${package_version}"
 
   file { $gpg_key_path:
-    source => 'puppet:///modules/postgresql/RPM-GPG-KEY-PGDG',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    before => Yumrepo['yum.postgresql.org'],
+    content => file('postgresql/RPM-GPG-KEY-PGDG'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    before  => Yumrepo['yum.postgresql.org'],
   }
 
   if($facts['os']['name'] == 'Fedora') {


### PR DESCRIPTION
The file() function can read a file form a module and return the content. This happens server side and is included in the catalog. This saves a request to the fileserver at runtime. That request can fail for various reasons (it's still a network). It also means that a cached catalog is sufficient and an agent can reapply it without a Puppetserver running. These files are small enough to inline in the catalog.