### PR TITLE
Add Fedora 39 support

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -180,7 +180,7 @@ class postgresql::globals (
   $default_version = $facts['os']['family'] ? {
     /^(RedHat|Linux)/ => $facts['os']['name'] ? {
       'Fedora' => $facts['os']['release']['major'] ? {
-        /^(38)$/       => '15',
+        /^(38|39)$/    => '15',
         /^(36|37)$/    => '14',
         /^(34|35)$/    => '13',
         /^(32|33)$/    => '12',


### PR DESCRIPTION
## Summary
Added default PostreSQL version for Fedora 39

## Additional Context
Add any additional context about the problem here. 
- [n/a] Root cause and the steps to reproduce. (If applicable)
- [n/a] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [n/a] 🟢 Spec tests.
- [n/a] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)