### PR TITLE
(CONT-949) - Bump stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 5.2.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Prior to this PR, postgresql module had allowed installations of puppetlabs-stdlib versions < 5.2.0. This was incorrect as this module references a type "Stdlib::IP::Address::V6::CIDR" that was released with stdlib v5.2.0. (see [here](https://forge.puppet.com/modules/puppetlabs/stdlib/5.2.0/changelog#:~:text=New%20type%20Stdlib%3A%3AIP%3A%3AAddress%3A%3AV6%3A%3ACIDR%20has%20been%20created.))

This PR bumps the dependency of puppetlabs/stdlib in metadata.json to versions >= 5.2.0. 

Fixes https://github.com/puppetlabs/puppetlabs-postgresql/issues/1427