### PR TITLE
maint: removing debian 12 from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,8 +57,7 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "11",
-        "12"
+        "11"
       ]
     },
     {


### PR DESCRIPTION
Partially reverts puppetlabs/puppetlabs-postgresql#1460