### PR TITLE
(MODULES-11858) Restore Puppet 7 support broken by 10.6.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: '2.6'
   Include:
   - "**/*.rb"
   Exclude:

--- a/lib/puppet/functions/postgresql/postgresql_password.rb
+++ b/lib/puppet/functions/postgresql/postgresql_password.rb
@@ -66,7 +66,7 @@ Puppet::Functions.create_function(:'postgresql::postgresql_password') do
   def digest_key(password, salt)
     OpenSSL::KDF.pbkdf2_hmac(
       password,
-      salt:,
+      salt: salt,
       iterations: 4096,
       length: 32,
       hash: OpenSSL::Digest.new('SHA256'),

--- a/lib/puppet/provider/postgresql_conf/ruby.rb
+++ b/lib/puppet/provider/postgresql_conf/ruby.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:postgresql_conf).provide(:ruby) do
                 else
                   matches[:value].delete("'")
                 end
-        attributes_hash = { line_number:, key: matches[:key], ensure: 'present', value:, comment: matches[:comment] }
+        attributes_hash = { line_number: line_number, key: matches[:key], ensure: 'present', value: value, comment: matches[:comment] }
         active_settings.push(attributes_hash)
       end
     end

--- a/lib/puppet/provider/postgresql_replication_slot/ruby.rb
+++ b/lib/puppet/provider/postgresql_replication_slot/ruby.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:postgresql_replication_slot).provide(:ruby) do
   def self.instances
     run_sql_command('SELECT * FROM pg_replication_slots;')[0].split("\n").select { |l| l.include?('|') }.map do |l|
       name, *_others = l.strip.split(%r{\s+\|\s+})
-      new(name:,
+      new(name: name,
           ensure: :present)
     end
   end

--- a/spec/defines/server/pg_hba_rule_spec.rb
+++ b/spec/defines/server/pg_hba_rule_spec.rb
@@ -25,7 +25,7 @@ describe 'postgresql::server::pg_hba_rule' do
         user: 'all',
         address: '1.1.1.1/24',
         auth_method: 'md5',
-        target:
+        target: target
       }
     end
 
@@ -47,7 +47,7 @@ describe 'postgresql::server::pg_hba_rule' do
         database: 'all',
         user: 'all',
         auth_method: 'ident',
-        target:
+        target: target
       }
     end
 
@@ -71,7 +71,7 @@ describe 'postgresql::server::pg_hba_rule' do
         address: '0.0.0.0/0',
         auth_method: 'ldap',
         auth_option: 'foo=bar',
-        target:
+        target: target
       }
     end
 
@@ -98,7 +98,7 @@ describe 'postgresql::server::pg_hba_rule' do
           user: 'all',
           address: '0.0.0.0/0',
           auth_method: 'peer',
-          target:
+          target: target
         }
       end
 
@@ -126,7 +126,7 @@ describe 'postgresql::server::pg_hba_rule' do
           user: 'all',
           address: '0.0.0.0/0',
           auth_method: 'scram-sha-256',
-          target:
+          target: target
         }
       end
 
@@ -240,7 +240,7 @@ describe 'postgresql::server::pg_hba_rule' do
           user: 'all',
           address: '.domain.tld',
           auth_method: 'md5',
-          target:
+          target: target
         }
       end
 
@@ -263,7 +263,7 @@ describe 'postgresql::server::pg_hba_rule' do
           user: 'all',
           address: '/45',
           auth_method: 'md5',
-          target:
+          target: target
         }
       end
 

--- a/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_psql/ruby_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Puppet::Type.type(:postgresql_psql).provider(:ruby) do
   let(:name) { 'rspec psql test' }
   let(:resource) do
-    Puppet::Type.type(:postgresql_psql).new({ name:, provider: :ruby }.merge(attributes))
+    Puppet::Type.type(:postgresql_psql).new({ name: name, provider: :ruby }.merge(attributes))
   end
   let(:provider) { resource.provider }
 

--- a/spec/unit/puppet/provider/postgresql_replication_slot/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postgresql_replication_slot/ruby_spec.rb
@@ -20,7 +20,7 @@ describe type.provider(:ruby) do
 
   let(:name) { 'standby' }
   let(:resource) do
-    type.new({ name:, provider: :ruby }.merge(attributes))
+    type.new({ name: name, provider: :ruby }.merge(attributes))
   end
   let(:sql_instances) do
     "abc |        | physical  |        |          | t      |      |              | 0/3000420

--- a/spec/unit/puppet/type/postgresql_psql_spec.rb
+++ b/spec/unit/puppet/type/postgresql_psql_spec.rb
@@ -132,7 +132,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [true, :true].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly: }
+          { refreshonly: refreshonly }
         end
 
         context 'not refreshing'
@@ -141,7 +141,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly: }
+          { refreshonly: refreshonly }
         end
 
         context 'refreshing'
@@ -152,7 +152,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [false, :false].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly: }
+          { refreshonly: refreshonly }
         end
 
         context 'not refreshing'
@@ -161,7 +161,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly: }
+          { refreshonly: refreshonly }
         end
 
         context 'refreshing'
@@ -176,7 +176,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [true, :true].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'not refreshing'
@@ -185,7 +185,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'refreshing'
@@ -196,7 +196,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [false, :false].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'not refreshing'
@@ -205,7 +205,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'refreshing'
@@ -220,7 +220,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [true, :true].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'not refreshing'
@@ -229,7 +229,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'refreshing'
@@ -240,7 +240,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
     [false, :false].each do |refreshonly|
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'not refreshing'
@@ -249,7 +249,7 @@ describe Puppet::Type.type(:postgresql_psql), unless: Puppet.features.microsoft_
 
       context "refreshonly => #{refreshonly.inspect}" do
         let(:attributes) do
-          { refreshonly:, unless: 'SELECT something' }
+          { refreshonly: refreshonly, unless: 'SELECT something' }
         end
 
         context 'refreshing'


### PR DESCRIPTION
## Summary

Fixes #1685 (MODULES-11858). `10.6.2` was tagged a **patch** but PR #1646 (`CAT-2385 Puppetcore update`) introduced a hard syntax error that breaks existing installations on Puppet 7.

`.rubocop.yml` bumped `TargetRubyVersion` to `3.1`, so `rubocop -A` rewrote hash literals to Ruby 3.1 **shorthand** (`salt:` instead of `salt: salt`) in three custom functions/providers. That shorthand is a *syntax error* on Ruby 2.7 — the Ruby that Puppet 7 ships — so any Puppet 7 catalog using `postgresql::postgresql_password`, `postgresql_conf`, or `postgresql_replication_slot` fails to compile with `syntax error, unexpected ','` (#1685).

## What this PR does

Reverts **only** the Ruby-side breakage:

| File(s) | Change |
|---|---|
| `postgresql_password.rb`, `postgresql_conf/ruby.rb`, `postgresql_replication_slot/ruby.rb` | Revert Ruby 3.1 shorthand hash → explicit form (keeps the unrelated `postgresql_conf` `entry_regex` bugfix from #1657) |
| `.rubocop.yml` | `TargetRubyVersion` back to `'2.6'` so autocorrect can't reintroduce the shorthand |
| 4 spec files | Revert the same shorthand autocorrection so they parse under the `2.6` target |

The puppet requirement in `metadata.json` is left at `>= 8.0.0` per review — this PR is scoped to the Ruby syntax fix only. The puppetcore8 `Gemfile`/CI changes from #1646 also stay in place (dev/test only, not consumer-facing).

## Testing

- `pdk validate` → clean (exit 0)
- Full unit suite → **685 examples, 0 failures**
- **Litmus end-to-end** on Rocky 9, both agents:
  - **Puppet 7.34 / Ruby 2.7.8** — reproduced #1685 with the old code, then confirmed fixed: `postgresql::server` install → idempotent second run, `testdb` created, and a **SCRAM-SHA-256** password hash written to the live database (the exact `digest_key` path that was crashing).
  - **Puppet 8.10 / Ruby 3.2.5** — same install + idempotency + SCRAM checks pass (no forward regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
