### PR TITLE
Ensure multiple postgresql::server::recovery resources can be defined

### DIFF
--- a/manifests/server/recovery.pp
+++ b/manifests/server/recovery.pp
@@ -61,7 +61,7 @@ define postgresql::server::recovery (
     }
 
     # Create the recovery.conf content
-    concat::fragment { 'recovery.conf':
+    concat::fragment { "${name}-recovery.conf":
       target  => $target,
       content => template('postgresql/recovery.conf.erb'),
     }

--- a/spec/defines/server/recovery_spec.rb
+++ b/spec/defines/server/recovery_spec.rb
@@ -29,7 +29,7 @@ describe 'postgresql::server::recovery' do
     end
 
     it do
-      is_expected.to contain_concat__fragment('recovery.conf')
+      is_expected.to contain_concat__fragment('test-recovery.conf')
         .with(content: %r{restore_command = 'restore_command'[\n]+recovery_target_timeline = 'recovery_target_timeline'})
     end
   end
@@ -100,7 +100,7 @@ describe 'postgresql::server::recovery' do
     end
 
     it do
-      is_expected.to contain_concat__fragment('recovery.conf')
+      is_expected.to contain_concat__fragment('test-recovery.conf')
         .with(content: %r{restore_command = 'restore_command'[\n]+archive_cleanup_command = 'archive_cleanup_command'[\n]+recovery_end_command = 'recovery_end_command'[\n]+recovery_target_name = 'recovery_target_name'[\n]+recovery_target_time = 'recovery_target_time'[\n]+recovery_target_xid = 'recovery_target_xid'[\n]+recovery_target_inclusive = true[\n]+recovery_target = 'recovery_target'[\n]+recovery_target_timeline = 'recovery_target_timeline'[\n]+pause_at_recovery_target = true[\n]+standby_mode = on[\n]+primary_conninfo = 'primary_conninfo'[\n]+primary_slot_name = 'primary_slot_name'[\n]+trigger_file = 'trigger_file'[\n]+recovery_min_apply_delay = 0[\n]+}) # rubocop:disable Layout/LineLength
     end
   end


### PR DESCRIPTION
As `postgresql::server::recovery` is a define it should support multiple instances of itself.
With the `concat::fragment` having a fixed name this is not possible. Thus I just interpolated the name property into that so that one may create multiple recovery files in different locations, if required.