### PR TITLE
Fix python package name in RHEL/CentOS 8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,11 @@ class postgresql::params inherits postgresql::globals {
       $psql_path           = pick($psql_path, "${bindir}/psql")
 
       $perl_package_name   = pick($perl_package_name, 'perl-DBD-Pg')
-      $python_package_name = pick($python_package_name, 'python-psycopg2')
+      if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '8') >= 0 {
+        $python_package_name = pick($python_package_name, 'python3-psycopg2')
+      } else {
+        $python_package_name = pick($python_package_name, 'python-psycopg2')
+      }
 
       if $postgresql::globals::postgis_package_name {
         $postgis_package_name = $postgresql::globals::postgis_package_name

--- a/spec/unit/classes/lib/python_spec.rb
+++ b/spec/unit/classes/lib/python_spec.rb
@@ -22,6 +22,25 @@ describe 'postgresql::lib::python', type: :class do
     }
   end
 
+  describe 'on a redhat based os with python 3' do
+    let :facts do
+      {
+        os: {
+          family: 'RedHat',
+          name: 'RedHat',
+          release: { 'full' => '8.2', 'major' => '8' },
+        },
+      }
+    end
+
+    it {
+      is_expected.to contain_package('python-psycopg2').with(
+        name: 'python3-psycopg2',
+        ensure: 'present',
+      )
+    }
+  end
+
   describe 'on a debian based os' do
     let :facts do
       {


### PR DESCRIPTION
In RHEL/CentOS8, python3 is used globally instead of python2. Because
of that python-* package is no longer available and most of python
packages are named python3-*.