### PR TITLE
fix: ignore postgresql_conf resource value when set to absent

### DIFF
--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
 
   # remove resource if exists and is set to absent
   def destroy
-    entry_regex = %r{#{resource[:key]}.*=.*}
+    entry_regex = %r{^\s*#{resource[:key]}\s*=}
     lines = File.readlines(resource[:target])
 
     lines.delete_if do |entry|


### PR DESCRIPTION
## Summary
This PR makes the `postgresql_conf` provider ignore the `value` field when `ensure `is set to `absent`.

## Additional Context
Much more info in the related issue.

## Related Issues (if any)
config_entry removal incorrectly depends on existing value in postgresql.yml #1656

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)