### PR TITLE
Add optional VERSION clause to CREATE EXTENSION

### DIFF
--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -54,7 +54,7 @@ define postgresql::server::extension (
 
   case $ensure {
     'present': {
-      $command = "CREATE EXTENSION \"${extension}\""
+      $command = "CREATE EXTENSION \"${extension}\"${if $version and $version != 'latest' { " VERSION \"${version}\"" } else { '' }}"
       $unless_mod = undef
       $psql_cmd_require = $package_name ? {
         undef   => $default_psql_require,

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -54,7 +54,7 @@ define postgresql::server::extension (
 
   case $ensure {
     'present': {
-      $command = inline_epp('CREATE EXTENSION "<%= $extension %>"<% if $version and $version != "latest" { %> VERSION "<%= $version %>"<% } %>', { extension => $extension, version => $version })
+      $command = inline_epp('<%- | String $extension, Optional[String] $version | -%>CREATE EXTENSION "<%= $extension %>"<% if $version and $version != "latest" { %> VERSION "<%= $version %>"<% } %>', { extension => $extension, version => $version })
       $unless_mod = undef
       $psql_cmd_require = $package_name ? {
         undef   => $default_psql_require,

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -54,7 +54,7 @@ define postgresql::server::extension (
 
   case $ensure {
     'present': {
-      $command = "CREATE EXTENSION \"${extension}\"${if $version and $version != 'latest' { " VERSION \"${version}\"" } else { '' }}"
+      $command = inline_epp('CREATE EXTENSION "<%= $extension %>"<% if $version and $version != "latest" { %> VERSION "<%= $version %>"<% } %>', { extension => $extension, version => $version })
       $unless_mod = undef
       $psql_cmd_require = $package_name ? {
         undef   => $default_psql_require,


### PR DESCRIPTION
## Summary
This pull request adds support for specifying an explicit extension version when using CREATE EXTENSION. Allowing users to control which extension version is installed instead of relying on the default.

## Additional Context
I recently encountered this issue with TimescaleDB 2.23.1 and PostgreSQL 18 on Debian 12 using the official TimescaleDB APT repository. The package timescaledb-2-loader-postgresql-18 (dependency of timescaledb-2-2.23.1-postgresql-18) sets the default to 2.24.0 in `/usr/share/postgresql/18/extension/timescaledb.control`. When creating a new database, Puppet wants to create the extension with `CREATE EXTENSION "timescaledb" ;`. In the next step `ALTER EXTENSION "timescaledb" UPDATE TO "2.23.1" ;` is executed and fails with following error:

```
Error: Error executing SQL; psql returned pid 115701 exit 1: 'ERROR:  extension "timescaledb" has no installation script nor update path for version "2.24.0"
'
Error: /Stage[main]/Profile::Postgresql/Postgresql::Server::Extension[timescaledb]/Postgresql_psql[zabbix: CREATE EXTENSION "timescaledb"]/command: change from 'notrun' to 'CREATE EXTENSION "timescaledb"' failed: Error executing SQL; psql returned pid 115701 exit 1: 'ERROR:  extension "timescaledb" has no installation script nor update path for version "2.24.0"
' (corrective)
Error: Error executing SQL; psql returned pid 115705 exit 1: 'ERROR:  extension "timescaledb" does not exist
'
Error: /Stage[main]/Profile::Postgresql/Postgresql::Server::Extension[timescaledb]/Postgresql_psql[zabbix: ALTER EXTENSION "timescaledb" UPDATE TO '2.23.1']/command: change from 'notrun' to 'ALTER EXTENSION "timescaledb" UPDATE TO \'2.23.1\'' failed: Error executing SQL; psql returned pid 115705 exit 1: 'ERROR:  extension "timescaledb" does not exist
' (corrective)

```

If no version is specified, the default from the file `/usr/share/postgresql/18/extension/timescaledb.control` is used. Since the “version” is already implemented, I would like to use it in CREATE as well.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
