### PR TITLE
apt::source: configure repo only for current architecture

### DIFF
--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -15,14 +15,15 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
     priority   => 500,
   }
   -> apt::source { 'apt.postgresql.org':
-    location => $_baseurl,
-    release  => "${facts['os']['distro']['codename']}-pgdg",
-    repos    => 'main',
-    key      => {
+    location     => $_baseurl,
+    release      => "${facts['os']['distro']['codename']}-pgdg",
+    repos        => 'main',
+    architecture => $facts['os']['architecture'],
+    key          => {
       id     => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
       source => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
     },
-    include  => {
+    include      => {
       src => false,
     },
   }


### PR DESCRIPTION
Without this setting, we tell apt to download release information for all architectures apt knows. This includes i386 on amd64 systems. postgresql doesn't publish i386 packages. because of that, it results in a warning during apt update:

N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://apt.postgresql.org/pub/repos/apt jammy-pgdg InRelease' doesn't support architecture 'i386'

This is fixed with this change.