### PR TITLE
Replace systemctl `status` with systemctl `is-active`

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,7 +86,7 @@ class postgresql::params inherits postgresql::globals {
       }
 
       $service_reload = "systemctl reload ${service_name}"
-      $service_status = pick($service_status, "systemctl status ${service_name}")
+      $service_status = pick($service_status, "systemctl is-active --quiet ${service_name}")
 
       $psql_path           = pick($psql_path, "${bindir}/psql")
 
@@ -130,7 +130,7 @@ class postgresql::params inherits postgresql::globals {
       $confdir                = pick($confdir, $datadir)
       $psql_path              = pick($psql_path, "${bindir}/psql")
 
-      $service_status         = pick($service_status, "systemctl status ${service_name}")
+      $service_status         = pick($service_status, "systemctl is-active --quiet ${service_name}")
       $service_reload         = "systemctl reload ${service_name}"
       $python_package_name    = pick($python_package_name, 'python-psycopg2')
       # Archlinux does not have a perl::DBD::Pg package
@@ -173,7 +173,7 @@ class postgresql::params inherits postgresql::globals {
       $datadir                = pick($datadir, "/var/lib/postgresql/${version}/main")
       $confdir                = pick($confdir, "/etc/postgresql/${version}/main")
       $service_reload         = "systemctl reload ${service_name}"
-      $service_status         = pick($service_status, "systemctl status ${service_name}")
+      $service_status         = pick($service_status, "systemctl is-active --quiet ${service_name}")
       $psql_path              = pick($psql_path, '/usr/bin/psql')
       $postgresql_conf_mode   = pick($postgresql_conf_mode, '0644')
     }
@@ -194,7 +194,7 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, "/usr/lib/postgresql-${version}/bin")
       $datadir              = pick($datadir, "/var/lib/postgresql/${version}_data")
       $confdir              = pick($confdir, "/etc/postgresql-${version}")
-      $service_status       = pick($service_status, "systemctl status ${service_name}")
+      $service_status       = pick($service_status, "systemctl is-active --quiet ${service_name}")
       $service_reload       = "systemctl reload ${service_name}"
       $psql_path            = pick($psql_path, "${bindir}/psql")
 
@@ -267,7 +267,7 @@ class postgresql::params inherits postgresql::globals {
       $bindir               = pick($bindir, "/usr/lib/postgresql${version}/bin")
       $datadir              = pick($datadir, '/var/lib/pgsql/data')
       $confdir              = pick($confdir, $datadir)
-      $service_status       = pick($service_status, "systemctl status ${service_name}")
+      $service_status       = pick($service_status, "systemctl is-active --quiet ${service_name}")
       $service_reload       = "systemctl reload ${service_name}"
       $psql_path            = pick($psql_path, "${bindir}/psql")
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -130,7 +130,7 @@ class postgresql::server (
   Boolean                                            $service_restart_on_change    = $postgresql::params::service_restart_on_change,
   Optional[String[1]]                                $service_provider             = $postgresql::params::service_provider,
   String[1]                                          $service_reload               = $postgresql::params::service_reload,
-  Optional[String[1]]                                $service_status               = $postgresql::params::service_status,
+  Optional[Variant[Array[String[1]],String[1]]]      $service_status               = $postgresql::params::service_status,
   String[1]                                          $default_database             = $postgresql::params::default_database,
   Hash                                               $default_connect_settings     = $postgresql::globals::default_connect_settings,
   Optional[Variant[String[1], Array[String[1]]]]     $listen_addresses             = $postgresql::params::listen_addresses,

--- a/spec/acceptance/server_instance_spec.rb
+++ b/spec/acceptance/server_instance_spec.rb
@@ -46,7 +46,7 @@ describe 'postgresql instance test1', if: os[:family] == 'redhat' && !os[:releas
     },
     service_settings     => {
       'service_name'   => 'postgresql@13-test1',
-      'service_status' => 'systemctl status postgresql@13-test1.service',
+      'service_status' => 'systemctl is-active --quiet postgresql@13-test1.service',
       'service_ensure' => 'running',
       'service_enable' => true,
     },

--- a/spec/classes/server/service_spec.rb
+++ b/spec/classes/server/service_spec.rb
@@ -10,5 +10,5 @@ describe 'postgresql::server::service' do
   end
 
   it { is_expected.to contain_class('postgresql::server::service') }
-  it { is_expected.to contain_service('postgresqld_instance_main').with_name('postgresql').with_status('systemctl status postgresql') }
+  it { is_expected.to contain_service('postgresqld_instance_main').with_name('postgresql').with_status('systemctl is-active --quiet postgresql') }
 end

--- a/spec/defines/server_instance_spec.rb
+++ b/spec/defines/server_instance_spec.rb
@@ -42,7 +42,7 @@ describe 'postgresql::server_instance' do
                            'port' => 5433,
                            'pg_hba_conf_defaults' => false },
       'service_settings': { 'service_name' => 'postgresql@13-test1',
-                            'service_status' => 'systemctl status postgresql@13-test1.service',
+                            'service_status' => 'systemctl is-active --quiet postgresql@13-test1.service',
                             'service_ensure' => 'running',
                             'service_enable' => true },
       'initdb_settings': { 'auth_local' => 'peer',
@@ -120,7 +120,7 @@ describe 'postgresql::server_instance' do
     it { is_expected.to contain_postgresql__server_instance('test1') }
     it { is_expected.to contain_user('ins_test1') }
     it { is_expected.to contain_group('ins_test1') }
-    it { is_expected.to contain_service('postgresqld_instance_test1').with_name('postgresql@13-test1').with_status('systemctl status postgresql@13-test1.service') }
+    it { is_expected.to contain_service('postgresqld_instance_test1').with_name('postgresql@13-test1').with_status('systemctl is-active --quiet postgresql@13-test1.service') }
     it { is_expected.to contain_systemd__dropin_file('postgresql@13-test1.conf') }
     it { is_expected.to contain_postgresql_conn_validator('validate_service_is_running_instance_test1') }
     it { is_expected.to contain_postgresql_conf('port_for_instance_test1') }


### PR DESCRIPTION
Replace systemctl `status` with systemctl `is-active`

`systemctl status $service` will output a bunch of text. Some of this text, depending on the locale, contains unicode characters:

```
● postgresql.service - PostgreSQL RDBMS
     Loaded: loaded (/lib/systemd/system/postgresql.service; enabled; preset: enabled)
     Active: active (exited) since Wed 2025-09-24 21:40:00 UTC; 2 months 18 days ago
   Main PID: 1028 (code=exited, status=0/SUCCESS)
        CPU: 3ms

Notice: journal has been rotated since unit was started, output may be incomplete.
```

`●` is unicode. Puppet will fail with:

```
Error: /Stage[main]/Postgresql::Server::Reload/Postgresql::Server::Instance::Reload[main]/Exec[postgresql_reload_main]: Failed to call refresh: invalid byte sequence in US-ASCII
Error: /Stage[main]/Postgresql::Server::Reload/Postgresql::Server::Instance::Reload[main]/Exec[postgresql_reload_main]: invalid byte sequence in US-ASCII
```

`systemctl` will print `*` if it's executed with `LC_ALL=C`, but we cannot assume that this locale is always used.

The correct command to check if a service is up and running is `is-active`, not `status`. `status` is for humans only. the systemd provider for the service type also uses `is-active`. See https://github.com/puppetlabs/puppet/blob/main/lib/puppet/provider/service/systemd.rb#L201-L203

Since we only care about the exit code, we can even add `--quiet`. See https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#is-active%20PATTERN%E2%80%A6

## Summary

Ensure the service detection works with all locales.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)