### PR TITLE
Add multi instance support, refactoring reload.pp (6/x)

### DIFF
--- a/manifests/server/instance_reload.pp
+++ b/manifests/server/instance_reload.pp
@@ -1,0 +1,14 @@
+# @param service_reload Overrides the default reload command for your PostgreSQL service.
+# @param service_status Overrides the default status check command for your PostgreSQL service.
+define postgresql::server::instance_reload (
+  $service_status = $postgresql::server::service_status,
+  $service_reload = $postgresql::server::service_reload,
+) {
+  exec { 'postgresql_reload':
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+    command     => $service_reload,
+    onlyif      => $service_status,
+    refreshonly => true,
+    require     => Class['postgresql::server::service'],
+  }
+}

--- a/manifests/server/reload.pp
+++ b/manifests/server/reload.pp
@@ -1,13 +1,7 @@
 # @api private
 class postgresql::server::reload {
-  $service_status = $postgresql::server::service_status
-  $service_reload = $postgresql::server::service_reload
-
-  exec { 'postgresql_reload':
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-    command     => $service_reload,
-    onlyif      => $service_status,
-    refreshonly => true,
-    require     => Class['postgresql::server::service'],
+  postgresql::server::instance_reload { 'main':
+    service_status => $postgresql::server::service_status,
+    service_reload => $postgresql::server::service_reload,
   }
 }

--- a/spec/defines/server/instance_reload.rb
+++ b/spec/defines/server/instance_reload.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'postgresql::server::instance_reload' do
+  let(:title) { 'main' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
+
+      let :pre_condition do
+        "class {'postgresql::server':}"
+      end
+
+      context 'with defaults from server class' do
+        it { is_expected.to compile.with_all_deps }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds changes to a class to add multi instance support to this module.
The general idea is to first copy all classes which are used and create defines from them.
These classes will use the defines as is. Necessary changes for the instances itself will be added to the classes and defined types at a later point.
This ensures, the module will work as it does right now and there are no breaking changes.