### PR TITLE
add scram-sha-256 support

### DIFF
--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -20,8 +20,8 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   dispatch :default_impl do
     required_param 'Variant[String[1], Integer]', :username
     required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
-    required_param "Enum['md5', 'scram-sha-256']", :hash
     optional_param 'Boolean', :sensitive
+    optional_param "Enum['md5', 'scram-sha-256']", :hash
     optional_param 'Optional[Variant[String[1], Integer]]', :salt
     return_type 'Variant[String, Sensitive[String]]'
   end

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     required_param 'Variant[String[1], Integer]', :username
     required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
     optional_param 'Boolean', :sensitive
-    optional_param "Enum['md5', 'scram-sha-256']", :hash
+    optional_param "Optional[Enum['md5', 'scram-sha-256']]", :hash
     optional_param 'Optional[Variant[String[1], Integer]]', :salt
     return_type 'Variant[String, Sensitive[String]]'
   end

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def default_impl(username, password, hash, sensitive = false, salt = nil)
+  def default_impl(username, password, hash = 'md5', sensitive = false, salt = nil)
     password = password.unwrap if password.respond_to?(:unwrap)
     pass = if hash == 'md5'
              'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def default_impl(username, password, hash = 'md5', sensitive = false, salt = nil)
+  def default_impl(username, password, sensitive = false, hash = 'md5', salt = nil)
     password = password.unwrap if password.respond_to?(:unwrap)
     pass = if hash == 'md5'
              'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'openssl'
+require 'base64'
 
 # @summary This function returns the postgresql password hash from the clear text username / password
 Puppet::Functions.create_function(:'postgresql::postgresql_password') do
@@ -8,23 +10,66 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   #   The clear text `password`
   # @param sensitive
   #   If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
+  # @param hash
+  #   Set type for password hash
+  # @param salt
+  #   Use a specific salt value for scram-sha-256, default is username
   #
   # @return
   #   The postgresql password hash from the clear text username / password.
   dispatch :default_impl do
     required_param 'Variant[String[1], Integer]', :username
     required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
+    required_param "Enum['md5', 'scram-sha-256']", :hash
     optional_param 'Boolean', :sensitive
+    optional_param 'Optional[Variant[String[1], Integer]]', :salt
     return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def default_impl(username, password, sensitive = false)
+  def default_impl(username, password, hash, sensitive = false, salt = nil)
     password = password.unwrap if password.respond_to?(:unwrap)
-    result_string = 'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)
+    pass = if hash == 'md5'
+             'md5' + Digest::MD5.hexdigest(password.to_s + username.to_s)
+           else
+             pg_sha256(password, (salt || username))
+           end
     if sensitive
-      Puppet::Pops::Types::PSensitiveType::Sensitive.new(result_string)
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(pass)
     else
-      result_string
+      pass
     end
+  end
+
+  def pg_sha256(password, salt)
+    digest = digest_key(password, salt)
+    'SCRAM-SHA-256$%s:%s$%s:%s' % [
+      '4096',
+      Base64.strict_encode64(salt),
+      Base64.strict_encode64(client_key(digest)),
+      Base64.strict_encode64(server_key(digest))
+    ]
+  end
+
+  def digest_key(password, salt)
+    OpenSSL::KDF.pbkdf2_hmac(
+      password,
+      salt: salt,
+      iterations: 4096,
+      length: 32,
+      hash: OpenSSL::Digest::SHA256.new
+    )
+  end
+
+  def client_key(digest_key)
+    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
+    hmac << 'Client Key'
+    hmac.digest
+    OpenSSL::Digest.new('SHA256').digest hmac.digest
+  end
+
+  def server_key(digest_key)
+    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
+    hmac << 'Server Key'
+    hmac.digest
   end
 end

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -140,8 +140,8 @@ define postgresql::server::role (
         $pwd_hash_sql = postgresql::postgresql_password(
           $username,
           $password_hash,
-          $hash,
           $password_hash =~ Sensitive[String],
+          $hash,
           $salt,
         )
       }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -18,6 +18,8 @@
 # @param psql_group Sets the OS group to run psql
 # @param psql_path Sets path to psql command
 # @param module_workdir Specifies working directory under which the psql command should be executed. May need to specify if '/tmp' is on volume mounted with noexec option.
+# @param hash Specify the hash method for pg password
+# @param salt Specify the salt use for the scram-sha-256 encoding password (default username)
 define postgresql::server::role (
   $update_password = true,
   Variant[Boolean, String, Sensitive[String]] $password_hash  = false,
@@ -37,6 +39,8 @@ define postgresql::server::role (
   $psql_path        = $postgresql::server::psql_path,
   $module_workdir   = $postgresql::server::module_workdir,
   Enum['present', 'absent'] $ensure = 'present',
+  Enum['md5', 'scram-sha-256'] $hash = 'md5',
+  Optional[Variant[String[1], Integer]] $salt = undef,
 ) {
   $password_hash_unsensitive = if $password_hash =~ Sensitive[String] {
     $password_hash.unwrap
@@ -130,14 +134,19 @@ define postgresql::server::role (
     }
 
     if $password_hash_unsensitive and $update_password {
-      if($password_hash_unsensitive =~ /^md5.+/) {
+      if($password_hash_unsensitive =~ /^(md5|SCRAM-SHA-256).+/) {
         $pwd_hash_sql = $password_hash_unsensitive
       } else {
-        $pwd_md5 = md5("${password_hash_unsensitive}${username}")
-        $pwd_hash_sql = "md5${pwd_md5}"
+        $pwd_hash_sql = postgresql::postgresql_password(
+          $username,
+          $password_hash,
+          $hash,
+          $password_hash =~ Sensitive[String],
+          $salt,
+        )
       }
       postgresql_psql { "ALTER ROLE ${username} ENCRYPTED PASSWORD ****":
-        command   => Sensitive("ALTER ROLE \"${username}\" ${password_sql}"),
+        command   => Sensitive("ALTER ROLE \"${username}\" ENCRYPTED PASSWORD '${pwd_hash_sql}'"),
         unless    => Sensitive("SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'"),
         sensitive => true,
       }

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -48,10 +48,24 @@ shared_examples 'postgresql_password function' do
   it { is_expected.not_to eq(nil) }
 
   it {
-    is_expected.to run.with_params('foo', 'bar').and_return('md596948aad3fcae80c08a35c9b5958cd89')
+    is_expected.to run.with_params('foo', 'bar', 'md5').and_return(
+      'md596948aad3fcae80c08a35c9b5958cd89'
+    )
   }
   it {
-    is_expected.to run.with_params('foo', 1234).and_return('md539a0e1b308278a8de5e007cd1f795920')
+    is_expected.to run.with_params('foo', 1234, 'md5').and_return(
+      'md539a0e1b308278a8de5e007cd1f795920'
+    )
+  }
+  it {
+    is_expected.to run.with_params('foo', 'bar', 'scram-sha-256').and_return(
+      'SCRAM-SHA-256$4096:YmFy$y1VOaTvvs4V3OECvMzre9FtgCZClGuBLVE6sNPsTKbs=:HwFqmSKbihSyHMqkhufOy++cWCFIoTRSg8y6YgeALzE='
+    )
+  }
+  it {
+    is_expected.to run.with_params('foo', 'bar', 'scram-sha-256', nil, 'salt').and_return(
+      'SCRAM-SHA-256$4096:c2FsdA==$zOt2zFfUQMbpQf3/vRnYB33QDK/L7APOBHniLy39j/4=:DcW5Jp8Do7wYhVp1f9aT0cyhUfzIAozGcvzXZj+M3YI='
+    )
   }
   it 'raises an error if there is only 1 argument' do
     is_expected.to run.with_params('foo').and_raise_error(StandardError)

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -48,22 +48,22 @@ shared_examples 'postgresql_password function' do
   it { is_expected.not_to eq(nil) }
 
   it {
-    is_expected.to run.with_params('foo', 'bar', 'md5').and_return(
+    is_expected.to run.with_params('foo', 'bar').and_return(
       'md596948aad3fcae80c08a35c9b5958cd89'
     )
   }
   it {
-    is_expected.to run.with_params('foo', 1234, 'md5').and_return(
+    is_expected.to run.with_params('foo', 1234).and_return(
       'md539a0e1b308278a8de5e007cd1f795920'
     )
   }
   it {
-    is_expected.to run.with_params('foo', 'bar', 'scram-sha-256').and_return(
+    is_expected.to run.with_params('foo', 'bar', nil, 'scram-sha-256').and_return(
       'SCRAM-SHA-256$4096:YmFy$y1VOaTvvs4V3OECvMzre9FtgCZClGuBLVE6sNPsTKbs=:HwFqmSKbihSyHMqkhufOy++cWCFIoTRSg8y6YgeALzE='
     )
   }
   it {
-    is_expected.to run.with_params('foo', 'bar', 'scram-sha-256', nil, 'salt').and_return(
+    is_expected.to run.with_params('foo', 'bar', nil, 'scram-sha-256', 'salt').and_return(
       'SCRAM-SHA-256$4096:c2FsdA==$zOt2zFfUQMbpQf3/vRnYB33QDK/L7APOBHniLy39j/4=:DcW5Jp8Do7wYhVp1f9aT0cyhUfzIAozGcvzXZj+M3YI='
     )
   }


### PR DESCRIPTION
Hi,

Since pg 14, scram-sha-256 is the default encryption method. I've change the postgresql_password for support the new encoding methods and change in `postgresql::server::role` for use this function. The default methods of the function still md5, but that create a breaking (`encode` doesn't have default value on my code)

I've set the username as salt chain per default.

I've test and validate on postgresql14

This PR include https://github.com/puppetlabs/puppetlabs-postgresql/pull/1132

Regards,