### PR TITLE
Fix passing deferred password

### DIFF
--- a/lib/puppet/functions/postgresql/prepend_sql_password.rb
+++ b/lib/puppet/functions/postgresql/prepend_sql_password.rb
@@ -10,6 +10,6 @@ Puppet::Functions.create_function(:'postgresql::prepend_sql_password') do
   end
   def default_impl(password)
     password = password.unwrap if password.respond_to?(:unwrap)
-    "ENCRYPTED PASSWORD '#{password}'"
+    "ENCRYPTED PASSWORD '#{password.gsub("'", "''")}'"
   end
 end

--- a/lib/puppet/functions/postgresql/prepend_sql_password.rb
+++ b/lib/puppet/functions/postgresql/prepend_sql_password.rb
@@ -5,10 +5,11 @@ Puppet::Functions.create_function(:'postgresql::prepend_sql_password') do
   # @param password
   #   The clear text `password`
   dispatch :default_impl do
-    required_param 'String', :password
+    required_param 'Variant[String, Sensitive[String]]', :password
     return_type 'String'
   end
   def default_impl(password)
+    password = password.unwrap if password.respond_to?(:unwrap)
     "ENCRYPTED PASSWORD '#{password}'"
   end
 end

--- a/manifests/server/db.pp
+++ b/manifests/server/db.pp
@@ -17,7 +17,7 @@
 # @param instance The name of the Postgresql database instance.
 define postgresql::server::db (
   String[1]                                    $user,
-  Optional[Variant[String, Sensitive[String]]] $password   = undef,
+  Optional[Variant[String, Sensitive]]         $password   = undef,
   Optional[String[1]]                          $comment    = undef,
   String[1]                                    $dbname     = $title,
   Optional[String[1]]                          $encoding   = $postgresql::server::encoding,

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -27,7 +27,7 @@
 # @param instance The name of the Postgresql database instance.
 define postgresql::server::role (
   Boolean                                     $update_password  = true,
-  Variant[Boolean, String, Sensitive[String]] $password_hash    = false,
+  Variant[Boolean, String, Sensitive]         $password_hash    = false,
   Boolean                                     $createdb         = false,
   Boolean                                     $createrole       = false,
   String[1]                                   $db               = $postgresql::server::default_database,

--- a/spec/acceptance/db_deferred_spec.rb
+++ b/spec/acceptance/db_deferred_spec.rb
@@ -16,7 +16,7 @@ describe 'postgresql::server::db' do
       include postgresql::server
       postgresql::server::db { $database:
          user     => $user,
-         password => Deferred('unwrap', [Sensitive.new($password)]),
+         password => Deferred('new', [Sensitive, 'password']),
       }
     MANIFEST
   end

--- a/spec/acceptance/db_deferred_spec.rb
+++ b/spec/acceptance/db_deferred_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'postgresql::server::db:' do
+describe 'postgresql::server::db' do
   let(:user) { 'user_test' }
   let(:password) { 'deferred_password_test' }
   let(:database) { 'test_database' }
@@ -16,7 +16,7 @@ describe 'postgresql::server::db:' do
       include postgresql::server
       postgresql::server::db { $database:
          user     => $user,
-         password => Deferred('unwrap', [$password]),
+         password => Deferred('unwrap', [Sensitive.new($password)]),
       }
     MANIFEST
   end

--- a/spec/acceptance/db_deferred_spec.rb
+++ b/spec/acceptance/db_deferred_spec.rb
@@ -16,7 +16,7 @@ describe 'postgresql::server::db' do
       include postgresql::server
       postgresql::server::db { $database:
          user     => $user,
-         password => Deferred('new', [Sensitive, 'password']),
+         password => Deferred('new', [Sensitive, $password]),
       }
     MANIFEST
   end

--- a/spec/functions/postgresql_prepend_sql_password_spec.rb
+++ b/spec/functions/postgresql_prepend_sql_password_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'postgresql::prepend_sql_password' do
+  context 'with a plain string password' do
+    it 'prepends ENCRYPTED PASSWORD to a simple string' do
+      expect(subject).to run.with_params('mypassword')
+                            .and_return("ENCRYPTED PASSWORD 'mypassword'")
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to a password with special characters' do
+      expect(subject).to run.with_params('p@ssw0rd!#$')
+                            .and_return('ENCRYPTED PASSWORD \'p@ssw0rd!#$\'')
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to an empty string' do
+      expect(subject).to run.with_params('')
+                            .and_return("ENCRYPTED PASSWORD ''")
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to a password with quotes' do
+      expect(subject).to run.with_params("pass'word")
+                            .and_return("ENCRYPTED PASSWORD 'pass'word'")
+    end
+  end
+
+  context 'with a Sensitive[String] password' do
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string' do
+      expect(subject).to run.with_params(sensitive('secretpassword'))
+                            .and_return("ENCRYPTED PASSWORD 'secretpassword'")
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string with special characters' do
+      expect(subject).to run.with_params(sensitive('s3cr3t!@#$%'))
+                            .and_return('ENCRYPTED PASSWORD \'s3cr3t!@#$%\'')
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to an empty sensitive string' do
+      expect(subject).to run.with_params(sensitive(''))
+                            .and_return("ENCRYPTED PASSWORD ''")
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string with quotes' do
+      expect(subject).to run.with_params(sensitive("sec'ret"))
+                            .and_return("ENCRYPTED PASSWORD 'sec'ret'")
+    end
+  end
+
+  context 'with invalid input' do
+    it 'raises an error when called without parameters' do
+      expect(subject).to run.with_params
+                            .and_raise_error(ArgumentError)
+    end
+
+    it 'raises an error when called with too many parameters' do
+      expect(subject).to run.with_params('password', 'extra')
+                            .and_raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/functions/postgresql_prepend_sql_password_spec.rb
+++ b/spec/functions/postgresql_prepend_sql_password_spec.rb
@@ -21,7 +21,7 @@ describe 'postgresql::prepend_sql_password' do
 
     it 'prepends ENCRYPTED PASSWORD to a password with quotes' do
       expect(subject).to run.with_params("pass'word")
-                            .and_return("ENCRYPTED PASSWORD 'pass'word'")
+                            .and_return("ENCRYPTED PASSWORD 'pass''word'")
     end
   end
 
@@ -43,7 +43,7 @@ describe 'postgresql::prepend_sql_password' do
 
     it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string with quotes' do
       expect(subject).to run.with_params(sensitive("sec'ret"))
-                            .and_return("ENCRYPTED PASSWORD 'sec'ret'")
+                            .and_return("ENCRYPTED PASSWORD 'sec''ret'")
     end
   end
 


### PR DESCRIPTION
## Summary

I'm getting a strange error when passing `Deferred` object to `password_hash` or `password`:
```
parameter 'password_hash' expects a value of type Boolean, String, or Sensitive[String], got Sensitive
```
Changes done in #1611 weren't enough.

## Additional Context

Tested on Puppet `8.10.0`, I'm unable to compile catalog with `Deferred` secret returned from a function.

I have a function that returns `Deferred` object
```puppet
function vault::kv(String $key, Hash $opts = {}) >> Deferred {
  Deferred(
    'vault_lookup::lookup',
    ["kv/data/${key}", $_opts]
  )
}
```
Since it's not possible to specify type for `Deferred` object, like `Deferred[String]` or `Deferred[Sensitive[String]]` to only workaround remains relaxing `Sensitive[String]` to `Sensitive`

```puppet
    postgresql::server::db { 'mydb':
      user     => 'dbuser',
      password => vault::kv('db/password'),
    }
```

## Related Issues (if any)

- https://github.com/puppetlabs/puppetlabs-concat/pull/824
- https://github.com/OpenVoxProject/openvox/issues/189
- https://github.com/puppetlabs/puppet/issues/9174

## Checklist
- [ ] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)