### PR TITLE
(CONT-347) - correct centos/alma/rocky 8 hanging tests

### DIFF
--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper_acceptance'
 
 describe 'postgresql::server::db' do
+  before(:all) do
+    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
+  end
+
   it 'creates a database' do
     tmpdir = run_shell('mktemp').stdout
     pp = <<-MANIFEST

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper_acceptance'
 # These tests are designed to ensure that the module, when ran with defaults,
 # sets up everything correctly and allows us to connect to Postgres.
 describe 'postgresql::server' do
+  before(:all) do
+    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
+  end
+
   it 'with defaults' do
     pp = <<-MANIFEST
       class { 'postgresql::server': }

--- a/spec/acceptance/overridden_settings_spec.rb
+++ b/spec/acceptance/overridden_settings_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper_acceptance'
 # These tests are designed to ensure that the module, when ran overrides,
 # sets up everything correctly and allows us to connect to Postgres.
 describe 'postgresql::server' do
+  before(:all) do
+    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
+  end
+
   let(:pp) do
     <<-MANIFEST
     class { 'postgresql::server':

--- a/spec/acceptance/server/config_entry_spec.rb
+++ b/spec/acceptance/server/config_entry_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper_acceptance'
 
 describe 'postgresql::server::config_entry' do
+  before(:all) do
+    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
+  end
+
   context 'unix_socket_directories' do
     let(:pp_test) do
       <<-MANIFEST


### PR DESCRIPTION
This PR fixes the hanging tests found on el8 based litmus images like centos 8, alma 8 and rocky 8.

This issue was caused by Postgres smart shutdown functionality that would not shut down PGSQL if there was an active client connection.

This PR utilises `pg_ctl` to allow rspec to terminate those connections before executing the next set of tests.
