### PR TITLE
Role Valid Until Date

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -11,6 +11,7 @@
 # @param inherit Specifies whether to grant inherit capability for the new role.
 # @param superuser Specifies whether to grant super user capability for the new role.
 # @param replication Provides provides replication capabilities for this role if set to true.
+# @param valid_until Specifies whether to set a valid until date for the role.
 # @param connection_limit Specifies how many concurrent connections the role can make. Default value: '-1', meaning no limit.
 # @param username Defines the username of the role to create.
 # @param connect_settings Specifies a hash of environment variables used when connecting to a remote server.

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -35,6 +35,7 @@ define postgresql::server::role (
   Boolean                                     $inherit          = true,
   Boolean                                     $superuser        = false,
   Boolean                                     $replication      = false,
+  Optional[String[1]]                         $valid_until      = undef,
   String[1]                                   $connection_limit = '-1',
   String[1]                                   $username         = $title,
   Hash                                        $connect_settings = $postgresql::server::default_connect_settings,
@@ -124,6 +125,12 @@ define postgresql::server::role (
 
     postgresql_psql { "ALTER ROLE \"${username}\" ${inherit_sql}":
       unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolinherit = ${inherit}",
+    }
+
+    if $valid_until {
+      postgresql_psql { "ALTER ROLE \"${username}\" VALID UNTIL '${valid_until}'":
+        unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolvaliduntil = '${valid_until}'",
+      }
     }
 
     if(versioncmp($version, '9.1') >= 0) {

--- a/spec/defines/server_instance_spec.rb
+++ b/spec/defines/server_instance_spec.rb
@@ -73,7 +73,9 @@ describe 'postgresql::server_instance' do
                  'app_test1': { 'login' => true },
                  'rep_test1': { 'replication' => true,
                                 'login' => true },
-                 'rou_test1': { 'login' => true }, },
+                 'rou_test1': { 'login' => true },
+                 'val_test1': { 'login' => true,
+                                'valid_until' => '2030-01-01 00:00:00+00' }, },
       'pg_hba_rules': { 'local all INSTANCE user': { 'type' => 'local',
                                                      'database' => 'all',
                                                      'user' => 'ins_test1',
@@ -214,10 +216,19 @@ describe 'postgresql::server_instance' do
     it { is_expected.to contain_postgresql_psql('ALTER ROLE "rou_test1" NOCREATEROLE') }
     it { is_expected.to contain_postgresql_psql('ALTER ROLE "rou_test1" NOREPLICATION') }
     it { is_expected.to contain_postgresql_psql('ALTER ROLE "rou_test1" NOSUPERUSER') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" CONNECTION LIMIT -1') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" INHERIT') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" LOGIN') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" NOCREATEDB') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" NOCREATEROLE') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" NOREPLICATION') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" NOSUPERUSER') }
+    it { is_expected.to contain_postgresql_psql('ALTER ROLE "val_test1" VALID UNTIL \'2030-01-01 00:00:00+00\'') }
     it { is_expected.to contain_postgresql_psql('CREATE ROLE app_test1 ENCRYPTED PASSWORD ****') }
     it { is_expected.to contain_postgresql_psql('CREATE ROLE dba_test1 ENCRYPTED PASSWORD ****') }
     it { is_expected.to contain_postgresql_psql('CREATE ROLE ins_test1 ENCRYPTED PASSWORD ****') }
     it { is_expected.to contain_postgresql_psql('CREATE ROLE rep_test1 ENCRYPTED PASSWORD ****') }
     it { is_expected.to contain_postgresql_psql('CREATE ROLE rou_test1 ENCRYPTED PASSWORD ****') }
+    it { is_expected.to contain_postgresql_psql('CREATE ROLE val_test1 ENCRYPTED PASSWORD ****') }
   end
 end


### PR DESCRIPTION
## Summary
I have a requirement to set valid until dates for roles that I need to manage via this puppet postgresql module. This change adds support for setting a `valid_until` attribute for a role.

## Related Issues (if any)
None

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)