### PR TITLE
Drop postgresql 8.4/RHEL6 specific code

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -195,7 +195,6 @@ class postgresql::globals (
         '9'     => '13',
         '8'     => '10',
         '7'     => '9.2',
-        '6'     => '8.4',
         default => undef,
       },
     },
@@ -247,7 +246,6 @@ class postgresql::globals (
   }
 
   $default_postgis_version = $globals_version ? {
-    '8.4'   => '2.0',
     '9.0'   => '2.1',
     '9.1'   => '2.1',
     '91'    => '2.1',

--- a/manifests/server/pg_hba_rule.pp
+++ b/manifests/server/pg_hba_rule.pp
@@ -69,9 +69,6 @@ define postgresql::server::pg_hba_rule (
       '9.2' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.1' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam'],
       '9.0' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'ldap', 'radius', 'cert', 'pam'],
-      '8.4' => ['trust', 'reject', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'ldap', 'cert', 'pam'],
-      '8.3' => ['trust', 'reject', 'md5', 'crypt', 'password', 'gss', 'sspi', 'krb5', 'ident', 'ldap', 'pam'],
-      '8.2' => ['trust', 'reject', 'md5', 'crypt', 'password', 'krb5', 'ident', 'ldap', 'pam'],
       default => ['trust', 'reject', 'scram-sha-256', 'md5', 'password', 'gss', 'sspi', 'krb5', 'ident', 'peer', 'ldap', 'radius', 'cert', 'pam', 'crypt', 'bsd'] # lint:ignore:140chars
     }
 

--- a/spec/acceptance/server/grant_spec.rb
+++ b/spec/acceptance/server/grant_spec.rb
@@ -79,16 +79,14 @@ describe 'postgresql::server::grant:' do
       end
 
       it 'is expected to run idempotently' do
-        idempotent_apply(pp) if Gem::Version.new(postgresql_version) >= Gem::Version.new('8.4.0')
+        idempotent_apply(pp)
       end
 
       it 'is expected to GRANT USAGE ON LANGUAGE plpgsql to ROLE' do
-        if Gem::Version.new(postgresql_version) >= Gem::Version.new('8.4.0')
-          ## Check that the privilege was granted to the user
-          psql("-d #{db} --command=\"SELECT 1 WHERE has_language_privilege('#{user}', 'plpgsql', 'USAGE')\"", superuser) do |r|
-            expect(r.stdout).to match(%r{\(1 row\)})
-            expect(r.stderr).to eq('')
-          end
+        ## Check that the privilege was granted to the user
+        psql("-d #{db} --command=\"SELECT 1 WHERE has_language_privilege('#{user}', 'plpgsql', 'USAGE')\"", superuser) do |r|
+          expect(r.stdout).to match(%r{\(1 row\)})
+          expect(r.stderr).to eq('')
         end
       end
     end


### PR DESCRIPTION
Postgresql 8.4 is EoL since years and the metadata.json doesn't list RHEL6 as supported so it should be fine to merge.