### PR TITLE
Fix `postgresql::default()` return value for unknown parameters

### DIFF
--- a/functions/default.pp
+++ b/functions/default.pp
@@ -10,6 +10,5 @@ function postgresql::default(
 
   #search for the variable name in params first
   #then fall back to globals if not found
-  pick( getvar("postgresql::params::${parameter_name}"),
-  "postgresql::globals::${parameter_name}")
+  pick(getvar("postgresql::params::${parameter_name}"), getvar("postgresql::globals::${parameter_name}"))
 }

--- a/functions/default.pp
+++ b/functions/default.pp
@@ -8,7 +8,7 @@ function postgresql::default(
 ) {
   include postgresql::params
 
-  #search for the variable name in params first
-  #then fall back to globals if not found
-  pick(getvar("postgresql::params::${parameter_name}"), getvar("postgresql::globals::${parameter_name}"))
+  # Search for the variable name in params.
+  # params inherits from globals, so it will also catch these variables.
+  pick(getvar("postgresql::params::${parameter_name}"))
 }

--- a/spec/functions/postgresql_default_spec.rb
+++ b/spec/functions/postgresql_default_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'postgresql::default' do
+  let(:facts) do
+    {
+      'os' => {
+        'family' => 'Debian',
+        'name'   => 'Debian',
+        'release' => {
+          'full'  => '11.7',
+          'major' => '11',
+          'minor' => '7',
+        }
+      }
+    }
+  end
+
+  let(:pre_condition) do
+    <<~PP
+    class { 'postgresql::server':
+    }
+    PP
+  end
+
+  # parameter in params.pp only
+  it { is_expected.to run.with_params('port').and_return(5432) }
+
+  # parameter in globals.pp only
+  it { is_expected.to run.with_params('default_connect_settings').and_return({}) }
+
+  it { is_expected.to run.with_params('a_parameter_that_does_not_exist').and_raise_error(Puppet::ParseError, %r{pick\(\): must receive at least one non empty value}) }
+end


### PR DESCRIPTION
When calling `postgresql::default()` with a name that has no corresponding parameter, the function returns the string "postgresql::globals::<parameter-name>" which is probably not intended given the comment above the code.

The usage of pick seems to indicate that an exception should be raised when a parameter is not found in `params` nor `globals.pp`, so adjust the code accordingly.
