### PR TITLE
Update table_grant.pp to allow passing array as table name

### DIFF
--- a/manifests/server/table_grant.pp
+++ b/manifests/server/table_grant.pp
@@ -16,7 +16,7 @@
 define postgresql::server::table_grant (
   Enum['ALL', 'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'all', 'select', 'insert', 'update', 'delete',
   'truncate', 'references', 'trigger'] $privilege,
-  String[1]                                           $table,
+  Optional[Variant[Array[String,2,2],String[1]]]      $table,
   String[1]                                           $db,
   String[1]                                           $role,
   Optional[Enum['present', 'absent']]                 $ensure           = undef,


### PR DESCRIPTION
## Summary
Array required to allow grants on tables in specific schema

## Additional Context
it should be consistent with
https://github.com/puppetlabs/puppetlabs-postgresql/blob/49368d1eb7585b151960642b95bfe3f8b09a15c5/manifests/server/grant.pp#L41

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)