### PR TITLE
wrapper for extension type: allow extension config from server.pp

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -103,6 +103,8 @@
 # @param grants Specifies a hash from which to generate postgresql::server::grant resources.
 # @param config_entries Specifies a hash from which to generate postgresql::server::config_entry resources.
 # @param pg_hba_rules Specifies a hash from which to generate postgresql::server::pg_hba_rule resources.
+# @param extensions Specifies a hash from which to generate postgresql::server::extension resources.
+#   The hash keys are database names, and the values are hashes of extension names to extension parameters.
 #
 # @param backup_enable Whether a backup job should be enabled.
 # @param backup_options A hash of options that should be passed through to the backup provider.
@@ -189,6 +191,7 @@ class postgresql::server (
   Hash[String[1], Hash]                              $grants                       = {},
   Hash[String, Any]                                  $config_entries               = {},
   Postgresql::Pg_hba_rules                           $pg_hba_rules                 = {},
+  Hash[String, Hash]                                 $extensions                   = {},
 
   Boolean                                            $backup_enable                = $postgresql::params::backup_enable,
   Hash                                               $backup_options               = {},
@@ -235,6 +238,25 @@ class postgresql::server (
   $pg_hba_rules.each |String[1] $rule_name, Postgresql::Pg_hba_rule $rule| {
     postgresql::server::pg_hba_rule { $rule_name:
       * => $rule,
+    }
+  }
+
+  # Create databases first if not already defined
+  $extensions.each |$database, $extensions_hash| {
+    if $database != 'postgres' and ! defined(Postgresql::Server::Database[$database]) {
+      # The database resource doesn't exist, create it
+      postgresql::server::database { $database:
+        dbname => $database,
+      }
+    }
+  }
+
+  $extensions.each |$database, $extensions_hash| {
+    $extensions_hash.each |$extension_name, $extension_params| {
+      postgresql::server::extension { "${database}:${extension_name}":
+        database => $database,
+        *        => $extension_params,
+      }
     }
   }
 

--- a/manifests/server/extension.pp
+++ b/manifests/server/extension.pp
@@ -28,7 +28,7 @@
 define postgresql::server::extension (
   String[1]                                           $database,
   Optional[Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]]] $package_ensure = undef,
-  String[1]                                           $extension              = $name,
+  String[1]                                           $extension              = split($name, ':')[1],
   Optional[String[1]]                                 $schema                 = undef,
   Optional[String[1]]                                 $version                = undef,
   Enum['present', 'absent']                           $ensure                 = 'present',


### PR DESCRIPTION
## Summary
using the same merge pattern as server::roles to the role type, server::grants to the grant type this follows the same pattern creating the parameter extensions to access the extension type allowing extensions to be configured against database directly from server.pp

There is additional logic as there is a condition where you can define an extension against a database that has not yet been created (if the database has not been defined or server::database has not executed in this scenario there is logic to create the database first with the concept that there is no point trying to configure against an extension against a database you don't want to exist, so it is likely this database is either managed outside of the module, managed in the module but has not yet been properly configured (server::databases has not run) in which case the initial creation is done here and then the actual full database configuration will happen post the extension creation. This seems an acceptable way to handle this problem. 

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ x] Thought process behind the implementation.

following a proven pattern with roles -> server::roles , grants -> server::grants (and other variations that are still pending merge) 

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x ] 🟢 Spec tests.
- [x ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)