### PR TITLE
Flexible password encryption in pg hba conf

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4429,6 +4429,8 @@ Data type: `Optional[Optional[Postgresql::Pg_password_encryption]]`
 
 Set type for password hash
 
+Default value comes from `postgresql::params::password_encryption` and changes based on the `postgresql::globals::version`.
+
 ##### `salt`
 
 Data type: `Optional[Optional[Variant[String[1], Integer]]]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -874,6 +874,7 @@ The following parameters are available in the `postgresql::server` class:
 * [`manage_logdir`](#-postgresql--server--manage_logdir)
 * [`manage_xlogdir`](#-postgresql--server--manage_xlogdir)
 * [`password_encryption`](#-postgresql--server--password_encryption)
+* [`pg_hba_auth_password_encryption`](#-postgresql--server--pg_hba_auth_password_encryption)
 * [`roles`](#-postgresql--server--roles)
 * [`config_entries`](#-postgresql--server--config_entries)
 * [`pg_hba_rules`](#-postgresql--server--pg_hba_rules)
@@ -1300,11 +1301,20 @@ Default value: `$postgresql::params::manage_xlogdir`
 
 ##### <a name="-postgresql--server--password_encryption"></a>`password_encryption`
 
-Data type: `Optional[Postgresql::Pg_password_encryption]`
+Data type: `Postgresql::Pg_password_encryption`
 
 Specify the type of encryption set for the password.
 
 Default value: `$postgresql::params::password_encryption`
+
+##### <a name="-postgresql--server--pg_hba_auth_password_encryption"></a>`pg_hba_auth_password_encryption`
+
+Data type: `Optional[Postgresql::Pg_password_encryption]`
+
+Specify the type of encryption set for the password in pg_hba_conf,
+this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
+
+Default value: `undef`
 
 ##### <a name="-postgresql--server--roles"></a>`roles`
 
@@ -2417,6 +2427,7 @@ The following parameters are available in the `postgresql::server::instance::con
 * [`log_line_prefix`](#-postgresql--server--instance--config--log_line_prefix)
 * [`timezone`](#-postgresql--server--instance--config--timezone)
 * [`password_encryption`](#-postgresql--server--instance--config--password_encryption)
+* [`pg_hba_auth_password_encryption`](#-postgresql--server--instance--config--pg_hba_auth_password_encryption)
 * [`extra_systemd_config`](#-postgresql--server--instance--config--extra_systemd_config)
 
 ##### <a name="-postgresql--server--instance--config--ip_mask_deny_postgres_user"></a>`ip_mask_deny_postgres_user`
@@ -2633,11 +2644,20 @@ Default value: `$postgresql::server::timezone`
 
 ##### <a name="-postgresql--server--instance--config--password_encryption"></a>`password_encryption`
 
-Data type: `Optional[Postgresql::Pg_password_encryption]`
+Data type: `Postgresql::Pg_password_encryption`
 
 Specify the type of encryption set for the password.
 
 Default value: `$postgresql::server::password_encryption`
+
+##### <a name="-postgresql--server--instance--config--pg_hba_auth_password_encryption"></a>`pg_hba_auth_password_encryption`
+
+Data type: `Optional[Postgresql::Pg_password_encryption]`
+
+Specify the type of encryption set for the password in pg_hba_conf,
+this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
+
+Default value: `$postgresql::server::pg_hba_auth_password_encryption`
 
 ##### <a name="-postgresql--server--instance--config--extra_systemd_config"></a>`extra_systemd_config`
 

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -13,6 +13,8 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   #   If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
   # @param hash
   #   Set type for password hash
+  #
+  #   Default value comes from `postgresql::params::password_encryption` and changes based on the `postgresql::globals::version`.
   # @param salt
   #   Use a specific salt value for scram-sha-256, default is username
   #
@@ -27,7 +29,8 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     return_type 'Variant[String, Sensitive[String]]'
   end
 
-  def default_impl(username, password, sensitive = false, hash = 'md5', salt = nil)
+  def default_impl(username, password, sensitive = false, hash = nil, salt = nil)
+    hash = call_function(:'postgresql::default', 'password_encryption') if hash.nil?
     password = password.unwrap if password.respond_to?(:unwrap)
     if password.is_a?(String) && password.match?(%r{^(md5[0-9a-f]{32}$|SCRAM-SHA-256\$)})
       return Puppet::Pops::Types::PSensitiveType::Sensitive.new(password) if sensitive

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_selinux               = pick($manage_selinux, false)
   $package_ensure               = 'present'
   $module_workdir               = pick($module_workdir,'/tmp')
-  $password_encryption          = if versioncmp($version, '14') >= 0 { 'scram-sha-256' } else { undef }
+  $password_encryption          = versioncmp($version, '14') ? { -1 => 'md5', default => 'scram-sha-256' }
   $extra_systemd_config         = undef
   $manage_datadir               = true
   $manage_logdir                = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -96,7 +96,9 @@
 # @param manage_logdir Set to false if you have file{ $logdir: } already defined
 # @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
 # @param password_encryption Specify the type of encryption set for the password.
-#
+# @param pg_hba_auth_password_encryption
+#   Specify the type of encryption set for the password in pg_hba_conf,
+#   this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
@@ -178,7 +180,8 @@ class postgresql::server (
   Boolean                                            $manage_datadir               = $postgresql::params::manage_datadir,
   Boolean                                            $manage_logdir                = $postgresql::params::manage_logdir,
   Boolean                                            $manage_xlogdir               = $postgresql::params::manage_xlogdir,
-  Optional[Postgresql::Pg_password_encryption]       $password_encryption          = $postgresql::params::password_encryption,
+  Postgresql::Pg_password_encryption                 $password_encryption          = $postgresql::params::password_encryption,
+  Optional[Postgresql::Pg_password_encryption]       $pg_hba_auth_password_encryption = undef,
   Optional[String]                                   $extra_systemd_config         = $postgresql::params::extra_systemd_config,
 
   Hash[String, Hash]                                 $roles                        = {},

--- a/spec/acceptance/overridden_settings_spec.rb
+++ b/spec/acceptance/overridden_settings_spec.rb
@@ -26,7 +26,7 @@ describe 'postgresql::server' do
           type        => 'host',
           database    => 'mydb',
           user        => 'myuser',
-          auth_method => 'md5',
+          auth_method => postgresql::default('password_encryption'),
           address     => '192.0.2.100/32',
         },
       },

--- a/spec/functions/postgresql_password_spec.rb
+++ b/spec/functions/postgresql_password_spec.rb
@@ -3,5 +3,7 @@
 require 'spec_helper'
 
 describe 'postgresql_password' do
+  include_examples 'Ubuntu 18.04'
+
   it_behaves_like 'postgresql_password function'
 end

--- a/spec/functions/postgresql_postgresql_password_spec.rb
+++ b/spec/functions/postgresql_postgresql_password_spec.rb
@@ -3,5 +3,7 @@
 require 'spec_helper'
 
 describe 'postgresql::postgresql_password' do
+  include_examples 'Ubuntu 18.04'
+
   it_behaves_like 'postgresql_password function'
 end


### PR DESCRIPTION
## Summary
* ensure that default password encryption is also used in default pg hba conf
* ensure that `postgresql::postgresql_password` respect the module default password encryption

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
fixes #1465

replace #1479

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)