### PR TITLE
debian package postgresql-contrib virtual package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,8 +135,6 @@ class postgresql::params inherits postgresql::globals {
       $java_package_name      = pick($java_package_name, 'postgresql-jdbc')
       # Archlinux doesn't have develop packages
       $devel_package_name     = pick($devel_package_name, 'postgresql-devel')
-      # Archlinux does have postgresql-contrib but it isn't maintained
-      $contrib_package_name   = pick($contrib_package_name,'undef')
       # Archlinux postgresql package provides plperl
       $plperl_package_name    = pick($plperl_package_name, 'undef')
       $plpython_package_name  = pick($plpython_package_name, 'undef')
@@ -163,7 +161,6 @@ class postgresql::params inherits postgresql::globals {
 
       $client_package_name    = pick($client_package_name, "postgresql-client-${version}")
       $server_package_name    = pick($server_package_name, "postgresql-${version}")
-      $contrib_package_name = pick($contrib_package_name, "postgresql-contrib-${version}")
       if $postgis_version and versioncmp($postgis_version, '2') < 0 {
         $postgis_package_name = pick($postgis_package_name, "postgresql-${version}-postgis")
       } elsif $postgis_version and versioncmp($postgis_version, '3') >= 0 {
@@ -203,7 +200,6 @@ class postgresql::params inherits postgresql::globals {
 
       $client_package_name  = pick($client_package_name, 'UNSET')
       $server_package_name  = pick($server_package_name, 'postgresql')
-      $contrib_package_name = pick_default($contrib_package_name, undef)
       $devel_package_name   = pick_default($devel_package_name, undef)
       $java_package_name    = pick($java_package_name, 'jdbc-postgresql')
       $perl_package_name    = pick($perl_package_name, 'DBD-Pg')

--- a/manifests/server/contrib.pp
+++ b/manifests/server/contrib.pp
@@ -5,22 +5,20 @@
 # @param package_ensure
 #   Ensure the contrib package is installed.
 class postgresql::server::contrib (
-  String $package_name      = $postgresql::params::contrib_package_name,
-  String[1] $package_ensure = 'present'
+  Optional[String[1]] $package_name = $postgresql::params::contrib_package_name,
+  String[1] $package_ensure         = 'present'
 ) inherits postgresql::params {
-  if $facts['os']['family'] == 'Gentoo' {
-    fail('osfamily Gentoo does not have a separate "contrib" package, postgresql::server::contrib is not supported.')
-  }
+  if $package_name {
+    package { 'postgresql-contrib':
+      ensure => $package_ensure,
+      name   => $package_name,
+      tag    => 'puppetlabs-postgresql',
+    }
 
-  package { 'postgresql-contrib':
-    ensure => $package_ensure,
-    name   => $package_name,
-    tag    => 'puppetlabs-postgresql',
+    anchor { 'postgresql::server::contrib::start': }
+    -> Class['postgresql::server::install']
+    -> Package['postgresql-contrib']
+    -> Class['postgresql::server::service']
+    anchor { 'postgresql::server::contrib::end': }
   }
-
-  anchor { 'postgresql::server::contrib::start': }
-  -> Class['postgresql::server::install']
-  -> Package['postgresql-contrib']
-  -> Class['postgresql::server::service']
-  anchor { 'postgresql::server::contrib::end': }
 }

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -43,5 +43,4 @@ describe 'postgresql::server::contrib', type: :class do
       is_expected.to contain_package('postgresql-contrib').with(tag: 'puppetlabs-postgresql')
     end
   end
-
 end

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -43,4 +43,37 @@ describe 'postgresql::server::contrib', type: :class do
       is_expected.to contain_package('postgresql-contrib').with(tag: 'puppetlabs-postgresql')
     end
   end
+
+  describe 'on Gentoo' do
+    let :facts do
+      {
+        os: {
+          family: 'Gentoo',
+          name: 'Gentoo',
+        },
+      }
+    end
+
+    it 'postgresql-contrib should not be installed' do
+      is_expected.to compile
+      is_expected.not_to contain_package('postgresql-contrib')
+    end
+  end
+
+  describe 'on Debian' do
+    let :facts do
+      {
+        os: {
+          family: 'Debian',
+          name: 'Debian',
+          release: { 'full' => '8.0', 'major' => '8' },
+        },
+      }
+    end
+
+    it 'postgresql-contrib should not be installed' do
+      is_expected.to compile
+      is_expected.not_to contain_package('postgresql-contrib')
+    end
+  end
 end

--- a/spec/unit/classes/server/contrib_spec.rb
+++ b/spec/unit/classes/server/contrib_spec.rb
@@ -10,9 +10,12 @@ describe 'postgresql::server::contrib', type: :class do
   let :facts do
     {
       os: {
-        family: 'Debian',
-        name: 'Debian',
-        release: { 'full' => '8.0', 'major' => '8' },
+        family: 'RedHat',
+        name: 'RedHat',
+        release: { 'major' => '8' },
+        selinux: {
+          enabled: false,
+        },
       },
       kernel: 'Linux',
       id: 'root',
@@ -41,20 +44,4 @@ describe 'postgresql::server::contrib', type: :class do
     end
   end
 
-  describe 'on Gentoo' do
-    let :facts do
-      {
-        os: {
-          family: 'Gentoo',
-          name: 'Gentoo',
-        },
-      }
-    end
-
-    it 'fails to compile' do
-      expect {
-        is_expected.to compile
-      }.to raise_error(%r{is not supported})
-    end
-  end
 end


### PR DESCRIPTION
Debian family provides postgresql-contriub-XY as a virtual package of postgresql-XY.

Not sure if allowing virtual packages here is the best solution :thinking: 

Referencies:
https://packages.debian.org/bullseye/postgresql-contrib-13
https://packages.ubuntu.com/bionic/postgresql-contrib