### PR TITLE
Allow puppet/systemd 10.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 4.0.1 < 10.0.0"
+      "version_requirement": ">= 4.0.1 < 11.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
## Summary
Allow using `puppet-systemd` 10.x, this might fix broken acceptance tests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)