### PR TITLE
Add a global password_encryption parameter

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -81,6 +81,10 @@
 # @param timezone
 #   Sets the default timezone of the postgresql server. The postgresql built-in default is taking the systems timezone information.
 #
+# @param password_encryption
+#   Specify the type of encryption set for the password.
+#   Defaults to scram-sha-256 for PostgreSQL >= 14, otherwise md5.
+#
 # @param manage_pg_hba_conf Allow Puppet to manage the pg_hba.conf file.
 # @param manage_pg_ident_conf Allow Puppet to manage the pg_ident.conf file.
 # @param manage_recovery_conf Allow Puppet to manage the recovery.conf file.
@@ -159,6 +163,7 @@ class postgresql::globals (
   Optional[String[1]] $locale                      = undef,
   Optional[Boolean] $data_checksums                = undef,
   Optional[String[1]] $timezone                    = undef,
+  Optional[Postgresql::Pg_password_encryption] $password_encryption = undef,
 
   Optional[Boolean] $manage_pg_hba_conf            = undef,
   Optional[Boolean] $manage_pg_ident_conf          = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_selinux               = pick($manage_selinux, false)
   $package_ensure               = 'present'
   $module_workdir               = pick($module_workdir,'/tmp')
-  $password_encryption          = versioncmp($version, '14') ? { -1 => 'md5', default => 'scram-sha-256' }
+  $password_encryption          = pick($password_encryption, versioncmp($version, '14') ? { -1 => 'md5', default => 'scram-sha-256' })
   $extra_systemd_config         = undef
   $manage_datadir               = true
   $manage_logdir                = true

--- a/spec/functions/postgresql_default_spec.rb
+++ b/spec/functions/postgresql_default_spec.rb
@@ -30,5 +30,19 @@ describe 'postgresql::default' do
   # parameter in globals.pp only
   it { is_expected.to run.with_params('default_connect_settings').and_return({}) }
 
+  it { is_expected.to run.with_params('password_encryption').and_return('md5') }
+
   it { is_expected.to run.with_params('a_parameter_that_does_not_exist').and_raise_error(Puppet::ParseError, %r{pick\(\): must receive at least one non empty value}) }
+
+  context 'with overridden values' do
+    let(:pre_condition) do
+      <<~PUPPET
+      class { 'postgresql::globals':
+        password_encryption => 'scram-sha-256',
+      }
+      PUPPET
+    end
+
+    it { is_expected.to run.with_params('password_encryption').and_return('scram-sha-256') }
+  end
 end


### PR DESCRIPTION
## Summary

The function postgresql::password() looks at the default for encryption. If you want to use SCRAM on PostgreSQL < 14 then the default must be overridden, or specified for every use. This parameter allows it to be globally overridden.

## Related Issues (if any)

Found in https://github.com/theforeman/foreman-installer/pull/924 when testing out SCRAM support with PostgreSQL 13.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)