### PR TITLE
Add version for Ubuntu 22.04

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -208,6 +208,7 @@ class postgresql::globals (
         /^(18.04)$/ => '10',
         /^(20.04)$/ => '12',
         /^(21.04|21.10)$/ => '13',
+        /^(22.04)$/ => '14',
         default => undef,
       },
       default => undef,


### PR DESCRIPTION
Ubuntu 22.04 ships with version 14.