### PR TITLE
port parameter: Cleanup datatype

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1031,7 +1031,7 @@ Default value: `$postgresql::params::listen_addresses`
 
 ##### <a name="-postgresql--server--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port for the PostgreSQL server to listen on.
 Note: The same port number is used for all IP addresses the server listens on.
@@ -1946,7 +1946,7 @@ Default value: `$postgresql::server::psql_path`
 
 ##### <a name="-postgresql--server--default_privileges--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port to access the server. Default value: The default user for the module, usually '5432'.
 
@@ -2051,7 +2051,7 @@ Default value: `undef`
 
 ##### <a name="-postgresql--server--extension--port"></a>`port`
 
-Data type: `Optional[Variant[String[1], Stdlib::Port, Integer]]`
+Data type: `Optional[Variant[String[1], Stdlib::Port]]`
 
 Port to use when connecting.
 
@@ -2178,7 +2178,7 @@ Default value: `$postgresql::server::user`
 
 ##### <a name="-postgresql--server--grant--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Port to use when connecting.
 
@@ -2280,7 +2280,7 @@ Default value: `$postgresql::server::user`
 
 ##### <a name="-postgresql--server--grant_role--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Port to use when connecting.
 
@@ -2361,7 +2361,7 @@ Default value: `$postgresql::server::listen_addresses`
 
 ##### <a name="-postgresql--server--instance--config--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port for the PostgreSQL server to listen on.
 Note: The same port number is used for all IP addresses the server listens on. Also, for Red Hat systems and early Debian systems,
@@ -2785,7 +2785,7 @@ Default value: `$postgresql::server::psql_path`
 
 ##### <a name="-postgresql--server--instance--late_initdb--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port for the PostgreSQL server to listen on.
 Note: The same port number is used for all IP addresses the server listens on. Also, for Red Hat systems and early Debian systems,
@@ -2844,7 +2844,7 @@ Default value: `$postgresql::server::psql_path`
 
 ##### <a name="-postgresql--server--instance--passwd--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port for the PostgreSQL server to listen on.
 Note: The same port number is used for all IP addresses the server listens on. Also, for Red Hat systems and early Debian systems,
@@ -2982,7 +2982,7 @@ Default value: `$postgresql::server::user`
 
 ##### <a name="-postgresql--server--instance--service--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Specifies the port for the PostgreSQL server to listen on.
 Note: The same port number is used for all IP addresses the server listens on. Also, for Red Hat systems and early Debian systems,
@@ -3219,7 +3219,7 @@ Default value: `$postgresql::server::user`
 
 ##### <a name="-postgresql--server--reassign_owned_by--port"></a>`port`
 
-Data type: `Variant[String[1], Stdlib::Port, Integer]`
+Data type: `Variant[String[1], Stdlib::Port]`
 
 Port to use when connecting.
 
@@ -3465,7 +3465,7 @@ Default value: `$postgresql::server::default_database`
 
 ##### <a name="-postgresql--server--role--port"></a>`port`
 
-Data type: `Optional[Variant[String[1], Stdlib::Port, Integer]]`
+Data type: `Optional[Variant[String[1], Stdlib::Port]]`
 
 Port to use when connecting.
 
@@ -3700,7 +3700,7 @@ Default value: `undef`
 
 ##### <a name="-postgresql--server--table_grant--port"></a>`port`
 
-Data type: `Optional[Variant[String[1], Stdlib::Port, Integer]]`
+Data type: `Optional[Variant[String[1], Stdlib::Port]]`
 
 Port to use when connecting.
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -135,7 +135,7 @@ class postgresql::server (
   String[1]                                          $default_database             = $postgresql::params::default_database,
   Hash                                               $default_connect_settings     = $postgresql::globals::default_connect_settings,
   Optional[Variant[String[1], Array[String[1]]]]     $listen_addresses             = $postgresql::params::listen_addresses,
-  Variant[String[1], Stdlib::Port, Integer]          $port                         = $postgresql::params::port,
+  Variant[String[1], Stdlib::Port]                   $port                         = $postgresql::params::port,
   String[1]                                          $ip_mask_deny_postgres_user   = $postgresql::params::ip_mask_deny_postgres_user,
   String[1]                                          $ip_mask_allow_all_users      = $postgresql::params::ip_mask_allow_all_users,
   Array[String[1]]                                   $ipv4acls                     = $postgresql::params::ipv4acls,

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -28,7 +28,7 @@ define postgresql::server::default_privileges (
   String                                    $schema            = 'public',
   String                                    $psql_db           = $postgresql::server::default_database,
   String                                    $psql_user         = $postgresql::server::user,
-  Variant[String[1], Stdlib::Port, Integer] $port              = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]          $port              = $postgresql::server::port,
   Hash                                      $connect_settings  = $postgresql::server::default_connect_settings,
   Enum['present', 'absent']                 $ensure            = 'present',
   String                                    $group             = $postgresql::server::group,

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -29,7 +29,7 @@ define postgresql::server::extension (
   Optional[String[1]]                                 $version                = undef,
   Enum['present', 'absent']                           $ensure                 = 'present',
   Optional[String[1]]                                 $package_name           = undef,
-  Optional[Variant[String[1], Stdlib::Port, Integer]] $port                   = undef,
+  Optional[Variant[String[1], Stdlib::Port]]          $port                   = undef,
   Hash                                                $connect_settings       = postgresql::default('default_connect_settings'),
   String[1]                                           $database_resource_name = $database,
 ) {

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -41,7 +41,7 @@ define postgresql::server::grant (
   Array[String[1],0]                             $object_arguments  = [],
   String                                         $psql_db           = $postgresql::server::default_database,
   String                                         $psql_user         = $postgresql::server::user,
-  Variant[String[1], Stdlib::Port, Integer]      $port              = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]               $port              = $postgresql::server::port,
   Boolean                                        $onlyif_exists     = false,
   Hash                                           $connect_settings  = $postgresql::server::default_connect_settings,
   Enum['present', 'absent']                      $ensure            = 'present',

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -13,7 +13,7 @@ define postgresql::server::grant_role (
   Enum['present', 'absent']                 $ensure           = 'present',
   String[1]                                 $psql_db          = $postgresql::server::default_database,
   String[1]                                 $psql_user        = $postgresql::server::user,
-  Variant[String[1], Stdlib::Port, Integer] $port             = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]          $port             = $postgresql::server::port,
   Hash                                      $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   case $ensure {

--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -48,7 +48,7 @@ define postgresql::server::instance::config (
   String[1]                                      $ip_mask_deny_postgres_user   = $postgresql::server::ip_mask_deny_postgres_user,
   String[1]                                      $ip_mask_allow_all_users      = $postgresql::server::ip_mask_allow_all_users,
   Optional[Variant[String[1], Array[String[1]]]] $listen_addresses             = $postgresql::server::listen_addresses,
-  Variant[String[1], Stdlib::Port, Integer]      $port                         = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]               $port                         = $postgresql::server::port,
   Array[String[1]]                               $ipv4acls                     = $postgresql::server::ipv4acls,
   Array[String[1]]                               $ipv6acls                     = $postgresql::server::ipv6acls,
   Variant[String[1], Stdlib::Absolutepath]       $pg_hba_conf_path             = $postgresql::server::pg_hba_conf_path,

--- a/manifests/server/instance/late_initdb.pp
+++ b/manifests/server/instance/late_initdb.pp
@@ -16,7 +16,7 @@ define postgresql::server::instance::late_initdb (
   String[1]                                 $user           = $postgresql::server::user,
   String[1]                                 $group          = $postgresql::server::group,
   Variant[String[1], Stdlib::Absolutepath]  $psql_path      = $postgresql::server::psql_path,
-  Variant[String[1], Stdlib::Port, Integer] $port           = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]          $port           = $postgresql::server::port,
   String[1]                                 $module_workdir = $postgresql::server::module_workdir,
 ) {
   # Set the defaults for the postgresql_psql resource

--- a/manifests/server/instance/passwd.pp
+++ b/manifests/server/instance/passwd.pp
@@ -17,7 +17,7 @@ define postgresql::server::instance::passwd (
   String[1]                                                   $user              = $postgresql::server::user,
   String[1]                                                   $group             = $postgresql::server::group,
   Variant[String[1], Stdlib::Absolutepath]                    $psql_path         = $postgresql::server::psql_path,
-  Variant[String[1], Stdlib::Port, Integer]                   $port              = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]                            $port              = $postgresql::server::port,
   String[1]                                                   $database          = $postgresql::server::default_database,
   String[1]                                                   $module_workdir    = $postgresql::server::module_workdir,
   Optional[Variant[String[1], Sensitive[String[1]], Integer]] $postgres_password = $postgresql::server::postgres_password,

--- a/manifests/server/instance/service.pp
+++ b/manifests/server/instance/service.pp
@@ -25,7 +25,7 @@ define postgresql::server::instance::service (
   Optional[String[1]]                          $service_provider = $postgresql::server::service_provider,
   String[1]                                    $service_status   = $postgresql::server::service_status,
   String[1]                                    $user             = $postgresql::server::user,
-  Variant[String[1], Stdlib::Port, Integer]    $port             = $postgresql::server::port,
+  Variant[String[1], Stdlib::Port]             $port             = $postgresql::server::port,
   String[1]                                    $default_database = $postgresql::server::default_database,
   Variant[String[1], Stdlib::Absolutepath]     $psql_path        = $postgresql::server::psql_path,
   Hash                                         $connect_settings = $postgresql::server::default_connect_settings,

--- a/manifests/server/reassign_owned_by.pp
+++ b/manifests/server/reassign_owned_by.pp
@@ -12,9 +12,9 @@ define postgresql::server::reassign_owned_by (
   String $old_role,
   String $new_role,
   String $db,
-  String $psql_user                               = $postgresql::server::user,
-  Variant[String[1], Stdlib::Port, Integer] $port = $postgresql::server::port,
-  Hash $connect_settings                          = $postgresql::server::default_connect_settings,
+  String $psql_user                      = $postgresql::server::user,
+  Variant[String[1], Stdlib::Port] $port = $postgresql::server::port,
+  Hash $connect_settings                 = $postgresql::server::default_connect_settings,
 ) {
   $sql_command = "REASSIGN OWNED BY \"${old_role}\" TO \"${new_role}\""
 

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -29,7 +29,7 @@ define postgresql::server::role (
   Boolean                                             $createdb         = false,
   Boolean                                             $createrole       = false,
   String[1]                                           $db               = $postgresql::server::default_database,
-  Optional[Variant[String[1], Stdlib::Port, Integer]] $port             = undef,
+  Optional[Variant[String[1], Stdlib::Port]]          $port             = undef,
   Boolean                                             $login            = true,
   Boolean                                             $inherit          = true,
   Boolean                                             $superuser        = false,

--- a/manifests/server/table_grant.pp
+++ b/manifests/server/table_grant.pp
@@ -19,7 +19,7 @@ define postgresql::server::table_grant (
   String[1]                                           $db,
   String[1]                                           $role,
   Optional[Enum['present', 'absent']]                 $ensure           = undef,
-  Optional[Variant[String[1], Stdlib::Port, Integer]] $port             = undef,
+  Optional[Variant[String[1], Stdlib::Port]]          $port             = undef,
   Optional[String[1]]                                 $psql_db          = undef,
   Optional[String[1]]                                 $psql_user        = undef,
   Optional[Hash]                                      $connect_settings = undef,


### PR DESCRIPTION
It doesn't make Sense to Allow Integer when we already allow Stdlib::Port.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)