### PR TITLE
README.md: correct postgresql_conn_validator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,9 @@ postgresql_conn_validator { 'validate my postgres connection':
   db_username       => 'mydbuser',
   db_password       => 'mydbpassword',
   db_name           => 'mydbname',
-}->
-exec { 'rake db:migrate':
+  psql_path         => '/usr/bin/psql',
+}
+-> exec { 'rake db:migrate':
   cwd => '/opt/myrubyapp',
 }
 ```


### PR DESCRIPTION
it's required to set the psql_path parameter. Otherwise you end up with
something like:
```
Debug: Executing: '--tuples-only --quiet --no-psqlrc --host 127.0.0.1
--port 5432 --username grafana --dbname grafana --command SELECT 1'
```