### PR TITLE
Cleanup useless $connect_setting validation

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -27,14 +27,14 @@ define postgresql::server::database (
 
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
+  if 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version
   }
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and 'PGPORT' in $connect_settings {
+  if 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port

--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -37,7 +37,7 @@ define postgresql::server::default_privileges (
 ) {
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
+  if 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version
@@ -62,15 +62,15 @@ define postgresql::server::default_privileges (
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
   #
-  if $port != undef {
+  if $port {
     $port_override = $port
-  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
+  } elsif 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port
   }
 
-  if $target_role != undef {
+  if $target_role {
     $_target_role = " FOR ROLE ${target_role}"
     $_check_target_role = "/${target_role}"
   } else {
@@ -178,11 +178,11 @@ define postgresql::server::default_privileges (
     environment      => 'PGOPTIONS=--client-min-messages=error',
   }
 
-  if($role != undef and defined(Postgresql::Server::Role[$role])) {
+  if defined(Postgresql::Server::Role[$role]) {
     Postgresql::Server::Role[$role] -> Postgresql_psql["default_privileges:${name}"]
   }
 
-  if($db != undef and defined(Postgresql::Server::Database[$db])) {
+  if defined(Postgresql::Server::Database[$db]) {
     Postgresql::Server::Database[$db] -> Postgresql_psql["default_privileges:${name}"]
   }
 }

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -77,9 +77,9 @@ define postgresql::server::extension (
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
   #
-  if $port != undef {
+  if $port {
     $port_override = $port
-  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
+  } elsif 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -77,7 +77,7 @@ define postgresql::server::grant (
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
   #
-  if $port != undef {
+  if $port {
     $port_override = $port
   } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
     $port_override = undef
@@ -483,11 +483,11 @@ define postgresql::server::grant (
     onlyif           => $_onlyif,
   }
 
-  if($role != undef and defined(Postgresql::Server::Role[$role])) {
+  if defined(Postgresql::Server::Role[$role]) {
     Postgresql::Server::Role[$role] -> Postgresql_psql["grant:${name}"]
   }
 
-  if($db != undef and defined(Postgresql::Server::Database[$db])) {
+  if defined(Postgresql::Server::Database[$db]) {
     Postgresql::Server::Database[$db] -> Postgresql_psql["grant:${name}"]
   }
 }

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -39,7 +39,7 @@ define postgresql::server::grant_role (
     connect_settings => $connect_settings,
   }
 
-  if ! $connect_settings or empty($connect_settings) {
+  if empty($connect_settings) {
     Class['postgresql::server'] -> Postgresql_psql["grant_role:${name}"]
   }
   if defined(Postgresql::Server::Role[$role]) {

--- a/manifests/server/reassign_owned_by.pp
+++ b/manifests/server/reassign_owned_by.pp
@@ -21,15 +21,10 @@ define postgresql::server::reassign_owned_by (
   $group     = $postgresql::server::group
   $psql_path = $postgresql::server::psql_path
 
-  #
-  # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
-  #
-  if $port {
-    $port_override = $port
-  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
+  if 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
-    $port_override = $postgresql::server::port
+    $port_override = $port
   }
 
   $onlyif = "SELECT tablename FROM pg_catalog.pg_tables WHERE
@@ -54,14 +49,14 @@ define postgresql::server::reassign_owned_by (
     onlyif           => $onlyif,
   }
 
-  if($old_role != undef and defined(Postgresql::Server::Role[$old_role])) {
+  if defined(Postgresql::Server::Role[$old_role]) {
     Postgresql::Server::Role[$old_role] -> Postgresql_psql["reassign_owned_by:${db}:${sql_command}"]
   }
   if($new_role != undef and defined(Postgresql::Server::Role[$new_role])) {
     Postgresql::Server::Role[$new_role] -> Postgresql_psql["reassign_owned_by:${db}:${sql_command}"]
   }
 
-  if($db != undef and defined(Postgresql::Server::Database[$db])) {
+  if defined(Postgresql::Server::Database[$db]) {
     Postgresql::Server::Database[$db] -> Postgresql_psql["reassign_owned_by:${db}:${sql_command}"]
   }
 }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -53,9 +53,9 @@ define postgresql::server::role (
   #
   # Port, order of precedence: $port parameter, $connect_settings[PGPORT], $postgresql::server::port
   #
-  if $port != undef {
+  if $port {
     $port_override = $port
-  } elsif $connect_settings != undef and 'PGPORT' in $connect_settings {
+  } elsif 'PGPORT' in $connect_settings {
     $port_override = undef
   } else {
     $port_override = $postgresql::server::port
@@ -63,7 +63,7 @@ define postgresql::server::role (
 
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
-  if $connect_settings != undef and 'DBVERSION' in $connect_settings {
+  if 'DBVERSION' in $connect_settings {
     $version = $connect_settings['DBVERSION']
   } else {
     $version = $postgresql::server::_version

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -27,7 +27,7 @@ define postgresql::server::schema (
   Postgresql::Server::Db <| dbname == $db |> -> Postgresql::Server::Schema[$name]
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and 'PGPORT' in $connect_settings {
+  if 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -18,7 +18,7 @@ define postgresql::server::tablespace (
   $module_workdir = $postgresql::server::module_workdir
 
   # If the connection settings do not contain a port, then use the local server port
-  if $connect_settings != undef and 'PGPORT' in $connect_settings {
+  if 'PGPORT' in $connect_settings {
     $port = undef
   } else {
     $port = $postgresql::server::port


### PR DESCRIPTION
In the past we checked if $connect_setting isn't undef. That is not required because the default is {} and the Datatype is hash. Undef isn't allowed.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)