### PR TITLE
.fixtures.yml: unpin puppet_agent dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
+---
 fixtures:
   repositories:
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
@@ -7,9 +8,7 @@ fixtures:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
     provision: "https://github.com/puppetlabs/provision.git"
-    puppet_agent:
-      repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.13.0
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     yumrepo_core: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
     systemd: "https://github.com/voxpupuli/puppet-systemd.git"


### PR DESCRIPTION
pinning in .fixtures.yml is an antipattern and should be avoided. Best practice in the ecosystem is that modules pull in the main/HEAD branch of their dependencies via .fixtures.yml and in acceptance tests actual releases via metadata.json are/should be used.