### PR TITLE
Remove has_key usage

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -28,14 +28,14 @@ define postgresql::server::database (
 
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
+  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version
   }
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  if $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -37,7 +37,7 @@ define postgresql::server::default_privileges (
 ) {
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
+  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version
@@ -64,7 +64,7 @@ define postgresql::server::default_privileges (
   #
   if $port != undef {
     $port_override = $port
-  } elsif $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -74,7 +74,7 @@ define postgresql::server::extension (
   #
   if $port != undef {
     $port_override = $port
-  } elsif $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -75,7 +75,7 @@ define postgresql::server::grant (
   #
   if $port != undef {
     $port_override = $port
-  } elsif $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port

--- a/manifests/server/reassign_owned_by.pp
+++ b/manifests/server/reassign_owned_by.pp
@@ -26,7 +26,7 @@ define postgresql::server::reassign_owned_by (
   #
   if $port != undef {
     $port_override = $port
-  } elsif $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -52,7 +52,7 @@ define postgresql::server::role (
   #
   if $port != undef {
     $port_override = $port
-  } elsif $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port
@@ -60,7 +60,7 @@ define postgresql::server::role (
 
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
+  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -27,7 +27,7 @@ define postgresql::server::schema (
   Postgresql::Server::Db <| dbname == $db |> -> Postgresql::Server::Schema[$name]
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  if $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -18,7 +18,7 @@ define postgresql::server::tablespace (
   $module_workdir = $postgresql::server::module_workdir
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and has_key( $connect_settings, 'PGPORT') {
+  if $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port


### PR DESCRIPTION
In the next puppetlabs-stdlib major version this function will be dropped. Native Puppet is used instead.

https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319 broke this.