### PR TITLE
(#1532) Replace ParserError with Puppet::Error 

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
   # check, if resource exists in postgresql.conf file
   def exists?
     select = parse_config.select { |hash| hash[:key] == resource[:key] }
-    raise ParserError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
+    raise Puppet::Error, "found multiple config items of #{resource[:key]}, please fix this" if select.length > 1
     return false if select.empty?
 
     @result = select.first

--- a/spec/unit/provider/postgresql_conf/ruby_spec.rb
+++ b/spec/unit/provider/postgresql_conf/ruby_spec.rb
@@ -4,13 +4,14 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:postgresql_conf).provider(:ruby)
 
 describe provider_class do
-  let(:resource) { Puppet::Type.type(:postgresql_conf).new(name: 'foo', value: 'bar') }
+  let(:resource) { Puppet::Type.type(:postgresql_conf).new(name: 'foo', key: 'foo', value: 'bar') }
   let(:provider) { resource.provider }
 
   before(:each) do
     allow(provider).to receive(:file_path).and_return('/tmp/foo')
     allow(provider).to receive(:read_file).and_return('foo = bar')
     allow(provider).to receive(:write_file).and_return(true)
+    allow(provider).to receive(:resource).and_return(key: 'your_key', line_number: 1, value: 'foo')
   end
   # rubocop:enable RSpec/ReceiveMessages
 
@@ -26,8 +27,27 @@ describe provider_class do
     expect(provider).to respond_to(:add_header)
   end
 
-  it 'has a method exists?' do
-    expect(provider).to respond_to(:exists?)
+  describe '#exists?' do
+    it 'returns true when a matching config item is found' do
+      config_data = [{ key: 'your_key', value: 'your_value' }]
+      expect(provider).to receive(:parse_config).and_return(config_data)
+
+      expect(provider.exists?).to be true
+    end
+
+    it 'returns false when no matching config item is found' do
+      config_data = [{ key: 'other_key', value: 'other_value' }]
+      expect(provider).to receive(:parse_config).and_return(config_data)
+
+      expect(provider.exists?).to be false
+    end
+
+    it 'raises an error when multiple matching config items are found' do
+      config_data = [{ key: 'your_key', value: 'value1' }, { key: 'your_key', value: 'value2' }]
+      expect(provider).to receive(:parse_config).and_return(config_data)
+
+      expect { provider.exists? }.to raise_error(Puppet::Error, 'found multiple config items of your_key, please fix this')
+    end
   end
 
   it 'has a method create' do


### PR DESCRIPTION
I'm not sure how we ended up with ParserError in the
provider. This exception doesn't exist in Ruby.
Puppet ships ther own exception, Puppet::Error. It
probably makes sense to raise that instead.

Fixes https://github.com/bastelfreak/puppetlabs-postgresql/commit/179472ba261a7d0847fdb93fdcb1d43741c4cdde

Alternative implementation for https://github.com/puppetlabs/puppetlabs-postgresql/pull/1538

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)