### PR TITLE
don't set data_directory in config when we configure it via env

### DIFF
--- a/manifests/server/instance/config.pp
+++ b/manifests/server/instance/config.pp
@@ -219,9 +219,11 @@ define postgresql::server::instance::config (
     }
   }
 
-  postgresql::server::config_entry { "data_directory_for_instance_${name}":
-    key   => 'data_directory',
-    value => $datadir,
+  unless $facts['service_provider'] == 'systemd' and $facts['os']['family'] in ['RedHat', 'Gentoo'] {
+    postgresql::server::config_entry { "data_directory_for_instance_${name}":
+      key   => 'data_directory',
+      value => $datadir,
+    }
   }
   if $timezone {
     postgresql::server::config_entry { "timezone_for_instance_${name}":

--- a/spec/defines/server_instance_spec.rb
+++ b/spec/defines/server_instance_spec.rb
@@ -123,7 +123,6 @@ describe 'postgresql::server_instance' do
     it { is_expected.to contain_postgresql_conn_validator('validate_service_is_running_instance_test1') }
     it { is_expected.to contain_postgresql_conf('port_for_instance_test1') }
     it { is_expected.to contain_postgresql_conf('log_statement_stats_test1') }
-    it { is_expected.to contain_postgresql_conf('data_directory_for_instance_test1') }
     it { is_expected.to contain_postgresql_conf('autovacuum_vacuum_scale_factor_test1') }
     it { is_expected.to contain_postgresql_conf('authentication_timeout_test1') }
     it { is_expected.to contain_postgresql__server__role('app_test1') }
@@ -159,7 +158,6 @@ describe 'postgresql::server_instance' do
     it { is_expected.to contain_file('/opt/pgsql') }
     it { is_expected.to contain_postgresql__server__config_entry('authentication_timeout_test1') }
     it { is_expected.to contain_postgresql__server__config_entry('autovacuum_vacuum_scale_factor_test1') }
-    it { is_expected.to contain_postgresql__server__config_entry('data_directory_for_instance_test1') }
     it { is_expected.to contain_postgresql__server__config_entry('log_statement_stats_test1') }
     it { is_expected.to contain_postgresql__server__config_entry('password_encryption_for_instance_test1') }
     it { is_expected.to contain_postgresql__server__config_entry('port_for_instance_test1') }


### PR DESCRIPTION
Fixes: #1576

## Summary
see subject and linked issue

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
#1576

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)