### PR TITLE
(CI) Run acceptance tests against puppetcore8-nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--nightly"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,4 +15,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--nightly"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

The acceptance test job calls the `module_acceptance.yml` reusable workflow without any `flags`, so it runs against the released `puppetcore8` collection. Other modules (e.g. [puppetlabs-apache](https://github.com/puppetlabs/puppetlabs-apache/blob/main/.github/workflows/ci.yml)) pass `--nightly`, which targets the `puppetcore8-nightly` collection.

This PR adds `flags: "--nightly"` to the `Acceptance` job in both `ci.yml` and `nightly.yml` so acceptance tests run against `puppetcore8-nightly`, consistent with the other modules.

## Changes
- `.github/workflows/ci.yml` — add `--nightly` flag to the Acceptance job
- `.github/workflows/nightly.yml` — add `--nightly` flag to the Acceptance job

🤖 Generated with [Claude Code](https://claude.com/claude-code)