### PR TITLE
Drop code compatibility for non-systemd Red Hat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,13 +85,8 @@ class postgresql::params inherits postgresql::globals {
         $postgresql_conf_mode   = pick($postgresql_conf_mode, '0600')
       }
 
-      if pick($service_provider, $facts['service_provider']) == 'systemd' {
-        $service_reload = "systemctl reload ${service_name}"
-        $service_status = pick($service_status, "systemctl status ${service_name}")
-      } else {
-        $service_reload = "service ${service_name} reload"
-        $service_status = pick($service_status, "service ${service_name} status")
-      }
+      $service_reload = "systemctl reload ${service_name}"
+      $service_status = pick($service_status, "systemctl status ${service_name}")
 
       $psql_path           = pick($psql_path, "${bindir}/psql")
 

--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -242,11 +242,8 @@ define postgresql::server::instance::config (
       notify => Class['postgresql::server::reload'],
     }
   }
-  # lint:ignore:140chars
-  # RHEL 7 and 8 both support drop-in files for systemd units. Gentoo also supports drop-in files.
-  # Edit 02/2023 RHEL basedc Systems and Gentoo need Variables set for $PGPORT, $DATA_DIR or $PGDATA, thats what the drop-in file is for.
-  # lint:endignore:140chars
-  if $facts['os']['family'] in ['RedHat', 'Gentoo'] and $facts['service_provider'] == 'systemd' {
+  # RHEL based systems and Gentoo need variables set for $PGPORT, $DATA_DIR or $PGDATA via a drop-in file
+  if $facts['os']['family'] == 'RedHat' or ($facts['os']['family'] == 'Gentoo' and $facts['service_provider'] == 'systemd') {
     postgresql::server::instance::systemd { $service_name:
       port                 => $port,
       datadir              => $datadir,


### PR DESCRIPTION
Only EL6 used sysvinit, but that's no longer supported by the module.