### PR TITLE
Add multi instance support, refactoring late_initdb.pp (3/x)

### DIFF
--- a/manifests/server/instance_late_initdb.pp
+++ b/manifests/server/instance_late_initdb.pp
@@ -1,0 +1,43 @@
+# lint:ignore:140chars
+# @summary Manage the default encoding when database initialization is managed by the package
+# @param encoding Sets the default encoding for all databases created with this module. On certain operating systems this is also used during the template1 initialization, so it becomes a default outside of the module as well.
+# @param user Overrides the default PostgreSQL super user and owner of PostgreSQL related files in the file system.
+# @param group Overrides the default postgres user group to be used for related files in the file system.
+# @param psql_path Specifies the path to the psql command.
+# @param port Specifies the port for the PostgreSQL server to listen on. Note: The same port number is used for all IP addresses the server listens on. Also, for Red Hat systems and early Debian systems, changing the port causes the server to come to a full stop before being able to make the change.
+# @param module_workdir Working directory for the PostgreSQL module
+# lint:endignore:140chars
+define postgresql::server::instance_late_initdb (
+  $encoding       = $postgresql::server::encoding,
+  $user           = $postgresql::server::user,
+  $group          = $postgresql::server::group,
+  $psql_path      = $postgresql::server::psql_path,
+  $port           = $postgresql::server::port,
+  $module_workdir = $postgresql::server::module_workdir,
+) {
+  # Set the defaults for the postgresql_psql resource
+  Postgresql_psql {
+    psql_user  => $user,
+    psql_group => $group,
+    psql_path  => $psql_path,
+    port       => $port,
+    cwd        => $module_workdir,
+  }
+
+  # [workaround]
+  # by default pg_createcluster encoding derived from locale
+  # but it do does not work by installing postgresql via puppet because puppet
+  # always override LANG to 'C'
+  postgresql_psql { "Set template1 encoding to ${encoding}":
+    command => "UPDATE pg_database
+      SET datistemplate = FALSE
+      WHERE datname = 'template1'
+      ;
+      UPDATE pg_database
+      SET encoding = pg_char_to_encoding('${encoding}'), datistemplate = TRUE
+      WHERE datname = 'template1'",
+    unless  => "SELECT datname FROM pg_database WHERE
+      datname = 'template1' AND encoding = pg_char_to_encoding('${encoding}')",
+    before  => Anchor['postgresql::server::service::end'],
+  }
+}

--- a/manifests/server/late_initdb.pp
+++ b/manifests/server/late_initdb.pp
@@ -4,36 +4,12 @@
 class postgresql::server::late_initdb {
   assert_private()
 
-  $encoding       = $postgresql::server::encoding
-  $user           = $postgresql::server::user
-  $group          = $postgresql::server::group
-  $psql_path      = $postgresql::server::psql_path
-  $port           = $postgresql::server::port
-  $module_workdir = $postgresql::server::module_workdir
-
-  # Set the defaults for the postgresql_psql resource
-  Postgresql_psql {
-    psql_user  => $user,
-    psql_group => $group,
-    psql_path  => $psql_path,
-    port       => $port,
-    cwd        => $module_workdir,
-  }
-
-  # [workaround]
-  # by default pg_createcluster encoding derived from locale
-  # but it do does not work by installing postgresql via puppet because puppet
-  # always override LANG to 'C'
-  postgresql_psql { "Set template1 encoding to ${encoding}":
-    command => "UPDATE pg_database
-      SET datistemplate = FALSE
-      WHERE datname = 'template1'
-      ;
-      UPDATE pg_database
-      SET encoding = pg_char_to_encoding('${encoding}'), datistemplate = TRUE
-      WHERE datname = 'template1'",
-    unless  => "SELECT datname FROM pg_database WHERE
-      datname = 'template1' AND encoding = pg_char_to_encoding('${encoding}')",
-    before  => Anchor['postgresql::server::service::end'],
+  postgresql::server::instance_late_initdb { 'main':
+    encoding       => $postgresql::server::encoding,
+    user           => $postgresql::server::user,
+    group          => $postgresql::server::group,
+    psql_path      => $postgresql::server::psql_path,
+    port           => $postgresql::server::port,
+    module_workdir => $postgresql::server::module_workdir,
   }
 }

--- a/spec/defines/server/instance_late_initdb.rb
+++ b/spec/defines/server/instance_late_initdb.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'postgresql::server::instance_late_initdb' do
+  let(:title) { 'main' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
+
+      let :pre_condition do
+        "class {'postgresql::initdb':}"
+      end
+
+      context 'with defaults from initdb class' do
+        it { is_expected.to compile.with_all_deps }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds changes a class to add multi instance support to this
module. The general idea is to first copy all classes which are used and
create defines from them. These classes will use the defines as is.
Necessary changes for the instances itself will be added to the classes
and defined types at a later point. This ensures, the module will work
as it does right now and there are no breaking changes.