### PR TITLE
Add Red Hat Enterprise Linux 9 support

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -183,6 +183,7 @@ class postgresql::globals (
       },
       'Amazon' => '9.2',
       default => $facts['os']['release']['major'] ? {
+        '9'     => '13',
         '8'     => '10',
         '7'     => '9.2',
         '6'     => '8.4',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -82,28 +82,12 @@ class postgresql::params inherits postgresql::globals {
         $postgresql_conf_mode   = pick($postgresql_conf_mode, '0600')
       }
 
-      case $facts['os']['name'] {
-        'Amazon': {
-          $service_reload = "service ${service_name} reload"
-          $service_status = "service ${service_name} status"
-        }
-
-        # RHEL 5 uses SysV init, RHEL 6 uses upstart, RHEL 7+ uses systemd.
-        'RedHat', 'CentOS', 'Scientific', 'OracleLinux': {
-          if versioncmp($facts['os']['release']['major'], '7') >= 0 {
-            $service_reload = "systemctl reload ${service_name}"
-            $service_status = "systemctl status ${service_name}"
-          } else {
-            $service_reload = "service ${service_name} reload"
-            $service_status = "service ${service_name} status"
-          }
-        }
-
-        # Default will catch Fedora which uses systemd
-        default: {
-          $service_reload = "systemctl reload ${service_name}"
-          $service_status = "systemctl status ${service_name}"
-        }
+      if pick($service_provider, $facts['service_provider']) == 'systemd' {
+        $service_reload = "systemctl reload ${service_name}"
+        $service_status = "systemctl status ${service_name}"
+      } else {
+        $service_reload = "service ${service_name} reload"
+        $service_status = "service ${service_name} status"
       }
 
       $psql_path           = pick($psql_path, "${bindir}/psql")

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -181,7 +181,7 @@ class postgresql::server::config {
 
   # RedHat-based systems hardcode some PG* variables in the init script, and need to be overriden
   # in /etc/sysconfig/pgsql/postgresql. Create a blank file so we can manage it with augeas later.
-  if ($facts['os']['family'] == 'RedHat') and ($facts['os']['release']['major'] !~ /^(7|8)$/) and ($facts['os']['name'] != 'Fedora') {
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') < 0 {
     file { '/etc/sysconfig/pgsql/postgresql':
       ensure  => file,
       replace => false,

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/provision.yaml
+++ b/provision.yaml
@@ -37,6 +37,7 @@ release_checks_6:
   - redhat-6-x86_64
   - redhat-7-x86_64
   - redhat-8-x86_64
+  - redhat-9-x86_64
   - centos-6-x86_64
   - centos-7-x86_64
   - centos-8-x86_64
@@ -58,6 +59,7 @@ release_checks_7:
   images:
   - redhat-7-x86_64
   - redhat-8-x86_64
+  - redhat-9-x86_64
   - centos-7-x86_64
   - centos-8-x86_64
   - oracle-7-x86_64

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -92,32 +92,62 @@ shared_examples 'postgresql_escape function' do
   end
 end
 
+# This duplicates spec_helper but we need it for add_custom_fact
+include RspecPuppetFacts
+# Rough conversion of grepping in the puppet source:
+# grep defaultfor lib/puppet/provider/service/*.rb
+# See https://github.com/voxpupuli/voxpupuli-test/blob/master/lib/voxpupuli/test/facts.rb
+add_custom_fact :service_provider, ->(_os, facts) do
+  case facts[:osfamily].downcase
+  when 'archlinux'
+    'systemd'
+  when 'darwin'
+    'launchd'
+  when 'debian'
+    'systemd'
+  when 'freebsd'
+    'freebsd'
+  when 'gentoo'
+    'openrc'
+  when 'openbsd'
+    'openbsd'
+  when 'redhat'
+    facts[:operatingsystemrelease].to_i >= 7 ? 'systemd' : 'redhat'
+  when 'suse'
+    facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
+  when 'windows'
+    'windows'
+  else
+    'init'
+  end
+end
+
 shared_context 'Debian 9' do
-  let(:facts) { on_supported_os['debian-9-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['debian-9-x86_64'] }
 end
 
 shared_context 'Debian 10' do
-  let(:facts) { on_supported_os['debian-10-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['debian-10-x86_64'] }
 end
 
 shared_context 'Debian 11' do
-  let(:facts) { on_supported_os['debian-11-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['debian-11-x86_64'] }
 end
 
 shared_context 'Ubuntu 18.04' do
-  let(:facts) { on_supported_os['ubuntu-18.04-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['ubuntu-18.04-x86_64'] }
 end
 
 shared_context 'RedHat 6' do
-  let(:facts) { on_supported_os['redhat-6-x86_64'].merge(service_provider: 'redhat') }
+  let(:facts) { on_supported_os['redhat-6-x86_64'] }
 end
 
 shared_context 'RedHat 7' do
-  let(:facts) { on_supported_os['redhat-7-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['redhat-7-x86_64'] }
 end
 
 shared_context 'RedHat 8' do
-  let(:facts) { on_supported_os['redhat-8-x86_64'].merge(service_provider: 'systemd') }
+  let(:facts) { on_supported_os['redhat-8-x86_64'] }
 end
 
 shared_context 'Fedora 33' do


### PR DESCRIPTION
The comment indicates this is something that needs to be done on EL6 and older. The current check would also trigger on EL9. This uses a version comparison on the major version. We can leave out the Fedora check since we don't need to care about Fedora < 7.