### PR TITLE
remove debian 8 and 9 corpses

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -194,8 +194,6 @@ class postgresql::globals (
     },
     'Debian' => $facts['os']['name'] ? {
       'Debian' => $facts['os']['release']['major'] ? {
-        '8'     => '9.4',
-        '9'     => '9.6',
         '10'    => '11',
         '11'    => '13',
         default => undef,

--- a/spec/defines/server/default_privileges_spec.rb
+++ b/spec/defines/server/default_privileges_spec.rb
@@ -112,8 +112,8 @@ describe 'postgresql::server::default_privileges' do
       it { is_expected.to compile.and_raise_error(%r{Illegal value for \$privilege parameter}) }
     end
 
-    context 'schemas on postgres < 10.0' do
-      include_examples 'Debian 9'
+    context 'schemas on postgres < 9.6' do
+      include_examples 'RedHat 7'
 
       let :params do
         {
@@ -129,7 +129,7 @@ describe 'postgresql::server::default_privileges' do
         "class {'postgresql::server':}"
       end
 
-      it { is_expected.to compile.and_raise_error(%r{Default_privileges on schemas is only supported on PostgreSQL >= 10.0}m) }
+      it { is_expected.to compile.and_raise_error(%r{Default_privileges is only useable with PostgreSQL >= 9.6}m) }
     end
 
     context 'schemas on postgres >= 10.0' do

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -122,10 +122,6 @@ add_custom_fact :service_provider, ->(_os, facts) do
   end
 end
 
-shared_context 'Debian 9' do
-  let(:facts) { on_supported_os['debian-9-x86_64'] }
-end
-
 shared_context 'Debian 10' do
   let(:facts) { on_supported_os['debian-10-x86_64'] }
 end


### PR DESCRIPTION
originally it was deprecated in this commit:
https://github.com/puppetlabs/puppetlabs-postgresql/commit/07a09bd2c4207223cb573a15614607c14b344dbb