### PR TITLE
fix: Fixed typo ParserError

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
   # check, if resource exists in postgresql.conf file
   def exists?
     select = parse_config.select { |hash| hash[:key] == resource[:key] }
-    raise ParserError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
+    raise ParseError, "found multiple config items of #{resource[:key]} found, please fix this" if select.length > 1
     return false if select.empty?
 
     @result = select.first


### PR DESCRIPTION
## Summary
After running into a duplicate config entry I found that this line uses the wrong class to notify about the parser error

## Additional Context
Reproduce: Put a config entry twice into the postgresql conf and try to manage it using this module. => Leads to: 

``` 
Postgresql::Server::Config_entry[max_wal_size]/Postgresql_conf[max_wal_size]: Could not evaluate: uninitialized constant ParserError
Did you mean?  ParseError
```

I didn't run the tests as I just wanted to correct this simple thing. I can do a full checkout and test them if you'd like.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)