### PR TITLE
Accept Sensitive[String] in the function prepend_sql_password

### DIFF
--- a/lib/puppet/functions/postgresql/prepend_sql_password.rb
+++ b/lib/puppet/functions/postgresql/prepend_sql_password.rb
@@ -4,11 +4,13 @@
 Puppet::Functions.create_function(:'postgresql::prepend_sql_password') do
   # @param password
   #   The clear text `password`
+  #   Accept both String and Sensitive[String]
   dispatch :default_impl do
-    required_param 'String', :password
+    required_param 'Variant[String, Sensitive[String]]', :password
     return_type 'String'
   end
   def default_impl(password)
-    "ENCRYPTED PASSWORD '#{password}'"
+    pwd = password.respond_to?(:unwrap) ? password.unwrap : password
+    "ENCRYPTED PASSWORD '#{pwd}'"
   end
 end

--- a/spec/functions/postgresql_prepend_sql_password_spec.rb
+++ b/spec/functions/postgresql_prepend_sql_password_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'postgresql::prepend_sql_password' do
+  it { is_expected.not_to be_nil }
+
+  context 'with a plain string password' do
+    it 'prepends ENCRYPTED PASSWORD to a simple string' do
+      expect(subject).to run.with_params('mypassword')
+                            .and_return("ENCRYPTED PASSWORD 'mypassword'")
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to a password with special characters' do
+      expect(subject).to run.with_params('p@ssw0rd!#$')
+                            .and_return('ENCRYPTED PASSWORD \'p@ssw0rd!#$\'')
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to an empty string' do
+      expect(subject).to run.with_params('')
+                            .and_return("ENCRYPTED PASSWORD ''")
+    end
+
+    it 'prepends ENCRYPTED PASSWORD to a password with quotes' do
+      expect(subject).to run.with_params("pass'word")
+                            .and_return("ENCRYPTED PASSWORD 'pass'word'")
+    end
+  end
+
+  context 'with a Sensitive[String] password' do
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string' do
+      expect(subject).to run.with_params(sensitive('secretpassword'))
+                            .and_return("ENCRYPTED PASSWORD 'secretpassword'")
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string with special characters' do
+      expect(subject).to run.with_params(sensitive('s3cr3t!@#$%'))
+                            .and_return('ENCRYPTED PASSWORD \'s3cr3t!@#$%\'')
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to an empty sensitive string' do
+      expect(subject).to run.with_params(sensitive(''))
+                            .and_return("ENCRYPTED PASSWORD ''")
+    end
+
+    it 'unwraps and prepends ENCRYPTED PASSWORD to a sensitive string with quotes' do
+      expect(subject).to run.with_params(sensitive("sec'ret"))
+                            .and_return("ENCRYPTED PASSWORD 'sec'ret'")
+    end
+  end
+
+  context 'with invalid input' do
+    it 'raises an error when called without parameters' do
+      expect(subject).to run.with_params
+                            .and_raise_error(ArgumentError)
+    end
+
+    it 'raises an error when called with too many parameters' do
+      expect(subject).to run.with_params('password', 'extra')
+                            .and_raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Accept Sensitive[String] in the function prepend_sql_password

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)