### PR TITLE
define Enum on supported encryption types for postgresql_password

### DIFF
--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -24,7 +24,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     required_param 'Variant[String[1], Integer]', :username
     required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
     optional_param 'Boolean', :sensitive
-    optional_param 'Optional[Postgresql::Pg_password_encryption]', :hash
+    optional_param 'Optional[Enum["md5", "scram-sha-256"]]', :hash
     optional_param 'Optional[Variant[String[1], Integer]]', :salt
     return_type 'Variant[String, Sensitive[String]]'
   end

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -24,6 +24,8 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
     required_param 'Variant[String[1], Integer]', :username
     required_param 'Variant[String[1], Sensitive[String[1]], Integer]', :password
     optional_param 'Boolean', :sensitive
+    # Note that this Enum is also defined in:
+    # types/pg_password_encryption.pp
     optional_param 'Optional[Enum["md5", "scram-sha-256"]]', :hash
     optional_param 'Optional[Variant[String[1], Integer]]', :salt
     return_type 'Variant[String, Sensitive[String]]'

--- a/spec/acceptance/db_deferred_spec.rb
+++ b/spec/acceptance/db_deferred_spec.rb
@@ -2,45 +2,32 @@
 
 require 'spec_helper_acceptance'
 
-describe 'postgresql::server::db' do
-  before(:all) do
-    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
-  end
+describe 'postgresql::server::db:' do
+  let(:user) { 'user_test' }
+  let(:password) { 'deferred_password_test' }
+  let(:database) { 'test_database' }
 
-  it 'creates a database with a deferred password' do
-    tmpdir = run_shell('mktemp').stdout
-    pp = <<-MANIFEST
-      class { 'postgresql::server':
-        postgres_password => 'space password',
-      }
-      postgresql::server::tablespace { 'postgresql-test-db':
-        location => '#{tmpdir}',
-      } ->
-      postgresql::server::db { 'postgresql-test-db':
-        comment    => 'testcomment',
-        user       => 'test-user',
-        password   => Deferred('unwrap', ['test1'])
-        tablespace => 'postgresql-test-db',
+  let(:pp_one) do
+    <<-MANIFEST.unindent
+      $user = #{user}
+      $password = #{password}
+      $database = #{database}
+
+      include postgresql::server
+      postgresql::server::db { $database:
+         user     => $user,
+         password => Deferred('unwrap', [$password]),
       }
     MANIFEST
+  end
 
-    idempotent_apply(pp)
-
-    # Verify that the postgres password works
-    run_shell("echo 'localhost:*:*:postgres:'space password'' > /root/.pgpass")
-    run_shell('chmod 600 /root/.pgpass')
-    run_shell("psql -U postgres -h localhost --command='\\l'")
-
-    result = psql('--command="select datname from pg_database" "postgresql-test-db"')
-    expect(result.stdout).to match(%r{postgresql-test-db})
-    expect(result.stderr).to eq('')
-
-    result = psql('--command="SELECT 1 FROM pg_roles WHERE rolname=\'test-user\'"')
-    expect(result.stdout).to match(%r{\(1 row\)})
-
-    result = psql("--dbname postgresql-test-db --command=\"SELECT pg_catalog.shobj_description(d.oid, 'pg_database') FROM pg_catalog.pg_database d WHERE datname = 'postgresql-test-db' AND pg_catalog.shobj_description(d.oid, 'pg_database') = 'testcomment'\"") # rubocop:disable Layout/LineLength
-    expect(result.stdout).to match(%r{\(1 row\)})
-  ensure
-    psql('--command=\'drop database "postgresql-test-db"\'')
+  it 'creates a database with with the password in the deferred function' do
+    if run_shell('puppet --version').stdout[0].to_i < 7
+      skip # Deferred function fixes only in puppet 7, see https://tickets.puppetlabs.com/browse/PUP-11518
+    end
+    apply_manifest(pp_one)
+    psql_cmd = "PGPASSWORD=#{password} PGUSER=#{user} PGDATABASE=#{database} psql -h 127.0.0.1 -d postgres -c '\\q'"
+    run_shell("cd /tmp; su #{shellescape('postgres')} -c #{shellescape(psql_cmd)}",
+              acceptable_exit_codes: [0])
   end
 end

--- a/spec/acceptance/db_deferred_spec.rb
+++ b/spec/acceptance/db_deferred_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'postgresql::server::db' do
+  before(:all) do
+    LitmusHelper.instance.run_shell("cd /tmp; su 'postgres' -c 'pg_ctl stop -D /var/lib/pgsql/data/ -m fast'", acceptable_exit_codes: [0, 1]) unless os[:family].match?(%r{debian|ubuntu})
+  end
+
+  it 'creates a database with a deferred password' do
+    tmpdir = run_shell('mktemp').stdout
+    pp = <<-MANIFEST
+      class { 'postgresql::server':
+        postgres_password => 'space password',
+      }
+      postgresql::server::tablespace { 'postgresql-test-db':
+        location => '#{tmpdir}',
+      } ->
+      postgresql::server::db { 'postgresql-test-db':
+        comment    => 'testcomment',
+        user       => 'test-user',
+        password   => Deferred('unwrap', ['test1'])
+        tablespace => 'postgresql-test-db',
+      }
+    MANIFEST
+
+    idempotent_apply(pp)
+
+    # Verify that the postgres password works
+    run_shell("echo 'localhost:*:*:postgres:'space password'' > /root/.pgpass")
+    run_shell('chmod 600 /root/.pgpass')
+    run_shell("psql -U postgres -h localhost --command='\\l'")
+
+    result = psql('--command="select datname from pg_database" "postgresql-test-db"')
+    expect(result.stdout).to match(%r{postgresql-test-db})
+    expect(result.stderr).to eq('')
+
+    result = psql('--command="SELECT 1 FROM pg_roles WHERE rolname=\'test-user\'"')
+    expect(result.stdout).to match(%r{\(1 row\)})
+
+    result = psql("--dbname postgresql-test-db --command=\"SELECT pg_catalog.shobj_description(d.oid, 'pg_database') FROM pg_catalog.pg_database d WHERE datname = 'postgresql-test-db' AND pg_catalog.shobj_description(d.oid, 'pg_database') = 'testcomment'\"") # rubocop:disable Layout/LineLength
+    expect(result.stdout).to match(%r{\(1 row\)})
+  ensure
+    psql('--command=\'drop database "postgresql-test-db"\'')
+  end
+end

--- a/types/pg_password_encryption.pp
+++ b/types/pg_password_encryption.pp
@@ -1,2 +1,4 @@
 # @summary the supported password_encryption
+# Note that this Enum is also defined in:
+# lib/puppet/functions/postgresql/postgresql_password.rb
 type Postgresql::Pg_password_encryption = Enum['md5', 'scram-sha-256']


### PR DESCRIPTION
## Summary
This PR fixes [1575](https://github.com/puppetlabs/puppetlabs-postgresql/issues/1575)

## Additional Context

## Related Issues (if any)

## Checklist
I was hitting [1575](https://github.com/puppetlabs/puppetlabs-postgresql/issues/1575) when using a Deferred password. With this fix, puppet creates the database as before (v9.2.0)

```
postgresql::server::db { $db_name:
      user     => $db_username,
      password => Deferred('unwrap', [$db_password]),
}
```