### PR TITLE
pdksync - (GH-cat-12) Add Support for Redhat 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
(GH-cat-12) Add Support for Redhat 9
pdk version: `2.4.0` 
