### PR TITLE
Remove upstream-breaking REVOKE CONNECT * FROM public

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -52,7 +52,6 @@ define postgresql::server::database (
     undef   => '',
     default => "LC_COLLATE = '${locale}' LC_CTYPE = '${locale}'",
   }
-  $public_revoke_privilege = 'CONNECT'
 
   $template_option = $template ? {
     undef   => '',
@@ -73,12 +72,6 @@ define postgresql::server::database (
     command => "CREATE DATABASE \"${dbname}\" WITH ${template_option} ${encoding_option} ${locale_option} ${tablespace_option}",
     unless  => "SELECT 1 FROM pg_database WHERE datname = '${dbname}'",
     require => Postgresql::Server::Instance::Service[$instance],
-  }
-
-  # This will prevent users from connecting to the database unless they've been
-  #  granted privileges.
-  ~> postgresql_psql { "REVOKE ${public_revoke_privilege} ON DATABASE \"${dbname}\" FROM public":
-    refreshonly => true,
   }
 
   Postgresql_psql["CREATE DATABASE \"${dbname}\""]


### PR DESCRIPTION
The default installation of Pg allows public to connect - given proper pg_hba entries. The REVOKE subltely breaks expected usage.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)