### PR TITLE
(CONT-880) Update concat dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 8.0.0"
+      "version_requirement": ">= 4.1.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Following the last major version update for puppetlabs-concat, several modules found themselves needing a dependency update. This commit aims to adjust the concat dependency within the module so that it is compatible with concat 9.0.0 and onwards.