### PR TITLE
added default version for fedora 40 and 41

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -180,6 +180,7 @@ class postgresql::globals (
   $default_version = $facts['os']['family'] ? {
     /^(RedHat|Linux)/ => $facts['os']['name'] ? {
       'Fedora' => $facts['os']['release']['major'] ? {
+        /^(40|41)$/    => '16',
         /^(38|39)$/    => '15',
         /^(36|37)$/    => '14',
         /^(34|35)$/    => '13',


### PR DESCRIPTION
## Summary
added default version for fedora 40 and 41

## Checklist
- [n/a] 🟢 Spec tests.
- [n/a] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)