### PR TITLE
add EL10 basic support - align EL10 PGSQL 16 default package version

### DIFF
--- a/manifests/dnfmodule.pp
+++ b/manifests/dnfmodule.pp
@@ -9,6 +9,9 @@ class postgresql::dnfmodule (
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $ensure = 'installed',
   String[1] $module = 'postgresql',
 ) {
+  if $facts['os']['release']['major'] == '10' {
+    fail('DNF modules are not supported on EL 10')
+  }
   package { 'postgresql dnf module':
     ensure      => $ensure,
     name        => $module,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -199,6 +199,7 @@ class postgresql::globals (
       },
       'Amazon' => '9.2',
       default => $facts['os']['release']['major'] ? {
+        '10'    => '16',
         '9'     => '13',
         '8'     => '10',
         '7'     => '9.2',

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -39,14 +40,16 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -84,14 +87,16 @@
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],

--- a/spec/acceptance/server_instance_spec.rb
+++ b/spec/acceptance/server_instance_spec.rb
@@ -3,7 +3,7 @@
 # run a test task
 require 'spec_helper_acceptance'
 
-describe 'postgresql instance test1', if: os[:family] == 'redhat' && !os[:release].start_with?('7') do
+describe 'postgresql instance test1', if: os[:family] == 'redhat' && os[:release].to_i.between?(8,9) do
   pp = <<-MANIFEST
   # set global defaults
   class { 'postgresql::globals':

--- a/spec/acceptance/server_instance_spec.rb
+++ b/spec/acceptance/server_instance_spec.rb
@@ -3,7 +3,7 @@
 # run a test task
 require 'spec_helper_acceptance'
 
-describe 'postgresql instance test1', if: os[:family] == 'redhat' && os[:release].to_i.between?(8,9) do
+describe 'postgresql instance test1', if: os[:family] == 'redhat' && os[:release].to_i.between?(8, 9) do
   pp = <<-MANIFEST
   # set global defaults
   class { 'postgresql::globals':


### PR DESCRIPTION
## Summary
single commit adding version alignment to EL10 default postgresql 16 package versions

## Additional Context
Add any additional context about the problem here. 

Continuation of existing pattern to support OS version -> default PGSQL packages

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [X] 🟢 Spec tests.
- [ X] 🟢 Acceptance tests.
- [ x] Manually verified. (For example `puppet apply`)
- [x] puppet-lint 