### PR TITLE
Revert "puppetlabs/stdlib: Require 9.x"

### DIFF
--- a/manifests/backup/pg_dump.pp
+++ b/manifests/backup/pg_dump.pp
@@ -68,13 +68,13 @@ class postgresql::backup::pg_dump (
 ) {
   # Install required packages
   if $package_name {
-    stdlib::ensure_packages($package_name)
+    ensure_packages($package_name)
   }
   if $install_cron {
     if $facts['os']['family'] == 'RedHat' {
-      stdlib::ensure_packages('cronie')
+      ensure_packages('cronie')
     } elsif $facts['os']['family'] != 'FreeBSD' {
-      stdlib::ensure_packages('cron')
+      ensure_packages('cron')
     }
   }
 

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -137,7 +137,7 @@ define postgresql::server::extension (
       default => $package_ensure,
     }
 
-    stdlib::ensure_packages($package_name, {
+    ensure_packages($package_name, {
         ensure  => $_package_ensure,
         tag     => 'puppetlabs-postgresql',
     })

--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -189,7 +189,7 @@ define postgresql::server::instance::config (
       }
     }
 
-    stdlib::ensure_packages([$package_name])
+    ensure_packages([$package_name])
 
     $exec_command = ['/usr/sbin/semanage', 'port', '-a', '-t', 'postgresql_port_t', '-p', 'tcp', $port]
     $exec_unless = "/usr/sbin/semanage port -l | grep -qw ${port}"

--- a/manifests/server/instance/passwd.pp
+++ b/manifests/server/instance/passwd.pp
@@ -34,7 +34,7 @@ define postgresql::server::instance::passwd (
   # psql will default to connecting as $user if you don't specify name
   $_datbase_user_same = $database == $user
   $_dboption = $_datbase_user_same ? {
-    false => " --dbname ${stdlib::shell_escape($database)}",
+    false => " --dbname ${shell_escape($database)}",
     default => ''
   }
 
@@ -44,7 +44,7 @@ define postgresql::server::instance::passwd (
     #  without specifying a password ('ident' or 'trust' security). This is
     #  the default for pg_hba.conf.
     $escaped = postgresql::postgresql_escape($real_postgres_password)
-    $exec_command = "${stdlib::shell_escape($psql_path)}${_dboption} -c \"ALTER ROLE \\\"${stdlib::shell_escape($user)}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"" # lint:ignore:140chars
+    $exec_command = "${shell_escape($psql_path)}${_dboption} -c \"ALTER ROLE \\\"${shell_escape($user)}\\\" PASSWORD \${NEWPASSWD_ESCAPED}\"" # lint:ignore:140chars
     exec { 'set_postgres_postgrespw':
       # This command works w/no password because we run it as postgres system
       # user

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 5.2.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-postgresql#1449

To ensure we can do a minor release, we will try to revert this, do a minor release, apply it again.

This reverts e142268e9aa9f802a861d42bed2f7039bb8d6295