### PR TITLE
Fix the `postgresql::postgresql_password()` function

### DIFF
--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -30,7 +30,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   end
 
   def default_impl(username, password, sensitive = false, hash = nil, salt = nil)
-    hash = call_function(:'postgresql::default', 'password_encryption') if hash.nil?
+    hash = call_function('postgresql::default', 'password_encryption') if hash.nil?
     password = password.unwrap if password.respond_to?(:unwrap)
     if password.is_a?(String) && password.match?(%r{^(md5[0-9a-f]{32}$|SCRAM-SHA-256\$)})
       return Puppet::Pops::Types::PSensitiveType::Sensitive.new(password) if sensitive


### PR DESCRIPTION
The changes in #1512 introduced a regression when a hash value is not
explicitly passed:

```
Puppet Server Error: Evaluation Error: Error while evaluating a Function Call, failed to coerce org.jruby.RubySymbol to java.lang.String
```

Fixes #1528
