### PR TITLE
Fix log directory config entry name

### DIFF
--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -211,7 +211,7 @@ define postgresql::server::instance::config (
     }
   }
   if $logdir {
-    postgresql::server::config_entry { "log_directory for instance ${name}":
+    postgresql::server::config_entry { "log_directory_for_instance_${name}":
       value => $logdir,
     }
   }

--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -212,6 +212,7 @@ define postgresql::server::instance::config (
   }
   if $logdir {
     postgresql::server::config_entry { "log_directory_for_instance_${name}":
+      key   => 'log_directory',
       value => $logdir,
     }
   }


### PR DESCRIPTION
it does not satisfy the name regex and thus breaks the puppet run, if the log dir is set

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [/] Root cause and the steps to reproduce. (If applicable)
configure logdir parameter of postgresql::globals - puppet run breaks
- [/] Thought process behind the implementation.
the naming of the parameter is wrong and contains spaces

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [/] Manually verified. (For example `puppet apply`)