### PR TITLE
Unconfine postgresql_conf

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -9,7 +9,6 @@
 
 Puppet::Type.type(:postgresql_conf).provide(:ruby) do
   desc 'Set keys, values and comments in a postgresql config file.'
-  confine kernel: 'Linux'
 
   # The function pareses the postgresql.conf and figures out which active settings exist in a config file and returns an array of hashes
   #


### PR DESCRIPTION
Ruby should be available on all platforms (bundled with AIO, and in any
case required to run Puppet), so the provider should be functional
everywhere.

Fixes #1550
