### PR TITLE
Allow database creation from heira via postgresql::server::databases

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -99,6 +99,7 @@
 # @param pg_hba_auth_password_encryption
 #   Specify the type of encryption set for the password in pg_hba_conf,
 #   this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
+# @param databases Specifies a hash from which to generate postgresql::server::database resources.
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
@@ -184,6 +185,7 @@ class postgresql::server (
   Optional[Postgresql::Pg_password_encryption]       $pg_hba_auth_password_encryption = undef,
   Optional[String]                                   $extra_systemd_config         = $postgresql::params::extra_systemd_config,
 
+  Hash[String, Hash]                                 $databases                    = {},
   Hash[String, Hash]                                 $roles                        = {},
   Hash[String, Any]                                  $config_entries               = {},
   Postgresql::Pg_hba_rules                           $pg_hba_rules                 = {},
@@ -210,6 +212,12 @@ class postgresql::server (
   -> Class['postgresql::server::config']
   -> Class['postgresql::server::service']
   -> Class['postgresql::server::passwd']
+
+  $databases.each |$databasename, $database| {
+    postgresql::server::database { $databasename:
+      * => $database,
+    }
+  }
 
   $roles.each |$rolename, $role| {
     postgresql::server::role { $rolename:


### PR DESCRIPTION

## Summary
added the parameter databases to the server.pp file of the class. 
Loop through the new optional parameter passing the output into postgresql::server::database which will now allow the new functionality of database creation. 

Using a copy of the pattern set with postgresql::server::roles

## Additional Context
inability to create databases using hiera


## Related Issues (if any)
Mention any related issues or pull requests.
could be considered a fix to #1620 as well as new functionality. 

## Checklist
- [ x] 🟢 Spec tests.
- [x ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)