### PR TITLE
Drop EoL SLES 11.4 code

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -264,13 +264,8 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, "/usr/lib/postgresql${version}/bin")
       $datadir              = pick($datadir, '/var/lib/pgsql/data')
       $confdir              = pick($confdir, $datadir)
-      if $facts['os']['name'] == 'SLES' and versioncmp($facts['os']['release']['full'], '11.4') <= 0 {
-        $service_status     = pick($service_status, "/etc/init.d/${service_name} status")
-        $service_reload     = "/etc/init.d/${service_name} reload"
-      } else {
-        $service_status     = pick($service_status, "systemctl status ${service_name}")
-        $service_reload     = "systemctl reload ${service_name}"
-      }
+      $service_status       = pick($service_status, "systemctl status ${service_name}")
+      $service_reload       = "systemctl reload ${service_name}"
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
       $needs_initdb         = pick($needs_initdb, true)


### PR DESCRIPTION
SLES 11.4 and older are EoL and not present anymore in metadata.json. We can drop the code.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)