### PR TITLE
pg_hba_rule does not properly verify address parameter

### DIFF
--- a/manifests/backup/pg_dump.pp
+++ b/manifests/backup/pg_dump.pp
@@ -133,7 +133,7 @@ class postgresql::backup::pg_dump (
     mode      => '0600',
     owner     => 'root',
     group     => '0', # Use GID for compat with Linux and BSD.
-    content   => inline_epp ( '*:*:*:<%= $db_user %>:<%= $db_password %>',{
+    content   => inline_epp ( '*:*:*:<%= $db_user %>:<%= $db_password %>', {
         db_password => $db_password,
         db_user     => $db_user,
       }

--- a/manifests/backup/pg_dump.pp
+++ b/manifests/backup/pg_dump.pp
@@ -133,7 +133,7 @@ class postgresql::backup::pg_dump (
     mode      => '0600',
     owner     => 'root',
     group     => '0', # Use GID for compat with Linux and BSD.
-    content   => inline_epp('*:*:*:<%= $db_user %>:<%= $db_password %>',{
+    content   => inline_epp( '*:*:*:<%= $db_user %>:<%= $db_password %>',{
         db_password => $db_password,
         db_user     => $db_user,
       }

--- a/manifests/backup/pg_dump.pp
+++ b/manifests/backup/pg_dump.pp
@@ -41,10 +41,10 @@
 #   Weekdays on which the backup job should run. Defaults to `*`. This parameter is passed directly to the cron resource.
 #
 class postgresql::backup::pg_dump (
+  String[1] $dir,
   Boolean $compress = true,
   Array $databases = [],
   Boolean $delete_before_dump = false,
-  String[1] $dir,
   String[1] $dir_group = '0',
   String[1] $dir_mode = '0700',
   String[1] $dir_owner = 'root',
@@ -112,18 +112,19 @@ class postgresql::backup::pg_dump (
     owner   => 'root',
     group   => '0', # Use GID for compat with Linux and BSD.
     content => epp($template, {
-      compress           => $compress,
-      databases          => $databases,
-      db_user            => $db_user,
-      delete_before_dump => $delete_before_dump,
-      dir                => $dir,
-      format             => $format,
-      optional_args      => $optional_args,
-      post_script        => $post_script,
-      pre_script         => $pre_script,
-      rotate             => $rotate,
-      success_file_path  => $success_file_path,
-    }),
+        compress           => $compress,
+        databases          => $databases,
+        db_user            => $db_user,
+        delete_before_dump => $delete_before_dump,
+        dir                => $dir,
+        format             => $format,
+        optional_args      => $optional_args,
+        post_script        => $post_script,
+        pre_script         => $pre_script,
+        rotate             => $rotate,
+        success_file_path  => $success_file_path,
+      }
+    ),
   }
 
   # Create password file for pg_dump
@@ -133,9 +134,10 @@ class postgresql::backup::pg_dump (
     owner     => 'root',
     group     => '0', # Use GID for compat with Linux and BSD.
     content   => inline_epp('*:*:*:<%= $db_user %>:<%= $db_password %>',{
-      db_password => $db_password,
-      db_user     => $db_user,
-    }),
+        db_password => $db_password,
+        db_user     => $db_user,
+      }
+    ),
     show_diff => false,
   }
 

--- a/manifests/backup/pg_dump.pp
+++ b/manifests/backup/pg_dump.pp
@@ -133,7 +133,7 @@ class postgresql::backup::pg_dump (
     mode      => '0600',
     owner     => 'root',
     group     => '0', # Use GID for compat with Linux and BSD.
-    content   => inline_epp( '*:*:*:<%= $db_user %>:<%= $db_password %>',{
+    content   => inline_epp ( '*:*:*:<%= $db_user %>:<%= $db_password %>',{
         db_password => $db_password,
         db_user     => $db_user,
       }

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -23,7 +23,7 @@ define postgresql::server::default_privileges (
     /(?i:^SEQUENCES$)/,
     /(?i:^TABLES$)/,
     /(?i:^TYPES$)/,
-    /(?i:^SCHEMAS$)/,
+    /(?i:^SCHEMAS$)/ # lint:ignore:trailing_comma
   ] $object_type,
   String $schema                      = 'public',
   String $psql_db                     = $postgresql::server::default_database,

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -23,7 +23,7 @@ define postgresql::server::default_privileges (
     /(?i:^SEQUENCES$)/,
     /(?i:^TABLES$)/,
     /(?i:^TYPES$)/,
-    /(?i:^SCHEMAS$)/
+    /(?i:^SCHEMAS$)/,
   ] $object_type,
   String $schema                      = 'public',
   String $psql_db                     = $postgresql::server::default_database,

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -29,7 +29,7 @@ define postgresql::server::grant (
     /(?i:^TABLE$)/,
     #/(?i:^TABLESPACE$)/,
     /(?i:^SCHEMA$)/,
-    /(?i:^SEQUENCE$)/,
+    /(?i:^SEQUENCE$)/ # lint:ignore:trailing_comma
     #/(?i:^VIEW$)/
   ] $object_type                        = 'database',
   Optional[Variant[Array[String,2,2],String[1]]] $object_name = undef,

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -29,7 +29,7 @@ define postgresql::server::grant (
     /(?i:^TABLE$)/,
     #/(?i:^TABLESPACE$)/,
     /(?i:^SCHEMA$)/,
-    /(?i:^SEQUENCE$)/
+    /(?i:^SEQUENCE$)/,
     #/(?i:^VIEW$)/
   ] $object_type                        = 'database',
   Optional[Variant[Array[String,2,2],String[1]]] $object_name = undef,

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -5,7 +5,7 @@
 # @param database Sets a comma-separated list of databases that this rule matches.
 # @param user Sets a comma-separated list of users that this rule matches.
 # @param auth_method Provides the method that is used for authentication for the connection that this rule matches. Described further in the PostgreSQL pg_hba.conf documentation.
-# @param address Sets a address for this rule matching when the type is not 'local'. Value can either be IPv4 CIDR, IPv6 CIDR, a FQDN, the strings 'samehost' or 'samenet' or a domain either with or without starting dot (.) https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+# @param address Sets a address for this rule matching when the type is not 'local'. Value can either be IPv4 CIDR, IPv6 CIDR, a FQDN, the strings 'all', 'samehost' or 'samenet' or a domain either with or without starting dot (.) https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 # @param description Defines a longer description for this rule, if required. This description is placed in the comments above the rule in pg_hba.conf. Default value: 'none'.
 # @param auth_option For certain auth_method settings there are extra options that can be passed. Consult the PostgreSQL pg_hba.conf documentation for further details.
 # @param order Sets an order for placing the rule in pg_hba.conf. This can be either a string or an integer. If it is an integer, it will be converted to a string by zero-padding it to three digits. E.g. 42 will be zero-padded to the string '042'. The pg_hba_rule fragments are sorted using the alpha sorting order. Default value: 150.

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -5,7 +5,7 @@
 # @param database Sets a comma-separated list of databases that this rule matches.
 # @param user Sets a comma-separated list of users that this rule matches.
 # @param auth_method Provides the method that is used for authentication for the connection that this rule matches. Described further in the PostgreSQL pg_hba.conf documentation.
-# @param address Sets a CIDR based address for this rule matching when the type is not 'local'.
+# @param address Sets a address for this rule matching when the type is not 'local'. Value can either be IPv4 CIDR, IPv6 CIDR, a FQDN, the strings 'samehost' or 'samenet' or a domain either with or without starting dot (.) https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 # @param description Defines a longer description for this rule, if required. This description is placed in the comments above the rule in pg_hba.conf. Default value: 'none'.
 # @param auth_option For certain auth_method settings there are extra options that can be passed. Consult the PostgreSQL pg_hba.conf documentation for further details.
 # @param order Sets an order for placing the rule in pg_hba.conf. This can be either a string or an integer. If it is an integer, it will be converted to a string by zero-padding it to three digits. E.g. 42 will be zero-padded to the string '042'. The pg_hba_rule fragments are sorted using the alpha sorting order. Default value: 150.
@@ -16,7 +16,16 @@ define postgresql::server::pg_hba_rule (
   String $database,
   String $user,
   String $auth_method,
-  Optional[String] $address       = undef,
+  Optional[
+    Variant[
+      Stdlib::IP::Address::V4::CIDR,
+      Stdlib::IP::Address::V6::CIDR,
+      Stdlib::Fqdn,
+      Enum['samehost', 'samenet'],
+      # RegExp for a DNS domain - also starting with a single dot
+      Pattern[/^\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$/],
+    ]
+  ] $address                      = undef,
   String $description             = 'none',
   Optional[String] $auth_option   = undef,
   Variant[String, Integer] $order = 150,

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -16,16 +16,7 @@ define postgresql::server::pg_hba_rule (
   String $database,
   String $user,
   String $auth_method,
-  Optional[
-    Variant[
-      Stdlib::IP::Address::V4::CIDR,
-      Stdlib::IP::Address::V6::CIDR,
-      Stdlib::Fqdn,
-      Enum['all', 'samehost', 'samenet'],
-      # RegExp for a DNS domain - also starting with a single dot
-      Pattern[/^\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$/],
-    ]
-  ] $address                      = undef,
+  Optional[Postgresql::Pg_hba_rule_address] $address = undef,
   String $description             = 'none',
   Optional[String] $auth_option   = undef,
   Variant[String, Integer] $order = 150,

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -21,7 +21,7 @@ define postgresql::server::pg_hba_rule (
       Stdlib::IP::Address::V4::CIDR,
       Stdlib::IP::Address::V6::CIDR,
       Stdlib::Fqdn,
-      Enum['samehost', 'samenet'],
+      Enum['all', 'samehost', 'samenet'],
       # RegExp for a DNS domain - also starting with a single dot
       Pattern[/^\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$/],
     ]

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -154,7 +154,7 @@ define postgresql::server::role (
 
     if $password_hash_unsensitive and $update_password {
       if $password_hash_unsensitive =~ Deferred {
-        $pwd_hash_sql = Deferred('postgresql::postgresql_password',[$username,
+        $pwd_hash_sql = Deferred( 'postgresql::postgresql_password',[$username,
             $password_hash,
             false,
             $hash,

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -154,7 +154,7 @@ define postgresql::server::role (
 
     if $password_hash_unsensitive and $update_password {
       if $password_hash_unsensitive =~ Deferred {
-        $pwd_hash_sql = Deferred ( 'postgresql::postgresql_password',[$username,
+        $pwd_hash_sql = Deferred ( 'postgresql::postgresql_password', [$username,
             $password_hash,
             false,
             $hash,

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -154,7 +154,7 @@ define postgresql::server::role (
 
     if $password_hash_unsensitive and $update_password {
       if $password_hash_unsensitive =~ Deferred {
-        $pwd_hash_sql = Deferred( 'postgresql::postgresql_password',[$username,
+        $pwd_hash_sql = Deferred ( 'postgresql::postgresql_password',[$username,
             $password_hash,
             false,
             $hash,

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -95,14 +95,16 @@ define postgresql::server::role (
 
     if $password_sql =~ Deferred {
       $create_role_command = Deferred('sprintf', ["CREATE ROLE \"%s\" %s %s %s %s %s %s CONNECTION LIMIT %s",
-                                                  $username,
-                                                  $password_sql,
-                                                  $login_sql,
-                                                  $createrole_sql,
-                                                  $createdb_sql,
-                                                  $superuser_sql,
-                                                  $replication_sql,
-                                                  $connection_limit])
+          $username,
+          $password_sql,
+          $login_sql,
+          $createrole_sql,
+          $createdb_sql,
+          $superuser_sql,
+          $replication_sql,
+          $connection_limit,
+        ]
+      )
     } else {
       $create_role_command = "CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}"
     }
@@ -153,10 +155,12 @@ define postgresql::server::role (
     if $password_hash_unsensitive and $update_password {
       if $password_hash_unsensitive =~ Deferred {
         $pwd_hash_sql = Deferred('postgresql::postgresql_password',[$username,
-                                                                    $password_hash,
-                                                                    false,
-                                                                    $hash,
-                                                                    $salt])
+            $password_hash,
+            false,
+            $hash,
+            $salt,
+          ]
+        )
       }
       else {
         $pwd_hash_sql = postgresql::postgresql_password(
@@ -170,8 +174,10 @@ define postgresql::server::role (
       if $pwd_hash_sql =~ Deferred {
         $pw_command = Deferred('sprintf', ["ALTER ROLE \"%s\" ENCRYPTED PASSWORD '%s'", $username, $pwd_hash_sql])
         $unless_pw_command = Deferred('sprintf', ["SELECT 1 FROM pg_shadow WHERE usename = '%s' AND passwd = '%s'",
-                                                  $username,
-                                                  $pwd_hash_sql])
+            $username,
+            $pwd_hash_sql,
+          ]
+        )
       } else {
         $pw_command = "ALTER ROLE \"${username}\" ENCRYPTED PASSWORD '${pwd_hash_sql}'"
         $unless_pw_command = "SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'"

--- a/spec/defines/server/pg_hba_rule_spec.rb
+++ b/spec/defines/server/pg_hba_rule_spec.rb
@@ -266,7 +266,7 @@ describe 'postgresql::server::pg_hba_rule' do
         }
       end
 
-      it { is_expected.to compile.and_raise_error(%r{parameter 'address' expects a value of type Undef, Stdlib::IP::Address::V4::CIDR}) }
+      it { is_expected.to compile.and_raise_error(%r{parameter 'address' expects a Postgresql::Pg_hba_rule_address}) }
     end
   end
 end

--- a/spec/defines/server/pg_hba_rule_spec.rb
+++ b/spec/defines/server/pg_hba_rule_spec.rb
@@ -247,7 +247,6 @@ describe 'postgresql::server::pg_hba_rule' do
       it do
         is_expected.to contain_concat__fragment('pg_hba_rule_test').with(content: %r{host\s+all\s+all\s+\.domain\.tld\s+md5})
       end
-
     end
     context 'pg_hba_rule with illegal address' do
       let :pre_condition do
@@ -268,7 +267,6 @@ describe 'postgresql::server::pg_hba_rule' do
       end
 
       it { is_expected.to compile.and_raise_error(%r{parameter 'address' expects a value of type Undef, Stdlib::IP::Address::V4::CIDR}) }
-
     end
   end
 end

--- a/spec/defines/server/pg_hba_rule_spec.rb
+++ b/spec/defines/server/pg_hba_rule_spec.rb
@@ -225,5 +225,50 @@ describe 'postgresql::server::pg_hba_rule' do
         is_expected.to contain_concat__fragment('pg_hba_rule_test').with(order: '1234')
       end
     end
+
+    context 'pg_hba_rule with dot domain' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'host',
+          database: 'all',
+          user: 'all',
+          address: '.domain.tld',
+          auth_method: 'md5',
+          target: target,
+        }
+      end
+
+      it do
+        is_expected.to contain_concat__fragment('pg_hba_rule_test').with(content: %r{host\s+all\s+all\s+\.domain\.tld\s+md5})
+      end
+
+    end
+    context 'pg_hba_rule with illegal address' do
+      let :pre_condition do
+        <<-MANIFEST
+          class { 'postgresql::server': }
+        MANIFEST
+      end
+
+      let :params do
+        {
+          type: 'host',
+          database: 'all',
+          user: 'all',
+          address: '/45',
+          auth_method: 'md5',
+          target: target,
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{parameter 'address' expects a value of type Undef, Stdlib::IP::Address::V4::CIDR}) }
+
+    end
   end
 end

--- a/types/pg_hba_rule_address.pp
+++ b/types/pg_hba_rule_address.pp
@@ -1,0 +1,10 @@
+# @summary Supported address types
+# @see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+type Postgresql::Pg_hba_rule_address = Variant[
+  Stdlib::IP::Address::V4::CIDR,
+  Stdlib::IP::Address::V6::CIDR,
+  Stdlib::Fqdn,
+  Enum['all', 'samehost', 'samenet'],
+  # RegExp for a DNS domain - also starting with a single dot
+  Pattern[/^\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$/],
+]


### PR DESCRIPTION
According to PostgreSQL documentation there are only specific data possible for address:
https://www.postgresql.org/docs/current/auth-pg-hba-conf.html

- IPV4 CIDR
- IPV6 CIDR
- FQDN
- the strings 'samenet' or 'samehost'
- a domain
- a domain with a starting dot

fixes #1373 