### PR TITLE
support database creation from hiera parameters

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -99,6 +99,7 @@
 # @param pg_hba_auth_password_encryption
 #   Specify the type of encryption set for the password in pg_hba_conf,
 #   this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
+# @param databases Specifies a hash from which to generate postgresql::server::database resources.
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
 # @param grants Specifies a hash from which to generate postgresql::server::grant resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
@@ -185,6 +186,7 @@ class postgresql::server (
   Optional[Postgresql::Pg_password_encryption]       $pg_hba_auth_password_encryption = undef,
   Optional[String]                                   $extra_systemd_config         = $postgresql::params::extra_systemd_config,
 
+  Hash[String[1], Hash]                              $databases                    = {},
   Hash[String, Hash]                                 $roles                        = {},
   Hash[String[1], Hash]                              $grants                       = {},
   Hash[String, Any]                                  $config_entries               = {},
@@ -212,6 +214,12 @@ class postgresql::server (
   -> Class['postgresql::server::config']
   -> Class['postgresql::server::service']
   -> Class['postgresql::server::passwd']
+
+  $databases.each |$databasename, $database| {
+    postgresql::server::database { $databasename:
+      * => $database,
+    }
+  }
 
   $roles.each |$rolename, $role| {
     postgresql::server::role { $rolename:


### PR DESCRIPTION
## Summary
added $databases parameter to server.pp to allow iteration from server::database.pp to create databases 
reusing the existing included pattern of $roles iterating through server::role.pp to manage roles

## Additional Context
Add any additional context about the problem here. 
Inability to create database using hiera parameters


## Related Issues (if any)
new functionality but could also be considered a fix for #1620

## Checklist
- [ x] 🟢 Spec tests.
- [ x] 🟢 Acceptance tests.
- [ x] Manually verified. (For example `puppet apply`)