### PR TITLE
Add a fact for installed postgres version

### DIFF
--- a/lib/facter/postgres_version.rb
+++ b/lib/facter/postgres_version.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Facter.add('postgres_version') do
+  confine { Facter::Core::Execution.which('postgres') }
+  setcode do
+    version = Facter::Core::Execution.execute('postgres -V 2>/dev/null')
+    version.match(%r{\d+\.\d+$})[0] if version
+  end
+end

--- a/spec/unit/facter/postgres_version_spec.rb
+++ b/spec/unit/facter/postgres_version_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Facter::Util::Fact.to_s do
+  before(:each) do
+    Facter.clear
+  end
+
+  describe 'postgres_version' do
+    context 'with value' do
+      before :each do
+        allow(Facter::Core::Execution).to receive(:which).and_return('/usr/bin/postgres')
+        allow(Facter::Core::Execution).to receive(:execute).with('postgres -V 2>/dev/null').and_return('postgres (PostgreSQL) 10.0')
+      end
+
+      it 'postgres_version' do
+        expect(Facter.fact(:postgres_version).value).to eq('10.0')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
There is sometimes a need to handle versions differently.  (The last exampel for us being deciding whether to monitor the stats collector process.)  This fact provides a basis for writing such code.

## Checklist
- [X] 🟢 `pdk validate`
- [X] 🟢 `pdk test unit`