### PR TITLE
(#1532) Replace ParserError with Puppet::Error

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
   # check, if resource exists in postgresql.conf file
   def exists?
     select = parse_config.select { |hash| hash[:key] == resource[:key] }
-    raise ParserError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
+    raise Puppet::Error, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
     return false if select.empty?
 
     @result = select.first

--- a/spec/unit/provider/postgresql_conf/ruby_spec.rb
+++ b/spec/unit/provider/postgresql_conf/ruby_spec.rb
@@ -30,6 +30,16 @@ describe provider_class do
     expect(provider).to respond_to(:exists?)
   end
 
+  describe 'duplicate keys in postgresql.conf' do
+    it 'stubs the parse_config method' do
+      allow(provider).to receive(:parse_config).and_return([{ key: 'foo', line: 1 }, { key: 'foo', line: 2 }])
+      expect(provider).to have_received(:parse_config)
+    end
+    it 'raises an exception' do
+      expect { provider.exists? }.to raise_error(Puppet::Error, 'found multiple config items of foo found, please fix this')
+    end
+  end
+
   it 'has a method create' do
     expect(provider).to respond_to(:create)
   end


### PR DESCRIPTION
I'm not sure how we ended up with ParserError in the provider. This exception doesn't exist in Ruby. Puppet ships ther own exception, Puppet::Error. It probably makes sense to raise that instead.

Fixes 179472ba261a7d0847fdb93fdcb1d43741c4cdde

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)