### PR TITLE
Drop EoL FreeBSD 9.4/9.5 specific code

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,19 +199,9 @@ class postgresql::params inherits postgresql::globals {
     }
 
     'FreeBSD': {
-      case $version {
-        '94', '95': {
-          $user                 = pick($user, 'pgsql')
-          $group                = pick($group, 'pgsql')
-          $datadir              = pick($datadir, '/usr/local/pgsql/data')
-        }
-        default: {
-          $user                 = pick($user, 'postgres')
-          $group                = pick($group, 'postgres')
-          $datadir              = pick($datadir, "/var/db/postgres/data${version}")
-        }
-      }
-
+      $user                 = pick($user, 'postgres')
+      $group                = pick($group, 'postgres')
+      $datadir              = pick($datadir, "/var/db/postgres/data${version}")
       $link_pg_config       = true
       $client_package_name  = pick($client_package_name, "databases/postgresql${version}-client")
       $server_package_name  = pick($server_package_name, "databases/postgresql${version}-server")


### PR DESCRIPTION
Cherry-picked from
https://github.com/puppetlabs/puppetlabs-postgresql/pull/1514/

both FreeBSD versions are EoL since a long time and not listed in metadata.json anymore. We can drop them.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)