### PR TITLE
fix table grant with schema

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -425,10 +425,8 @@ define postgresql::server::grant (
   # }
   case $_object_name {
     Array:   {
-      $_togrant_object = $_enquote_object ? {
-        false   => join($_object_name, '.'),
-        default => join($_object_name, '"."'),
-      }
+      # pg_* views does not contain schema name as part of the object name
+      $_togrant_object = $_object_name
       # Never put double quotes into has_*_privilege function
       $_granted_object = join($_object_name, '.')
     }


### PR DESCRIPTION
There was an issue using `postgresql::server::grant::onlyif_exists = true` and specifying a schema `postgresql::server::grant::object_name = ['myschema', 'mytable']` as the onlyif check was including the schema in the query in pg_* views.