### PR TITLE
#1639 - fix - unless check in postgresql::server::instance::passwd do…

### DIFF
--- a/manifests/server/instance/passwd.pp
+++ b/manifests/server/instance/passwd.pp
@@ -60,7 +60,7 @@ define postgresql::server::instance::passwd (
       # environment variable. If the password is correct (current), this
       # command will exit with an exit code of 0, which will prevent the main
       # command from running.
-      unless      => "${psql_path} -h localhost -p ${port} -c 'select 1' > /dev/null",
+      unless      => "${shell_escape($psql_path)}${_dboption} -h localhost -p ${port} -c 'select 1' > /dev/null",
       path        => '/usr/bin:/usr/local/bin:/bin',
     }
   }


### PR DESCRIPTION
## Summary
This pull request updates the `unless` check in the `postgresql::server::instance::passwd` define to include the `${_dboption}` variable. This ensures that the `unless` command connects to the correct database, especially when the database name differs from the user name. Previously, the `unless` check always connected to the default database (matching the user), which could cause the password check to run against the wrong database and result in unnecessary or skipped password changes.

## Additional Context
- **Root cause and steps to reproduce:**  
  The root cause was that the `unless` command did not include the `--dbname` option when the database name was different from the user name.  
  **Steps to reproduce:**  
  1. Set up a PostgreSQL instance where the database name is different from the user name.  
  2. Apply the Puppet manifest to set the postgres password.  
  3. Observe that the password check may not work as intended, causing the password to be reset unnecessarily or not at all.
- **Thought process behind the implementation:**  
  The fix reuses the existing `${_dboption}` logic, which is already used in the main password change command, to ensure both commands operate on the intended database. This improves consistency and reliability for environments where the database and user names differ.

## Related Issues
Fixes: #1639 
Related: -

## Checklist
- [X] Manually verified. (For example `puppet apply`)