### PR TITLE
support for server::grant defined type iteration from hiera 

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -199,6 +199,7 @@ class postgresql::globals (
       },
       'Amazon' => '9.2',
       default => $facts['os']['release']['major'] ? {
+        '10'    => '16',
         '9'     => '13',
         '8'     => '10',
         '7'     => '9.2',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -100,6 +100,7 @@
 #   Specify the type of encryption set for the password in pg_hba_conf,
 #   this value is usefull if you want to start enforcing scram-sha-256, but give users transition time.
 # @param roles Specifies a hash from which to generate postgresql::server::role resources.
+# @param grants Specifies a hash from which to generate postgrsql::server::grant resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
 #
@@ -185,6 +186,7 @@ class postgresql::server (
   Optional[String]                                   $extra_systemd_config         = $postgresql::params::extra_systemd_config,
 
   Hash[String, Hash]                                 $roles                        = {},
+  Hash[String, Hash]                                 $grants                     = {},
   Hash[String, Any]                                  $config_entries               = {},
   Postgresql::Pg_hba_rules                           $pg_hba_rules                 = {},
 
@@ -216,6 +218,13 @@ class postgresql::server (
       * => $role,
     }
   }
+
+ $grants.each |$grantname, $grant| {
+    postgresql::server::grant { $grantname:
+      * => $grant,
+    }
+  }
+
 
   $config_entries.each |$entry, $value| {
     postgresql::server::config_entry { $entry:

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -39,14 +40,16 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -84,14 +87,16 @@
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
create parameter server::grants that is passed into server::grant.pp and looped through to manage grants via hiera when server.pp is included as a class.

testing of grant privilege management completed, however more complex grant pairing testing maybe useful before merge

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x ] 🟢 Spec tests.
- [x ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)