### PR TITLE
Support Ubuntu 24.04 and postgis for postgresql 16

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -211,6 +211,7 @@ class postgresql::globals (
         /^(20.04)$/ => '12',
         /^(21.04|21.10)$/ => '13',
         /^(22.04)$/ => '14',
+        /^(24.04)$/ => '16',
         default => undef,
       },
       default => undef,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -260,6 +260,7 @@ class postgresql::globals (
     '10'    => '2.4',
     '11'    => '3.0',
     '12'    => '3.0',
+    '16'    => '3.4',
     default => undef,
   }
   $globals_postgis_version = $postgis_version ? {


### PR DESCRIPTION
## Summary
Add support the upcoming Ubuntu version 24.04 ("Noble Numbat").
Ubuntu 24.04 comes with PostgreSQL version 16.2 and  postgis version 3.4. 


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)