### PR TITLE
pdksync - (CONT-189) Remove support for RedHat6 / OracleLinux6 / Scientific6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8",
         "9"

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/spec/classes/lib/devel_spec.rb
+++ b/spec/classes/lib/devel_spec.rb
@@ -26,13 +26,13 @@ describe 'postgresql::lib::devel' do
   end
 
   describe 'should not link pg_config on RedHat with default version' do
-    include_examples 'RedHat 6'
+    include_examples 'RedHat 8'
 
     it { is_expected.not_to contain_file('/usr/bin/pg_config') }
   end
 
   describe 'link pg_config on RedHat with non-default version' do
-    include_examples 'RedHat 6'
+    include_examples 'RedHat 8'
     let :pre_condition do
       "class { '::postgresql::globals': version => '9.3' }"
     end

--- a/spec/defines/server/config_entry_spec.rb
+++ b/spec/defines/server/config_entry_spec.rb
@@ -24,34 +24,12 @@ describe 'postgresql::server::config_entry' do
   context 'ports' do
     let(:params) { { ensure: 'present', name: 'port_spec', value: '5432' } }
 
-    context 'redhat 6' do
-      include_examples 'RedHat 6'
-
-      it 'stops postgresql and changes the port #exec' do
-        is_expected.to contain_exec('postgresql_stop_port')
-      end
-      it 'stops postgresql and changes the port #augeas' do
-        is_expected.to contain_augeas('override PGPORT in /etc/sysconfig/pgsql/postgresql')
-      end
-    end
     context 'redhat 7' do
       include_examples 'RedHat 7'
 
       it 'stops postgresql and changes the port #file' do
         is_expected.to contain_file('systemd-override')
       end
-    end
-  end
-
-  context 'data_directory' do
-    include_examples 'RedHat 6'
-    let(:params) { { ensure: 'present', name: 'data_directory_spec', value: '/var/pgsql' } }
-
-    it 'stops postgresql and changes the data directory #exec' do
-      is_expected.to contain_exec('postgresql_data_directory')
-    end
-    it 'stops postgresql and changes the data directory #augeas' do
-      is_expected.to contain_augeas('override PGDATA in /etc/sysconfig/pgsql/postgresql')
     end
   end
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -138,10 +138,6 @@ shared_context 'Ubuntu 18.04' do
   let(:facts) { on_supported_os['ubuntu-18.04-x86_64'] }
 end
 
-shared_context 'RedHat 6' do
-  let(:facts) { on_supported_os['redhat-6-x86_64'] }
-end
-
 shared_context 'RedHat 7' do
   let(:facts) { on_supported_os['redhat-7-x86_64'] }
 end


### PR DESCRIPTION
CONT-189/remove_os_support
pdk version: `2.5.0` 
