### PR TITLE
List Debian 12 as supported system

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
## Summary
Debian 12 has been removed from supported systems (f10ee71a28b7b727d9bffb869ecc1a76d7e98b57). Now since https://github.com/puppetlabs/litmusimage/pull/62  has been merged, there should be a [docker image available](https://hub.docker.com/layers/litmusimage/debian/12/images/sha256-607075d045ffbff953eff28e55bf01f3ecd2396fe963afa3aa126b507b11fc38?context=explore).