### PR TITLE
Fix wrong data type for `data_checksums` parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -563,7 +563,7 @@ Default value: `undef`
 
 ##### <a name="-postgresql--globals--data_checksums"></a>`data_checksums`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Boolean]`
 
 Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
 Warning: This option is used during initialization by initdb, and cannot be changed later.
@@ -1204,9 +1204,9 @@ Default value: `$postgresql::params::locale`
 
 ##### <a name="-postgresql--server--data_checksums"></a>`data_checksums`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Boolean]`
 
-Boolean. Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
+Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
 Warning: This option is used during initialization by initdb, and cannot be changed later. If set, checksums are calculated for all objects, in all databases.
 
 Default value: `$postgresql::params::data_checksums`

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -150,7 +150,7 @@ class postgresql::globals (
 
   Optional[String[1]] $encoding                    = undef,
   Optional[String[1]] $locale                      = undef,
-  Optional[String[1]] $data_checksums              = undef,
+  Optional[Boolean] $data_checksums                = undef,
   Optional[String[1]] $timezone                    = undef,
 
   Optional[Boolean] $manage_pg_hba_conf            = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -56,7 +56,7 @@
 #
 # @param encoding Sets the default encoding for all databases created with this module. On certain operating systems this is also used during the template1 initialization, so it becomes a default outside of the module as well.
 # @param locale Sets the default database locale for all databases created with this module. On certain operating systems this is used during the template1 initialization as well, so it becomes a default outside of the module.
-# @param data_checksums Boolean. Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
+# @param data_checksums Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
 #   Warning: This option is used during initialization by initdb, and cannot be changed later. If set, checksums are calculated for all objects, in all databases.
 #
 # @param timezone Set timezone for the PostgreSQL instance
@@ -138,7 +138,7 @@ class postgresql::server (
 
   Optional[String[1]]                                $encoding                     = $postgresql::params::encoding,
   Optional[String[1]]                                $locale                       = $postgresql::params::locale,
-  Optional[String[1]]                                $data_checksums               = $postgresql::params::data_checksums,
+  Optional[Boolean]                                  $data_checksums               = $postgresql::params::data_checksums,
   Optional[String[1]]                                $timezone                     = $postgresql::params::timezone,
 
   Boolean                                            $manage_pg_hba_conf           = $postgresql::params::manage_pg_hba_conf,


### PR DESCRIPTION
When adding data types, this `Boolean` value has been assigned a `String[1]` data type in some places, which break existing setup.

Consistently use an `Optional[Boolean]` data type.

Fixes #1419
