### PR TITLE
Clean up acceptance tests to minimize the spec helper

### DIFF
--- a/spec/acceptance/postgresql_psql_spec.rb
+++ b/spec/acceptance/postgresql_psql_spec.rb
@@ -73,7 +73,7 @@ describe 'postgresql_psql' do
       idempotent_apply(pp_five)
     end
 
-    pp_six = <<-MANIFEST.unindent
+    pp_six = <<~MANIFEST
       class { 'postgresql::server': } ->
       notify { 'trigger': } ~>
       postgresql_psql { 'foobar':
@@ -89,7 +89,7 @@ describe 'postgresql_psql' do
       apply_manifest(pp_six, expect_changes: true)
     end
 
-    pp_seven = <<-MANIFEST.unindent
+    pp_seven = <<~MANIFEST
       class { 'postgresql::server': } ->
       notify { 'trigger': } ~>
       postgresql_psql { 'foobar':

--- a/spec/acceptance/server/default_privileges_spec.rb
+++ b/spec/acceptance/server/default_privileges_spec.rb
@@ -14,7 +14,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:pp_one) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}
@@ -76,7 +76,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:pp_target_role) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}
@@ -121,7 +121,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:pp_target_role_revoke) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}
@@ -172,7 +172,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:pp_schema) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}
@@ -233,7 +233,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:pp_unset_schema) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}

--- a/spec/acceptance/server/deferred_pw_role_spec.rb
+++ b/spec/acceptance/server/deferred_pw_role_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::server::role:' do
   let(:password) { 'test_password' }
 
   let(:pp_one) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $user = #{user}
       $password = #{password}
 

--- a/spec/acceptance/server/grant_role_spec.rb
+++ b/spec/acceptance/server/grant_role_spec.rb
@@ -11,7 +11,7 @@ describe 'postgresql::server::grant_role:' do
     '8.1' if os[:family] == 'redhat' && os[:release].start_with?('5')
   end
   let(:pp_one) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $user = #{user}
       $group = #{group}

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -8,7 +8,7 @@ describe 'postgresql::server::grant:' do
   let(:user) { 'psql_grant_priv_tester' }
   let(:password) { 'psql_grant_role_pw' }
   let(:pp_setup) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $owner = #{owner}
       $user = #{user}
@@ -55,7 +55,7 @@ describe 'postgresql::server::grant:' do
       # testing grants on language requires a superuser
       let(:superuser) { 'postgres' }
       let(:pp) do
-        pp_setup + <<-MANIFEST.unindent
+        pp_setup + <<~MANIFEST
           postgresql_psql { 'make sure plpgsql exists':
             command   => 'CREATE LANGUAGE plpgsql',
             db        => $db,
@@ -97,34 +97,34 @@ describe 'postgresql::server::grant:' do
   ### SEQUENCE grants
   context 'sequence' do
     let(:pp) do
-      pp_setup + <<-MANIFEST.unindent
-          postgresql_psql { 'create test sequence':
-            command   => 'CREATE SEQUENCE test_seq',
-            db        => $db,
-            psql_user => $owner,
-            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq'",
-            require   => Postgresql::Server::Database[$db],
-          }
+      pp_setup + <<~MANIFEST
+        postgresql_psql { 'create test sequence':
+          command   => 'CREATE SEQUENCE test_seq',
+          db        => $db,
+          psql_user => $owner,
+          unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq'",
+          require   => Postgresql::Server::Database[$db],
+        }
 
-          postgresql::server::grant { 'grant usage on test_seq':
-            privilege   => 'USAGE',
-            object_type => 'SEQUENCE',
-            object_name => 'test_seq',
-            db          => $db,
-            role        => $user,
-            require     => [ Postgresql_psql['create test sequence'],
-                             Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant usage on test_seq':
+          privilege   => 'USAGE',
+          object_type => 'SEQUENCE',
+          object_name => 'test_seq',
+          db          => $db,
+          role        => $user,
+          require     => [ Postgresql_psql['create test sequence'],
+                           Postgresql::Server::Role[$user], ]
+        }
 
-          postgresql::server::grant { 'grant update on test_seq':
-            privilege   => 'UPDATE',
-            object_type => 'SEQUENCE',
-            object_name => 'test_seq',
-            db          => $db,
-            role        => $user,
-            require     => [ Postgresql_psql['create test sequence'],
-                             Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant update on test_seq':
+          privilege   => 'UPDATE',
+          object_type => 'SEQUENCE',
+          object_name => 'test_seq',
+          db          => $db,
+          role        => $user,
+          require     => [ Postgresql_psql['create test sequence'],
+                           Postgresql::Server::Role[$user], ]
+        }
       MANIFEST
     end
 
@@ -149,35 +149,35 @@ describe 'postgresql::server::grant:' do
 
   context 'all sequences' do
     let(:pp) do
-      pp_setup + <<-MANIFEST.unindent
+      pp_setup + <<~MANIFEST
 
-          postgresql_psql { 'create test sequences':
-            command   => 'CREATE SEQUENCE test_seq2; CREATE SEQUENCE test_seq3;',
-            db        => $db,
-            psql_user => $owner,
-            unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq2'",
-            require   => Postgresql::Server::Database[$db],
-          }
+        postgresql_psql { 'create test sequences':
+          command   => 'CREATE SEQUENCE test_seq2; CREATE SEQUENCE test_seq3;',
+          db        => $db,
+          psql_user => $owner,
+          unless    => "SELECT 1 FROM information_schema.sequences WHERE sequence_name = 'test_seq2'",
+          require   => Postgresql::Server::Database[$db],
+        }
 
-          postgresql::server::grant { 'grant usage on all sequences':
-            privilege   => 'USAGE',
-            object_type => 'ALL SEQUENCES IN SCHEMA',
-            object_name => 'public',
-            db          => $db,
-            role        => $user,
-            require     => [ Postgresql_psql['create test sequences'],
-                             Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant usage on all sequences':
+          privilege   => 'USAGE',
+          object_type => 'ALL SEQUENCES IN SCHEMA',
+          object_name => 'public',
+          db          => $db,
+          role        => $user,
+          require     => [ Postgresql_psql['create test sequences'],
+                           Postgresql::Server::Role[$user], ]
+        }
 
-          postgresql::server::grant { 'grant update on all sequences':
-            privilege   => 'UPDATE',
-            object_type => 'ALL SEQUENCES IN SCHEMA',
-            object_name => 'public',
-            db          => $db,
-            role        => $user,
-            require     => [ Postgresql_psql['create test sequences'],
-                             Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant update on all sequences':
+          privilege   => 'UPDATE',
+          object_type => 'ALL SEQUENCES IN SCHEMA',
+          object_name => 'public',
+          db          => $db,
+          role        => $user,
+          require     => [ Postgresql_psql['create test sequences'],
+                           Postgresql::Server::Role[$user], ]
+        }
       MANIFEST
     end
 
@@ -203,43 +203,43 @@ describe 'postgresql::server::grant:' do
   ### FUNCTION grants
   context 'sequence' do
     let(:pp) do
-      pp_setup + <<-MANIFEST.unindent
-          postgresql_psql { 'create test function':
-            command   => "CREATE FUNCTION test_func() RETURNS boolean AS 'SELECT true' LANGUAGE 'sql'",
-            db        => $db,
-            psql_user => $owner,
-            unless    => "SELECT 1 FROM information_schema.routines WHERE routine_name = 'test_func'",
-            require   => Postgresql::Server::Database[$db],
-          }
+      pp_setup + <<~MANIFEST
+        postgresql_psql { 'create test function':
+          command   => "CREATE FUNCTION test_func() RETURNS boolean AS 'SELECT true' LANGUAGE 'sql'",
+          db        => $db,
+          psql_user => $owner,
+          unless    => "SELECT 1 FROM information_schema.routines WHERE routine_name = 'test_func'",
+          require   => Postgresql::Server::Database[$db],
+        }
 
-          postgresql::server::grant { 'grant execute on test_func':
-            privilege   => 'EXECUTE',
-            object_type => 'FUNCTION',
-            object_name => 'test_func',
-            db          => $db,
-            role        => $user,
-            require     => [ Postgresql_psql['create test function'],
-                             Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant execute on test_func':
+          privilege   => 'EXECUTE',
+          object_type => 'FUNCTION',
+          object_name => 'test_func',
+          db          => $db,
+          role        => $user,
+          require     => [ Postgresql_psql['create test function'],
+                           Postgresql::Server::Role[$user], ]
+        }
 
-          postgresql_psql { 'create test function with argument':
-            command   => "CREATE FUNCTION test_func_with_arg(val integer) RETURNS integer AS 'SELECT val + 1' LANGUAGE 'sql'",
-            db        => $db,
-            psql_user => $owner,
-            unless    => "SELECT 1 FROM (SELECT format('%I.%I(%s)', ns.nspname, p.proname, oidvectortypes(p.proargtypes)) as func_with_args FROM pg_proc p INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid) WHERE ns.nspname not in ('pg_catalog', 'information_schema')) as funclist WHERE func_with_args='public.test_func_with_arg(integer)'",
-            require   => Postgresql::Server::Database[$db],
-          }
+        postgresql_psql { 'create test function with argument':
+          command   => "CREATE FUNCTION test_func_with_arg(val integer) RETURNS integer AS 'SELECT val + 1' LANGUAGE 'sql'",
+          db        => $db,
+          psql_user => $owner,
+          unless    => "SELECT 1 FROM (SELECT format('%I.%I(%s)', ns.nspname, p.proname, oidvectortypes(p.proargtypes)) as func_with_args FROM pg_proc p INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid) WHERE ns.nspname not in ('pg_catalog', 'information_schema')) as funclist WHERE func_with_args='public.test_func_with_arg(integer)'",
+          require   => Postgresql::Server::Database[$db],
+        }
 
-          postgresql::server::grant { 'grant execute on test_func_with_arg':
-            privilege         => 'EXECUTE',
-            object_type       => 'FUNCTION',
-            object_name       => 'test_func_with_arg',
-            object_arguments  => ['integer'],
-            db                => $db,
-            role              => $user,
-            require           => [ Postgresql_psql['create test function with argument'],
-                                   Postgresql::Server::Role[$user], ]
-          }
+        postgresql::server::grant { 'grant execute on test_func_with_arg':
+          privilege         => 'EXECUTE',
+          object_type       => 'FUNCTION',
+          object_name       => 'test_func_with_arg',
+          object_arguments  => ['integer'],
+          db                => $db,
+          role              => $user,
+          require           => [ Postgresql_psql['create test function with argument'],
+                                 Postgresql::Server::Role[$user], ]
+        }
       MANIFEST
     end
 
@@ -272,7 +272,7 @@ describe 'postgresql::server::grant:' do
   context 'table' do
     describe 'GRANT ... ON TABLE' do
       let(:pp_create_table) do
-        pp_setup + <<-EOS.unindent
+        pp_setup + <<~EOS
           postgresql_psql { 'create test table':
             command   => 'CREATE TABLE test_tbl (col1 integer)',
             db        => $db,
@@ -298,46 +298,46 @@ describe 'postgresql::server::grant:' do
       end
 
       it 'grant select on a table to a user' do
-        pp_grant = pp_setup + <<-EOS.unindent
+        pp_grant = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'grant select on test_tbl':
-              privilege   => 'SELECT',
-              object_type => 'TABLE',
-              object_name => 'test_tbl',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'grant select on test_tbl':
+            privilege   => 'SELECT',
+            object_type => 'TABLE',
+            object_name => 'test_tbl',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
 
-            postgresql::server::table_grant { 'INSERT priviledge to table':
-              privilege => 'INSERT',
-              table     => 'test_tbl',
-              db        => $db,
-              role      => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::table_grant { 'INSERT priviledge to table':
+            privilege => 'INSERT',
+            table     => 'test_tbl',
+            db        => $db,
+            role      => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
-        pp_revoke = pp_setup + <<-EOS.unindent
+        pp_revoke = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'revoke select on test_tbl':
-              ensure      => absent,
-              privilege   => 'SELECT',
-              object_type => 'TABLE',
-              object_name => 'test_tbl',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'revoke select on test_tbl':
+            ensure      => absent,
+            privilege   => 'SELECT',
+            object_type => 'TABLE',
+            object_name => 'test_tbl',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
 
-            postgresql::server::table_grant { 'INSERT priviledge to table':
-              ensure      => absent,
-              privilege => 'INSERT',
-              table     => 'test_tbl',
-              db        => $db,
-              role      => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::table_grant { 'INSERT priviledge to table':
+            ensure      => absent,
+            privilege => 'INSERT',
+            table     => 'test_tbl',
+            db        => $db,
+            role      => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
         if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.0')
@@ -367,29 +367,29 @@ describe 'postgresql::server::grant:' do
       end
 
       it 'grant update on all tables to a user' do
-        pp_grant = pp_setup + <<-EOS.unindent
+        pp_grant = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'grant update on all tables':
-              privilege   => 'UPDATE',
-              object_type => 'ALL TABLES IN SCHEMA',
-              object_name => 'public',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'grant update on all tables':
+            privilege   => 'UPDATE',
+            object_type => 'ALL TABLES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
-        pp_revoke = pp_setup + <<-EOS.unindent
+        pp_revoke = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'revoke update on all tables':
-              ensure      => absent,
-              privilege   => 'UPDATE',
-              object_type => 'ALL TABLES IN SCHEMA',
-              object_name => 'public',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'revoke update on all tables':
+            ensure      => absent,
+            privilege   => 'UPDATE',
+            object_type => 'ALL TABLES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
         if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.0')
@@ -419,29 +419,29 @@ describe 'postgresql::server::grant:' do
       end
 
       it 'grant all on all tables to a user' do
-        pp_grant = pp_setup + <<-EOS.unindent
+        pp_grant = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'grant all on all tables':
-              privilege   => 'ALL',
-              object_type => 'ALL TABLES IN SCHEMA',
-              object_name => 'public',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'grant all on all tables':
+            privilege   => 'ALL',
+            object_type => 'ALL TABLES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
-        pp_revoke = pp_setup + <<-EOS.unindent
+        pp_revoke = pp_setup + <<~EOS
 
-            postgresql::server::grant { 'revoke all on all tables':
-              ensure      => absent,
-              privilege   => 'ALL',
-              object_type => 'ALL TABLES IN SCHEMA',
-              object_name => 'public',
-              db          => $db,
-              role        => $user,
-              require     => [ Postgresql::Server::Role[$user] ],
-            }
+          postgresql::server::grant { 'revoke all on all tables':
+            ensure      => absent,
+            privilege   => 'ALL',
+            object_type => 'ALL TABLES IN SCHEMA',
+            object_name => 'public',
+            db          => $db,
+            role        => $user,
+            require     => [ Postgresql::Server::Role[$user] ],
+          }
         EOS
 
         if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.0')
@@ -478,14 +478,14 @@ describe 'postgresql::server::grant:' do
       it 'do not fail on revoke connect from non-existant user' do
         if Gem::Version.new(postgresql_version) >= Gem::Version.new('9.1.24')
           apply_manifest(pp_setup, catch_failures: true)
-          pp = pp_setup + <<-EOS.unindent
-              postgresql::server::grant { 'revoke connect on db from norole':
-                ensure      => absent,
-                privilege   => 'CONNECT',
-                object_type => 'DATABASE',
-                db          => '#{db}',
-                role        => '#{user}_does_not_exist',
-              }
+          pp = pp_setup + <<~EOS
+            postgresql::server::grant { 'revoke connect on db from norole':
+              ensure      => absent,
+              privilege   => 'CONNECT',
+              object_type => 'DATABASE',
+              db          => '#{db}',
+              role        => '#{user}_does_not_exist',
+            }
           EOS
           idempotent_apply(pp)
         end

--- a/spec/acceptance/server/reassign_owned_by_spec.rb
+++ b/spec/acceptance/server/reassign_owned_by_spec.rb
@@ -10,7 +10,7 @@ describe 'postgresql::server::reassign_owned_by:' do
   let(:superuser) { 'postgres' }
 
   let(:pp_setup) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = #{db}
       $old_owner = #{old_owner}
       $new_owner = #{new_owner}
@@ -54,7 +54,7 @@ describe 'postgresql::server::reassign_owned_by:' do
   end
 
   let(:pp_db_old_owner) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       postgresql::server::database { $db:
         owner   => $old_owner,
         require => Postgresql::Server::Role[$old_owner],
@@ -63,7 +63,7 @@ describe 'postgresql::server::reassign_owned_by:' do
   end
 
   let(:pp_db_no_owner) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       postgresql::server::database { $db:
       }
     MANIFEST
@@ -76,7 +76,7 @@ describe 'postgresql::server::reassign_owned_by:' do
       let(:new_owner) { 'psql_reassign_new_owner' }
 
       let(:pp_setup_objects) do
-        <<-MANIFEST.unindent
+        <<~MANIFEST
           postgresql_psql { 'create test table':
             command   => 'CREATE TABLE test_tbl (col1 integer)',
             db        => '#{db}',
@@ -94,7 +94,7 @@ describe 'postgresql::server::reassign_owned_by:' do
         MANIFEST
       end
       let(:pp_reassign_owned_by) do
-        <<-MANIFEST.unindent
+        <<~MANIFEST
           postgresql::server::reassign_owned_by { 'test reassign to new_owner':
             db          => '#{db}',
             old_role    => '#{old_owner}',

--- a/spec/acceptance/server/recovery_spec.rb
+++ b/spec/acceptance/server/recovery_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper_acceptance'
 describe 'postgresql::server::recovery', skip: 'IAC-1286' do
   describe 'should manage recovery' do
     before(:all) do
-      pre_run
+      LitmusHelper.instance.apply_manifest("class { 'postgresql::server': postgres_password => 'postgres' }", catch_failures: true)
     end
 
     after(:all) do

--- a/spec/acceptance/server/recovery_spec.rb
+++ b/spec/acceptance/server/recovery_spec.rb
@@ -9,7 +9,7 @@ describe 'postgresql::server::recovery', skip: 'IAC-1286' do
     end
 
     after(:all) do
-      pp = <<-MANIFEST.unindent
+      pp = <<~MANIFEST
         file { '/tmp/recovery.conf':
           ensure => absent,
         }
@@ -18,7 +18,7 @@ describe 'postgresql::server::recovery', skip: 'IAC-1286' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    pp = <<-MANIFEST.unindent
+    pp = <<~MANIFEST
       class { 'postgresql::globals':
         recovery_conf_path => '/tmp/recovery.conf',
         manage_recovery_conf => true,
@@ -45,7 +45,7 @@ describe 'postgresql::server::recovery', skip: 'IAC-1286' do
 
   describe 'should not create recovery if recovery config not specified' do
     it 'does not add conf file' do
-      pp = <<-EOS.unindent
+      pp = <<~EOS
         class { 'postgresql::globals':
           recovery_conf_path => '/tmp/recovery.conf',
           manage_recovery_conf => true,

--- a/spec/acceptance/server/schema_spec.rb
+++ b/spec/acceptance/server/schema_spec.rb
@@ -7,7 +7,7 @@ describe 'postgresql::server::schema:' do
     '8.1' if os[:family] == 'redhat' && os[:release].start_with?('5')
   end
   let(:pp) do
-    <<-MANIFEST.unindent
+    <<~MANIFEST
       $db = 'schema_test'
       $user = 'psql_schema_tester'
       $password = 'psql_schema_pw'

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,30 @@
+if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['major'] == '18.04' {
+  package { 'iproute2':
+    ensure => installed,
+  }
+}
+
+# needed for netstat, for serverspec checks
+if $facts['os']['family'] in ['SLES', 'SUSE'] {
+  exec { 'Enable legacy repos':
+    path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+    command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
+    unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
+  }
+
+  package { 'net-tools-deprecated':
+    ensure  => 'latest',
+    require => Exec['Enable legacy repos'],
+  }
+}
+
+if $facts['os']['family'] == 'RedHat' {
+  if versioncmp($facts['os']['release']['major'], '8') >= 0 {
+    $package = ['iproute', 'policycoreutils-python-utils']
+  } else {
+    $package = 'policycoreutils-python'
+  }
+  package { $package:
+    ensure => installed,
+  }
+}

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -7,12 +7,6 @@ class LitmusHelper
   include PuppetLitmus
 end
 
-class String
-  def unindent
-    gsub(%r{^#{scan(%r{^\s*}).min_by(&:length)}}, '')
-  end
-end
-
 RSpec.configure do |c|
   c.before :suite do
     LitmusHelper.instance.apply_manifest(File.read(File.join(__dir__, 'setup_acceptance_node.pp')))

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -26,10 +26,6 @@ def export_locales(locale)
   LitmusHelper.instance.run_shell('source ~/.bashrc')
 end
 
-def pre_run
-  LitmusHelper.instance.apply_manifest("class { 'postgresql::server': postgres_password => 'postgres' }", catch_failures: true)
-end
-
 def postgresql_version
   result = LitmusHelper.instance.run_shell('psql --version')
   result.stdout.match(%r{\s(\d{1,2}\.\d)})[1]

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -37,25 +37,5 @@ end
 
 def psql(psql_cmd, user = 'postgres', exit_codes = [0, 1], &block)
   psql = "psql #{psql_cmd}"
-  LitmusHelper.instance.run_shell("cd /tmp; su #{shellescape(user)} -c #{shellescape(psql)}", acceptable_exit_codes: exit_codes, &block)
-end
-
-def shellescape(str)
-  str = str.to_s
-
-  # An empty argument will be skipped, so return empty quotes.
-  return "''" if str.empty?
-
-  str = str.dup
-
-  # Treat multibyte characters as is.  It is caller's responsibility
-  # to encode the string in the right encoding for the shell
-  # environment.
-  str.gsub!(%r{([^A-Za-z0-9_\-.,:/@\n])}, '\\\\\\1')
-
-  # A LF cannot be escaped with a backslash because a backslash + LF
-  # combo is regarded as line continuation and simply ignored.
-  str.gsub!(%r{\n}, "'\n'")
-
-  str
+  LitmusHelper.instance.run_shell("cd /tmp; su #{Shellwords.shellescape(user)} -c #{Shellwords.shellescape(psql)}", acceptable_exit_codes: exit_codes, &block)
 end


### PR DESCRIPTION
During cfgmgmtcamp it was mentioned that Puppet may want to switch back from Litmus to Beaker. This takes some small steps by reducing the size of `spec_helper_acceptance_local.rb`, which in my experience is always a good step towards alignment. Even if the switch doesn't happen, reducing local spec helpers is always good.

I'm going to rely on CI to make sure this is valid.