### PR TITLE
Use RequiresMountsFor on datadir

### DIFF
--- a/templates/systemd-override.conf.epp
+++ b/templates/systemd-override.conf.epp
@@ -3,6 +3,9 @@
   Stdlib::Absolutepath             $datadir,
   Optional[String[1]]              $extra_systemd_config,
 | -%>
+[Unit]
+RequiresMountsFor=<%= $datadir %>
+
 [Service]
 Environment=PGPORT=<%= $port %>
 <%- if $facts['os']['family'] == 'Gentoo' { -%>


### PR DESCRIPTION
It is quite common for the data directory to be on its own mount.  Systemd can ensure a directory is mounted before a service starts using [RequiresMountsFor](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#RequiresMountsFor=):

> Takes a space-separated list of absolute paths. Automatically adds dependencies of type Requires= and After= for all mount units required to access the specified path.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)