### PR TITLE
Fix acceptance tests on SLES 15

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,16 @@
+case $facts['os']['family'] {
+  'SLES', 'SUSE': {
+    if $facts['os']['release']['major'] == '15' {
+      # CI needs netstat(1) to check listening port.  netstat is part of the
+      # net-tools package which is deprecated and now a legacy module.
+      exec { 'enable legacy repos':
+        path =>  '/bin:/usr/bin/:/sbin:/usr/sbin',
+        command =>  'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        unless =>  'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      }
+      package { 'net-tools':
+        ensure => installed,
+      }
+    }
+  }
+}

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -16,6 +16,7 @@ end
 RSpec.configure do |c|
   c.before :suite do
     install_dependencies
+    LitmusHelper.instance.apply_manifest(File.read(File.join(__dir__, 'setup_acceptance_node.pp')))
   end
 end
 


### PR DESCRIPTION
The net-tools package which contain netstat(1) has been deprecated and
is now part of the legacy modules.

Enable and install the required tooling to fix CI.
