### PR TITLE
Remove non-portable source commands

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -27,9 +27,7 @@ def export_locales(locale)
   LitmusHelper.instance.run_shell("echo export LANGUAGE=#{locale} >> /etc/profile.d/my-custom.lang.sh")
   LitmusHelper.instance.run_shell('echo export LC_COLLATE=C >> /etc/profile.d/my-custom.lang.sh')
   LitmusHelper.instance.run_shell("echo export LC_CTYPE=#{locale} >> /etc/profile.d/my-custom.lang.sh")
-  LitmusHelper.instance.run_shell('source /etc/profile.d/my-custom.lang.sh')
   LitmusHelper.instance.run_shell('echo export LC_ALL="C" >> ~/.bashrc')
-  LitmusHelper.instance.run_shell('source ~/.bashrc')
 end
 
 def pre_run


### PR DESCRIPTION
`source(1)` is a bashism and is equivalent to the portable `.(1)`, but
as each command is run in a new shell, spawning a shell to source a file
and exit is at best noop.

Some SUT used by acceptance tests do not use bash(1) as the default
shell (e.g. Ubuntu 22.04 ARM), which cause CI failures because
`source` is not found (127 exit code):

```
  1) postgresql task sql task sets up a postgres db
     On host `104.154.182.99'
     Failure/Error: LitmusHelper.instance.run_shell('source /etc/profile.d/my-custom.lang.sh')
     RuntimeError:
       shell failed
       `source /etc/profile.d/my-custom.lang.sh`
       ======
       [{"target"=>"104.154.182.99", "action"=>"command", "object"=>"source /etc/profile.d/my-custom.lang.sh", "status"=>"failure", "value"=>{"stdout"=>"", "stderr"=>"sh: 1: source: not found\n", "merged_output"=>"sh: 1: source: not found\n", "exit_code"=>127, "_error"=>{"kind"=>"puppetlabs.tasks/command-error", "issue_code"=>"COMMAND_ERROR", "msg"=>"The command failed with exit code 127", "details"=>{"exit_code"=>127}}}}]

     # ./vendor/bundle/ruby/2.7.0/gems/puppet_litmus-1.3.0/lib/puppet_litmus/puppet_helpers.rb:206:in `run_shell'
     # ./spec/spec_helper_acceptance_local.rb:30:in `export_locales'
     # ./spec/acceptance/sql_task_spec.rb:17:in `block (3 levels) in <top (required)>'

  2) postgresql task sql task execute some sql
     On host `104.154.182.99'
     Failure/Error:
       result = run_bolt_task('postgresql::sql', 'sql' => 'SELECT count(table_name) FROM information_schema.tables;', 'host' => 'localhost',
                                                 'user' => 'root1', 'password' => 'password', 'database' => 'spec1')
     RuntimeError:
       task failed
       `postgresql::sql`
       ======
       [{"target"=>"104.154.182.99", "action"=>"task", "object"=>"postgresql::sql", "status"=>"failure", "value"=>{"status"=>"failure", "error"=>"psql: error: connection to server at \"localhost\" (127.0.0.1), port 5432 failed: FATAL:  password authentication failed for user \"root1\"\nconnection to server at \"localhost\" (127.0.0.1), port 5432 failed: FATAL:  password authentication failed for user \"root1\"\n", "_error"=>{"kind"=>"puppetlabs.tasks/task-error", "issue_code"=>"TASK_ERROR", "msg"=>"The task failed with exit code 1", "details"=>{"exit_code"=>1}}}}]

     # ./vendor/bundle/ruby/2.7.0/gems/puppet_litmus-1.3.0/lib/puppet_litmus/puppet_helpers.rb:299:in `run_bolt_task'
     # ./spec/acceptance/sql_task_spec.rb:23:in `block (3 levels) in <top (required)>'

Finished in 17 minutes 2 seconds (files took 3.36 seconds to load)
59 examples, 2 failures, 10 pending

Failed examples:

rspec ./spec/acceptance/sql_task_spec.rb:16 # postgresql task sql task sets up a postgres db
rspec ./spec/acceptance/sql_task_spec.rb:21 # postgresql task sql task execute some sql
```

Because we set variables in profile files, assume they are sourced
during shell startup and will be available to next spawned shells.
