### PR TITLE
Drop code for Debian without systemd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -164,13 +164,8 @@ class postgresql::params inherits postgresql::globals {
       $bindir                 = pick($bindir, "/usr/lib/postgresql/${version}/bin")
       $datadir                = pick($datadir, "/var/lib/postgresql/${version}/main")
       $confdir                = pick($confdir, "/etc/postgresql/${version}/main")
-      if pick($service_provider, $facts['service_provider']) == 'systemd' {
-        $service_reload = "systemctl reload ${service_name}"
-        $service_status = pick($service_status, "systemctl status ${service_name}")
-      } else {
-        $service_reload = "service ${service_name} reload"
-        $service_status = pick($service_status, "service ${service_name} status")
-      }
+      $service_reload         = "systemctl reload ${service_name}"
+      $service_status         = pick($service_status, "systemctl status ${service_name}")
       $psql_path              = pick($psql_path, '/usr/bin/psql')
       $postgresql_conf_mode   = pick($postgresql_conf_mode, '0644')
     }


### PR DESCRIPTION
FreeBSD 9.4/9.5 are EoL since ages and not listed as supported in metadata.json. Also no linux operating system without Systemd is supported, so we can drop the old code.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)