### PR TITLE
fix spec postgresql_password with scram-sha-256

### DIFF
--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -59,12 +59,12 @@ shared_examples 'postgresql_password function' do
   }
   it {
     is_expected.to run.with_params('foo', 'bar', false, 'scram-sha-256').and_return(
-      'SCRAM-SHA-256$4096:YmFy$y1VOaTvvs4V3OECvMzre9FtgCZClGuBLVE6sNPsTKbs=:HwFqmSKbihSyHMqkhufOy++cWCFIoTRSg8y6YgeALzE=',
+      'SCRAM-SHA-256$4096:Zm9v$ea66ynZ8cS9Ty4ZkEYicwC72StsKLSwjcXIXKMgepTk=:dJYmOU6BMCaWkQOB3lrXH9OAF3lW2n3NJ26NO7Srq7U=',
     )
   }
   it {
     is_expected.to run.with_params('foo', 'bar', false, 'scram-sha-256', 'salt').and_return(
-      'SCRAM-SHA-256$4096:c2FsdA==$zOt2zFfUQMbpQf3/vRnYB33QDK/L7APOBHniLy39j/4=:DcW5Jp8Do7wYhVp1f9aT0cyhUfzIAozGcvzXZj+M3YI=',
+      'SCRAM-SHA-256$4096:c2FsdA==$hl63wu9L6vKIjd/UGPfpRl/hIQRBnlkoCiJ9KgxzbX0=:3Q39uiwDZ51m3iPpV8rSgISgRiYqkbnpc+wScL2lSAU=',
     )
   }
   it 'raises an error if there is only 1 argument' do


### PR DESCRIPTION
Hello,

Fix discussion https://github.com/puppetlabs/puppetlabs-postgresql/pull/1313#discussion_r798455572 

The correct values on the test should be `SCRAM-SHA-256$4096:Zm9v$ea66ynZ8cS9Ty4ZkEYicwC72StsKLSwjcXIXKMgepTk=:dJYmOU6BMCaWkQOB3lrXH9OAF3lW2n3NJ26NO7Srq7U=` and `SCRAM-SHA-256$4096:c2FsdA==$hl63wu9L6vKIjd/UGPfpRl/hIQRBnlkoCiJ9KgxzbX0=:3Q39uiwDZ51m3iPpV8rSgISgRiYqkbnpc+wScL2lSAU=`

```
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> require 'base64'
=> true
irb(main):003:0>   def pg_sha256(password, salt)
    digest = digest_key(password, salt)
    'SCRAM-SHA-256$%{iterations}:%{salt}$%{client_key}:%{server_key}' % {
      iterations: '4096',
      salt: Base64.strict_encode64(salt),
      client_key: Base64.strict_encode64(client_key(digest)),
      server_key: Base64.strict_encode64(server_key(digest)),
    }
  end

  def digest_key(password, salt)
    OpenSSL::KDF.pbkdf2_hmac(
      password,
      salt: salt,
      iterations: 4096,
      length: 32,
      hash: OpenSSL::Digest::SHA256.new,
    )
  end

  def client_key(digest_key)
    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
    hmac << 'Client Key'
    hmac.digest
    OpenSSL::Digest.new('SHA256').digest hmac.digest
  end

  def server_key(digest_key)
    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
    hmac << 'Server Key'
    hmac.digest
  end
=> :pg_sha256
=> :digest_key
=> :client_key
=> :server_key
irb(main):036:0> pg_sha256('bar', 'foo')
=> "SCRAM-SHA-256$4096:Zm9v$ea66ynZ8cS9Ty4ZkEYicwC72StsKLSwjcXIXKMgepTk=:dJYmOU6BMCaWkQOB3lrXH9OAF3lW2n3NJ26NO7Srq7U="
irb(main):037:0> pg_sha256('bar', 'salt')
=> "SCRAM-SHA-256$4096:c2FsdA==$hl63wu9L6vKIjd/UGPfpRl/hIQRBnlkoCiJ9KgxzbX0=:3Q39uiwDZ51m3iPpV8rSgISgRiYqkbnpc+wScL2lSAU="
```