### PR TITLE
postgresql::server: Remove deprecated createdb_path parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -181,7 +181,6 @@ The following parameters are available in the `postgresql::globals` class:
 * [`default_database`](#-postgresql--globals--default_database)
 * [`validcon_script_path`](#-postgresql--globals--validcon_script_path)
 * [`initdb_path`](#-postgresql--globals--initdb_path)
-* [`createdb_path`](#-postgresql--globals--createdb_path)
 * [`psql_path`](#-postgresql--globals--psql_path)
 * [`pg_hba_conf_path`](#-postgresql--globals--pg_hba_conf_path)
 * [`pg_ident_conf_path`](#-postgresql--globals--pg_ident_conf_path)
@@ -353,14 +352,6 @@ Default value: `undef`
 Data type: `Optional[Variant[String[1], Stdlib::Absolutepath]]`
 
 Path to the initdb command.
-
-Default value: `undef`
-
-##### <a name="-postgresql--globals--createdb_path"></a>`createdb_path`
-
-Data type: `Optional[Variant[String[1], Stdlib::Absolutepath]]`
-
-Deprecated. Path to the createdb command.
 
 Default value: `undef`
 
@@ -856,7 +847,6 @@ The following parameters are available in the `postgresql::server` class:
 * [`ipv4acls`](#-postgresql--server--ipv4acls)
 * [`ipv6acls`](#-postgresql--server--ipv6acls)
 * [`initdb_path`](#-postgresql--server--initdb_path)
-* [`createdb_path`](#-postgresql--server--createdb_path)
 * [`psql_path`](#-postgresql--server--psql_path)
 * [`pg_hba_conf_path`](#-postgresql--server--pg_hba_conf_path)
 * [`pg_ident_conf_path`](#-postgresql--server--pg_ident_conf_path)
@@ -1084,14 +1074,6 @@ Data type: `Variant[String[1], Stdlib::Absolutepath]`
 Specifies the path to the initdb command.
 
 Default value: `$postgresql::params::initdb_path`
-
-##### <a name="-postgresql--server--createdb_path"></a>`createdb_path`
-
-Data type: `Optional[Variant[String[1], Stdlib::Absolutepath]]`
-
-Deprecated. Specifies the path to the createdb command.
-
-Default value: `$postgresql::params::createdb_path`
 
 ##### <a name="-postgresql--server--psql_path"></a>`psql_path`
 

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -26,7 +26,6 @@
 # @param validcon_script_path Scipt path for the connection validation check.
 #
 # @param initdb_path Path to the initdb command.
-# @param createdb_path Deprecated. Path to the createdb command.
 # @param psql_path Sets the path to the psql command.
 # @param pg_hba_conf_path Specifies the path to your pg_hba.conf file.
 # @param pg_ident_conf_path Specifies the path to your pg_ident.conf file.
@@ -124,7 +123,6 @@ class postgresql::globals (
   Optional[String[1]] $validcon_script_path        = undef,
 
   Optional[Variant[String[1], Stdlib::Absolutepath]] $initdb_path                 = undef,
-  Optional[Variant[String[1], Stdlib::Absolutepath]] $createdb_path               = undef,
   Optional[Variant[String[1], Stdlib::Absolutepath]] $psql_path                   = undef,
   Optional[Variant[String[1], Stdlib::Absolutepath]] $pg_hba_conf_path            = undef,
   Optional[Variant[String[1], Stdlib::Absolutepath]] $pg_ident_conf_path          = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -46,7 +46,6 @@
 # @param ipv6acls Lists strings for access control for connection method, users, databases, IPv6 addresses.
 #
 # @param initdb_path Specifies the path to the initdb command.
-# @param createdb_path Deprecated. Specifies the path to the createdb command.
 # @param psql_path Specifies the path to the psql command.
 # @param pg_hba_conf_path Specifies the path to your pg_hba.conf file.
 # @param pg_ident_conf_path Specifies the path to your pg_ident.conf file.
@@ -140,7 +139,6 @@ class postgresql::server (
   Array[String[1]]                                   $ipv6acls                     = $postgresql::params::ipv6acls,
 
   Variant[String[1], Stdlib::Absolutepath]           $initdb_path                  = $postgresql::params::initdb_path,
-  Optional[Variant[String[1], Stdlib::Absolutepath]] $createdb_path                = $postgresql::params::createdb_path,
   Variant[String[1], Stdlib::Absolutepath]           $psql_path                    = $postgresql::params::psql_path,
   Variant[String[1], Stdlib::Absolutepath]           $pg_hba_conf_path             = $postgresql::params::pg_hba_conf_path,
   Variant[String[1], Stdlib::Absolutepath]           $pg_ident_conf_path           = $postgresql::params::pg_ident_conf_path,
@@ -192,9 +190,6 @@ class postgresql::server (
   Enum['pg_dump']                                    $backup_provider              = $postgresql::params::backup_provider,
 ) inherits postgresql::params {
   $_version = $postgresql::params::version
-  if $createdb_path != undef {
-    warning('Passing "createdb_path" to postgresql::server is deprecated, it can be removed safely for the same behaviour')
-  }
 
   # Reload has its own ordering, specified by other defines
   class { 'postgresql::server::reload':

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -20,7 +20,6 @@ define postgresql::server::database (
   Boolean             $istemplate       = false,
   Hash                $connect_settings = $postgresql::server::default_connect_settings,
 ) {
-  $createdb_path = $postgresql::server::createdb_path
   $user          = $postgresql::server::user
   $group         = $postgresql::server::group
   $psql_path     = $postgresql::server::psql_path
@@ -77,10 +76,6 @@ define postgresql::server::database (
   $tablespace_option = $tablespace ? {
     undef   => '',
     default => "TABLESPACE \"${tablespace}\"",
-  }
-
-  if $createdb_path != undef {
-    warning('Passing "createdb_path" to postgresql::database is deprecated, it can be removed safely for the same behaviour')
   }
 
   postgresql_psql { "CREATE DATABASE \"${dbname}\"":


### PR DESCRIPTION
It looks like `$postgresql::params::createdb_path` doesn't even exist? That's quite odd. A) my grep failed or b) the rspec-puppet tests don't use strict_variables=true.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)