### PR TITLE
(CONT-1180) - Fixing build failures caused by SUSE 15 SP4

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -46,6 +46,12 @@ def install_dependencies
 
     # needed for netstat, for serverspec checks
     if $facts['os']['family'] in ['SLES', 'SUSE'] {
+      exec { 'Enable legacy repos':
+        path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      }
+
       package { 'net-tools-deprecated':
         ensure   => 'latest',
       }


### PR DESCRIPTION
## Summary

Enable legacy SP3 repo so that we can leverage the old packages without any issues.

## Additional Context

New release of SUSE 15 introduced new version SP4 which deprecated old packages where `net-tools-deprecated (netstat)` is one of them. As the package is deprecated with SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)