### PR TITLE
Support setting datadir_mode

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -892,6 +892,7 @@ The following parameters are available in the `postgresql::server` class:
 * [`manage_datadir`](#-postgresql--server--manage_datadir)
 * [`manage_logdir`](#-postgresql--server--manage_logdir)
 * [`manage_xlogdir`](#-postgresql--server--manage_xlogdir)
+* [`datadir_mode`](#-postgresql--server--datadir_mode)
 * [`password_encryption`](#-postgresql--server--password_encryption)
 * [`pg_hba_auth_password_encryption`](#-postgresql--server--pg_hba_auth_password_encryption)
 * [`roles`](#-postgresql--server--roles)
@@ -1318,6 +1319,14 @@ Data type: `Boolean`
 Set to false if you have file{ $xlogdir: } already defined
 
 Default value: `$postgresql::params::manage_xlogdir`
+
+##### <a name="-postgresql--server--datadir_mode"></a>`datadir_mode`
+
+Data type: `Stdlib::Filemode`
+
+Overrides the default mode (permissions) of the PostgreSQL data directory.
+
+Default value: `$postgresql::params::datadir_mode`
 
 ##### <a name="-postgresql--server--password_encryption"></a>`password_encryption`
 
@@ -2797,6 +2806,7 @@ The following parameters are available in the `postgresql::server::instance::ini
 * [`auth_local`](#-postgresql--server--instance--initdb--auth_local)
 * [`data_checksums`](#-postgresql--server--instance--initdb--data_checksums)
 * [`datadir`](#-postgresql--server--instance--initdb--datadir)
+* [`datadir_mode`](#-postgresql--server--instance--initdb--datadir_mode)
 * [`encoding`](#-postgresql--server--instance--initdb--encoding)
 * [`group`](#-postgresql--server--instance--initdb--group)
 * [`initdb_path`](#-postgresql--server--instance--initdb--initdb_path)
@@ -2845,6 +2855,14 @@ Data type: `Stdlib::Absolutepath`
 PostgreSQL data directory
 
 Default value: `$postgresql::server::datadir`
+
+##### <a name="-postgresql--server--instance--initdb--datadir_mode"></a>`datadir_mode`
+
+Data type: `Stdlib::Filemode`
+
+Overrides the default mode (permissions) of the PostgreSQL data directory.
+
+Default value: `$postgresql::server::datadir_mode`
 
 ##### <a name="-postgresql--server--instance--initdb--encoding"></a>`encoding`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@ class postgresql::params inherits postgresql::globals {
   $manage_datadir               = true
   $manage_logdir                = true
   $manage_xlogdir               = true
+  $datadir_mode                 = '0700'
 
   $backup_enable = false
   $backup_provider = 'pg_dump'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -95,6 +95,7 @@
 # @param manage_datadir Set to false if you have file{ $datadir: } already defined
 # @param manage_logdir Set to false if you have file{ $logdir: } already defined
 # @param manage_xlogdir Set to false if you have file{ $xlogdir: } already defined
+# @param datadir_mode Overrides the default mode (permissions) of the PostgreSQL data directory.
 # @param password_encryption Specify the type of encryption set for the password.
 # @param pg_hba_auth_password_encryption
 #   Specify the type of encryption set for the password in pg_hba_conf,
@@ -181,6 +182,7 @@ class postgresql::server (
   Boolean                                            $manage_datadir               = $postgresql::params::manage_datadir,
   Boolean                                            $manage_logdir                = $postgresql::params::manage_logdir,
   Boolean                                            $manage_xlogdir               = $postgresql::params::manage_xlogdir,
+  Stdlib::Filemode                                   $datadir_mode                 = $postgresql::params::datadir_mode,
   Postgresql::Pg_password_encryption                 $password_encryption          = $postgresql::params::password_encryption,
   Optional[Postgresql::Pg_password_encryption]       $pg_hba_auth_password_encryption = undef,
   Optional[String]                                   $extra_systemd_config         = $postgresql::params::extra_systemd_config,

--- a/manifests/server/initdb.pp
+++ b/manifests/server/initdb.pp
@@ -5,6 +5,7 @@ class postgresql::server::initdb {
     auth_local     => $postgresql::server::auth_local,
     data_checksums => $postgresql::server::data_checksums,
     datadir        => $postgresql::server::datadir,
+    datadir_mode   => $postgresql::server::datadir_mode,
     encoding       => $postgresql::server::encoding,
     group          => $postgresql::server::group,
     initdb_path    => $postgresql::server::initdb_path,

--- a/manifests/server/instance/initdb.pp
+++ b/manifests/server/instance/initdb.pp
@@ -4,6 +4,7 @@
 # @param auth_local  auth method used by default for local authorization
 # @param data_checksums Boolean. Use checksums on data pages to help detect corruption by the I/O system that would otherwise be silent.
 # @param datadir PostgreSQL data directory
+# @param datadir_mode Overrides the default mode (permissions) of the PostgreSQL data directory.
 # @param encoding
 #   Sets the default encoding for all databases created with this module.
 #   On certain operating systems this is also used during the template1 initialization,
@@ -35,6 +36,7 @@ define postgresql::server::instance::initdb (
   Optional[String[1]]            $auth_local     = $postgresql::server::auth_local,
   Optional[Boolean]              $data_checksums = $postgresql::server::data_checksums,
   Stdlib::Absolutepath           $datadir        = $postgresql::server::datadir,
+  Stdlib::Filemode               $datadir_mode   = $postgresql::server::datadir_mode,
   Optional[String[1]]            $encoding       = $postgresql::server::encoding,
   String[1]                      $group          = $postgresql::server::group,
   Stdlib::Absolutepath           $initdb_path    = $postgresql::server::initdb_path,
@@ -66,7 +68,7 @@ define postgresql::server::instance::initdb (
       ensure  => directory,
       owner   => $user,
       group   => $group,
-      mode    => '0700',
+      mode    => $datadir_mode,
       seltype => $seltype,
     }
   } else {
@@ -75,7 +77,7 @@ define postgresql::server::instance::initdb (
       ensure  => directory,
       owner   => $user,
       group   => $group,
-      mode    => '0700',
+      mode    => $datadir_mode,
       seltype => $seltype,
     }
   }

--- a/spec/classes/server/initdb_spec.rb
+++ b/spec/classes/server/initdb_spec.rb
@@ -10,7 +10,19 @@ describe 'postgresql::server::initdb' do
   describe 'on RedHat' do
     include_examples 'RedHat 8'
 
-    it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory') }
+    it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory').with_mode('0700') }
+
+    context 'with datadir_mode set to 0750' do
+      let :pre_condition do
+        "
+        class {'postgresql::server':
+          datadir_mode => '0750',
+        }
+        "
+      end
+
+      it { is_expected.to contain_file('/var/lib/pgsql/data').with_ensure('directory').with_mode('0750') }
+    end
 
     context 'with (log,manage,xlog)_datadir set to false' do
       let :pre_condition do


### PR DESCRIPTION
## Summary

With current implementation it's not possible to override permissions for main database directory. Even with `manage_datadir = false`, it would be overwritten to hard-coded `0700`




## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)