### PR TITLE
(#1432) - Fix `Unable to mark 'unless' as sensitive`

### DIFF
--- a/lib/puppet/type/postgresql_psql.rb
+++ b/lib/puppet/type/postgresql_psql.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:postgresql_psql) do
 
   private
 
-  def sensitive_parameters=(sensitive_parameters)
+  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Style/AccessorMethodName
     # Respect sensitive commands
     if sensitive_parameters.include?(:unless)
       sensitive_parameters.delete(:unless)


### PR DESCRIPTION
disable 'Naming/AccessorMethodName' for 'set_sensitive_parameters'