### PR TITLE
(MODULES-11812) bump puppetlabs/concat upper bound to < 11.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 10.0.0"
+      "version_requirement": ">= 4.1.0 < 11.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary

Bumps the `puppetlabs/concat` dependency upper bound in `metadata.json` from `< 10.0.0` to `< 11.0.0` so that the dependency-check stage of CI can resolve against the newly released `puppetlabs/concat 10.0.0`.

```diff
-      "version_requirement": ">= 4.1.0 < 10.0.0"
+      "version_requirement": ">= 4.1.0 < 11.0.0"
```

## Why

`puppetlabs/concat 10.0.0` was released and is now the latest on the Forge. The existing `< 10.0.0` cap causes every PR against this module to fail the metadata.json dependency-check stage with:

```
puppetlabs/concat (>= 4.1.0 < 10.0.0) doesn't match 10.0.0
##[error]Process completed with exit code 1.
```

## Tickets

- Sub-task: MODULES-11812
- Parent (org-wide fix): MODULES-11809
- Unblocks: MODULES-11807 / community PR #1668 test PR #1670

## Test plan

- [ ] CI's `Spec / Spec tests` job reaches the actual spec tests (no longer fails at the dependency-check step).
- [ ] No other deps regress.