### PR TITLE
(CAT-1262)-updated legacy repo for SUSE

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -48,8 +48,8 @@ def install_dependencies
     if $facts['os']['family'] in ['SLES', 'SUSE'] {
       exec { 'Enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+        command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
       }
 
       package { 'net-tools-deprecated':


### PR DESCRIPTION
## Summary
Enable legacy SP5 repo so that we can leverage the old packages without any issues.

## Additional Context
New release of SUSE introduced new version SP5 which deprecated old postgresql14-server package. As the package is deprecated with old SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)