### PR TITLE
Fix service status detection on Debian-based OSes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -166,18 +166,13 @@ class postgresql::params inherits postgresql::globals {
       $bindir                 = pick($bindir, "/usr/lib/postgresql/${version}/bin")
       $datadir                = pick($datadir, "/var/lib/postgresql/${version}/main")
       $confdir                = pick($confdir, "/etc/postgresql/${version}/main")
-      if $facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '8') >= 0 {
-        # Jessie uses systemd
-        $service_status = pick($service_status, "/usr/sbin/service ${service_name}@*-main status")
-      } elsif $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '18.04') >= 0 {
-        $service_status = pick($service_status, "/usr/sbin/service ${service_name}@*-main status")
-      } elsif $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '15.04') >= 0 {
-        # Ubuntu releases since vivid use systemd
-        $service_status = pick($service_status, "/usr/sbin/service ${service_name} status")
+      if pick($service_provider, $facts['service_provider']) == 'systemd' {
+        $service_reload = "systemctl reload ${service_name}"
+        $service_status = pick($service_status, "systemctl status ${service_name}")
       } else {
-        $service_status = pick($service_status, "/etc/init.d/${service_name} status | /bin/egrep -q 'Running clusters: .+|online'")
+        $service_reload = "service ${service_name} reload"
+        $service_status = pick($service_status, "service ${service_name} status")
       }
-      $service_reload         = "service ${service_name} reload"
       $psql_path              = pick($psql_path, '/usr/bin/psql')
       $postgresql_conf_mode   = pick($postgresql_conf_mode, '0644')
     }

--- a/spec/classes/server/service_spec.rb
+++ b/spec/classes/server/service_spec.rb
@@ -10,5 +10,5 @@ describe 'postgresql::server::service' do
   end
 
   it { is_expected.to contain_class('postgresql::server::service') }
-  it { is_expected.to contain_service('postgresqld').with_name('postgresql').with_status('/usr/sbin/service postgresql@*-main status') }
+  it { is_expected.to contain_service('postgresqld').with_name('postgresql').with_status('systemctl status postgresql') }
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server' do
     it { is_expected.to contain_class('postgresql::server') }
     it { is_expected.to contain_file('/var/lib/postgresql/13/main') }
     it {
-      is_expected.to contain_exec('postgresql_reload').with('command' => 'service postgresql reload')
+      is_expected.to contain_exec('postgresql_reload').with('command' => 'systemctl reload postgresql')
     }
     it 'validates connection' do
       is_expected.to contain_postgresql_conn_validator('validate_service_is_running')


### PR DESCRIPTION
`/usr/sbin/service postgresql@*-main status` on at least Ubuntu 18.04, 20.04 and 22.04, always exits 0 (even when service is down), so puppet always believes the service is up (which both causes all kinds of failures and prevents puppet from starting the stopped service).

Not sure why all the convoluted logic in this bit is needed, but this fixes it for me on 18 and 20 (and also 22 but that's not yet supported by this module).
