### PR TITLE
pg_hba_rule: Move `type` datatype to own type

### DIFF
--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -1,7 +1,6 @@
 # @summary This resource manages an individual rule that applies to the file defined in target.
 #
 # @param type Sets the type of rule.
-#   Enum['local','host','hostssl','hostnossl','hostgssenc'].
 # @param database Sets a comma-separated list of databases that this rule matches.
 # @param user Sets a comma-separated list of users that this rule matches.
 # @param auth_method Provides the method that is used for authentication for the connection that this rule matches. Described further in the PostgreSQL pg_hba.conf documentation.
@@ -12,7 +11,7 @@
 # @param target Provides the target for the rule, and is generally an internal only property. Use with caution.
 # @param postgresql_version Manages pg_hba.conf without managing the entire PostgreSQL instance.
 define postgresql::server::pg_hba_rule (
-  Enum['local', 'host', 'hostssl', 'hostnossl', 'hostgssenc'] $type,
+  Postgresql::Pg_hba_rule_type $type,
   String $database,
   String $user,
   String $auth_method,

--- a/spec/type_aliases/pg_hba_rule_type_spec.rb
+++ b/spec/type_aliases/pg_hba_rule_type_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Postgresql::Pg_hba_rule_type' do
+  describe 'valid values' do
+    [
+      'local',
+      'host',
+      'hostssl',
+      'hostnossl',
+      'hostgssenc',
+      'hostnogssenc',
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid values' do
+    context 'with garbage inputs' do
+      [
+        :symbol,
+        nil,
+        'foobar',
+        '',
+        true,
+        false,
+        ['meep', 'meep'],
+        65_538,
+        [95_000, 67_000],
+        {},
+        { 'foo' => 'bar' },
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/types/pg_hba_rule_type.pp
+++ b/types/pg_hba_rule_type.pp
@@ -1,0 +1,3 @@
+# @summary enum for all different types for the pg_hba_conf
+# @see https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+type Postgresql::Pg_hba_rule_type = Enum['local', 'host', 'hostssl', 'hostnossl', 'hostgssenc', 'hostnogssenc']


### PR DESCRIPTION
This makes it easier to test the type, and people can use it in their downstream modules. In addition I added the type `hostnogssenc`. The list is now complete/covers all auth types from PostgreSQL 14.