### PR TITLE
Fix password_encryption for DBVERSION in server::role

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -142,7 +142,7 @@ define postgresql::server::role (
     $_hash = if $hash {
       $hash
     } elsif $connect_settings != undef and 'DBVERSION' in $connect_settings {
-      if (versioncmp($version, '14') >= 0) { 'scram-sha-256' } else { undef }
+      versioncmp($version, '14') ? { -1 => 'md5', default => 'scram-sha-256' }
     } else {
       $postgresql::server::password_encryption
     }

--- a/spec/acceptance/server/role_spec.rb
+++ b/spec/acceptance/server/role_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'postgresql::server::role' do
+  let(:user) { 'foo' }
+  let(:password) { 'bar' }
+
+  it 'with different DBVERSION in connect_settings' do
+    pp_role = <<-MANIFEST
+      $user = '#{user}'
+      $password = '#{password}'
+
+      class { 'postgresql::server': }
+
+      postgresql::server::role { $user:
+        password_hash    => $password,
+        connect_settings => {
+          'DBVERSION' => '13',
+        },
+      }
+    MANIFEST
+
+    if Gem::Version.new(postgresql_version) >= Gem::Version.new('14')
+      idempotent_apply(pp_role)
+
+      # verify that password_encryption selectio is based on 'DBVERSION' and not on postgresql::serverglobals::version
+      psql("--command=\"SELECT 1 FROM pg_shadow WHERE usename = '#{user}' AND passwd = 'md596948aad3fcae80c08a35c9b5958cd89'\"") do |r|
+        expect(r.stdout).to match(%r{\(1 row\)})
+        expect(r.stderr).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
After #1512 the `postgresql::postgresql_password()` must not default to 'md5' anymore which creates a edge case in `postgresql::server::role`. When `DBVERSION` in paramter `connect_settings` is set to a version before 14 and the global version is 14 or above, the used `hash` parameter of `postgresql::postgresql_password()`  will be set to undef instead of 'md5'.

This PR fixes that edge case by setting the wanted hash type and do not relay anymore on the default hash type of `postgresql::postgresql_password()` itself.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes #1512

## Checklist
- [ ] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)