### PR TITLE
support for a custom apt source release

### DIFF
--- a/data/os/Ubuntu/18.04.yaml
+++ b/data/os/Ubuntu/18.04.yaml
@@ -1,0 +1,3 @@
+---
+postgresql::repo::baseurl: https://apt-archive.postgresql.org/pub/repos/apt/
+postgresql::repo::release: "%{facts.os.distro.codename}-pgdg-archive"

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -60,6 +60,7 @@
 #
 # @param repo_baseurl Sets the baseurl for the PostgreSQL repository. Useful if you host your own mirror of the repository.
 # @param yum_repo_commonurl Sets the url for the PostgreSQL common Yum repository. Useful if you host your own mirror of the YUM repository.
+# @param apt_source_release Overrides the default release for the apt source.
 #
 # @param needs_initdb
 #   Explicitly calls the initdb operation after the server package is installed and before the PostgreSQL service is started.
@@ -150,6 +151,7 @@ class postgresql::globals (
   Optional[String[1]] $repo_proxy                  = undef,
   Optional[String[1]] $repo_baseurl                = undef,
   Optional[String[1]] $yum_repo_commonurl          = undef,
+  Optional[String[1]] $apt_source_release          = undef,
 
   Optional[Boolean] $needs_initdb                  = undef,
 
@@ -271,6 +273,7 @@ class postgresql::globals (
       proxy     => $repo_proxy,
       baseurl   => $repo_baseurl,
       commonurl => $yum_repo_commonurl,
+      release   => $apt_source_release,
     }
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,7 @@
 # @api private
 class postgresql::repo (
   Optional[String[1]] $version = undef,
+  Optional[String[1]] $release = undef,
   Optional[String[1]] $proxy = undef,
   Optional[String[1]] $baseurl = undef,
   Optional[String[1]] $commonurl = undef,

--- a/manifests/repo/apt_postgresql_org.pp
+++ b/manifests/repo/apt_postgresql_org.pp
@@ -7,8 +7,10 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
   # http://www.postgresql.org/download/linux/debian/
   #
   $default_baseurl = 'https://apt.postgresql.org/pub/repos/apt/'
-
   $_baseurl = pick($postgresql::repo::baseurl, $default_baseurl)
+
+  $default_release = "${facts['os']['distro']['codename']}-pgdg"
+  $_release = pick($postgresql::repo::release, $default_release)
 
   apt::pin { 'apt_postgresql_org':
     originator => 'apt.postgresql.org',
@@ -16,7 +18,7 @@ class postgresql::repo::apt_postgresql_org inherits postgresql::repo {
   }
   -> apt::source { 'apt.postgresql.org':
     location     => $_baseurl,
-    release      => "${facts['os']['distro']['codename']}-pgdg",
+    release      => $_release,
     repos        => 'main',
     architecture => $facts['os']['architecture'],
     key          => {

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -9,5 +9,28 @@ describe 'postgresql::repo' do
     it 'instantiates apt_postgresql_org class' do
       expect(subject).to contain_class('postgresql::repo::apt_postgresql_org')
     end
+
+    it {
+      is_expected.to contain_apt__source('apt.postgresql.org')
+        .with_location('https://apt.postgresql.org/pub/repos/apt/')
+        .with_release("#{facts[:os]['distro']['codename']}-pgdg")
+    }
+
+    it { is_expected.to contain_apt__pin('apt_postgresql_org') }
+  end
+
+  describe 'with custom baseurl and release' do
+    let(:params) do
+      {
+        baseurl: 'https://apt-archive.postgresql.org/pub/repos/apt/',
+        release: 'bionic-pgdg-archive',
+      }
+    end
+
+    it {
+      is_expected.to contain_apt__source('apt.postgresql.org')
+        .with_location(params[:baseurl])
+        .with_release(params[:release])
+    }
   end
 end


### PR DESCRIPTION
Postgresql no longer specifically supports Ubuntu 18.04, but still supports Debian 10 which can be used until Puppet drops support for Ubuntu 18.04.

## Summary
Postgresql recommends using the Debian buster repo for Ubuntu bionic.

## Additional Context
Temporary until Puppet no longer supports Ubuntu 18.04.

## Related Issues (if any)
https://github.com/voxpupuli/puppet-puppetboard/pull/402

## Checklist
- 🟢 Spec tests.
- 🟢 Acceptance tests.