### PR TITLE
.fixtures.yml: Cleanup Puppet 5 leftovers

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 fixtures:
   repositories:
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
-    augeas_core:
-      repo: "https://github.com/puppetlabs/puppetlabs-augeas_core.git"
-      puppet_version: ">= 6.0.0"
+    augeas_core: "https://github.com/puppetlabs/puppetlabs-augeas_core.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     cron_core: "https://github.com/puppetlabs/puppetlabs-cron_core.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
@@ -11,8 +9,4 @@ fixtures:
     provision: "https://github.com/puppetlabs/provision.git"
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    yumrepo_core: 
-      repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
-      puppet_version: ">= 6.0.0"
-  symlinks:
-    postgresql: "#{source_dir}"
+    yumrepo_core: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"


### PR DESCRIPTION
The core modules are a requirements for unit testing with Puppet 6 and newer. This module doesn't support Puppet 5 anymore, so it can be removed (we did the same at Vox Pupuli).