### PR TITLE
add loop through grant_role type to allow predefined roles to be used in existing databases

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -103,6 +103,7 @@
 # @param grants Specifies a hash from which to generate postgresql::server::grant resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
+# @param grant_roles Specifies a hash from which to generate postgresql::server::grant_role resources. 
 #
 # @param backup_enable Whether a backup job should be enabled.
 # @param backup_options A hash of options that should be passed through to the backup provider.
@@ -189,6 +190,7 @@ class postgresql::server (
   Hash[String[1], Hash]                              $grants                       = {},
   Hash[String, Any]                                  $config_entries               = {},
   Postgresql::Pg_hba_rules                           $pg_hba_rules                 = {},
+  Hash[String[1], Hash]                              $grant_roles                  = {},
 
   Boolean                                            $backup_enable                = $postgresql::params::backup_enable,
   Hash                                               $backup_options               = {},
@@ -224,6 +226,12 @@ class postgresql::server (
       * => $grant,
     }
   }
+
+ $grant_roles.each |$grantname, $grant_role| {
+   postgresql::server::grant_role { $grantname:
+     * => $grant_role, 
+   }
+ }
 
   $config_entries.each |$entry, $value| {
     postgresql::server::config_entry { $entry:

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -227,11 +227,11 @@ class postgresql::server (
     }
   }
 
- $grant_roles.each |$grantname, $grant_role| {
-   postgresql::server::grant_role { $grantname:
-     * => $grant_role, 
-   }
- }
+  $grant_roles.each |$grantname, $grant_role| {
+    postgresql::server::grant_role { $grantname:
+      * => $grant_role,
+    }
+  }
 
   $config_entries.each |$entry, $value| {
     postgresql::server::config_entry { $entry:

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -42,9 +42,6 @@ define postgresql::server::grant_role (
     connect_settings => $connect_settings,
   }
 
-  if empty($connect_settings) {
-    Class['postgresql::server'] -> Postgresql_psql["grant_role:${name}"]
-  }
   if defined(Postgresql::Server::Role[$role]) {
     Postgresql::Server::Role[$role] -> Postgresql_psql["grant_role:${name}"]
   }


### PR DESCRIPTION
## Summary
previous MR's have added parameters, roles to align to the role type, grants to allow to the grant type and databases to align to the database type, which allow the creation of resources from values within hiera. 

This additional loop following the same pattern as the other approved MR's loops through grant_roles to the grant_role type, which allow the use of pre-defined roles within Postgres such as https://www.postgresql.org/docs/current/predefined-roles.html which cannot be set with the grant type alone.



## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

Following existing working patterns to extend the functionality of the module in a least complex way

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ x] 🟢 Spec tests.
- [x ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)

no changes needed to the spec, acceptance tests not required I believe based on the other MR's of this type. Tested against pre-defined roles. 