### PR TITLE
allow puppet-systemd version 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 4.0.1 < 7.0.0"
+      "version_requirement": ">= 4.0.1 < 8.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
## Summary
Update dependency puppet-systemd to allow newer version


## Related Issues (if any)
Blocking https://github.com/voxpupuli/puppet-jira/pull/423

Fixes: #1594.

