### PR TITLE
Remove unused variable in reload.pp

### DIFF
--- a/manifests/server/reload.pp
+++ b/manifests/server/reload.pp
@@ -1,6 +1,5 @@
 # @api private
 class postgresql::server::reload {
-  $service_name   = $postgresql::server::service_name
   $service_status = $postgresql::server::service_status
   $service_reload = $postgresql::server::service_reload
 


### PR DESCRIPTION
When service_reload was introduced, it made service_name redundant.

Fixes: ef1681f5e50ae7976484dd1daf6a18a92bcb9191