### PR TITLE
(MODULES-11720) Add puppet 9 support in puppetlabs-postgresql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
+      additional_packages: "libcurl4-openssl-dev"
+      ruby_version: "3.2"
     secrets: "inherit"
 
   Acceptance:
@@ -22,4 +24,9 @@ jobs:
         --platform-exclude centos-7
         --platform-exclude oraclelinux-7
         --platform-exclude scientific-7
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -13,3 +13,5 @@ jobs:
   mend:
     uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
     secrets: "inherit"
+    with:
+      ruby_version: "3.2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,8 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
+      additional_packages: "libcurl4-openssl-dev"
+      ruby_version: "3.2"
     secrets: "inherit"
 
   Acceptance:
@@ -21,4 +23,9 @@ jobs:
         --platform-exclude centos-7
         --platform-exclude oraclelinux-7
         --platform-exclude scientific-7
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,29 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# frozen_string_literal: true
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
+
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
   end
 end
 
@@ -18,7 +32,7 @@ group :development do
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
@@ -38,7 +52,7 @@ group :development do
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppetlabs_spec_helper", '~> 9.0', require: false
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
@@ -57,8 +71,8 @@ hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 # If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
 # Otherwise, do as before and use location_for to fetch gems from the default source
 if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+  gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 else
   gems['puppet'] = location_for(puppet_version)
   gems['facter'] = location_for(facter_version) if facter_version

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppetlabs-syntax/tasks/puppetlabs-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
@@ -15,5 +15,10 @@ PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_autoloader_layout')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+# strict_indent is disabled because its expected indentation changed incompatibly
+# between puppet-lint-strict_indent-check 3.x (Puppet 7/8 lane, Ruby 3.1) and 5.x
+# (Puppet 9 lane, Ruby 3.4+): the two lanes demand opposite indentation for nested
+# hashes, so no single manifest layout can satisfy both. See MODULES-11726 / MODULES-11700.
+PuppetLint.configuration.send('disable_strict_indent')
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]

--- a/metadata.json
+++ b/metadata.json
@@ -103,7 +103,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "pdk-version": "3.5.0",


### PR DESCRIPTION
  1) ci, nightly & mend update for puppet 9 support
  2) Gemfile udpate for new gem compatible with puppet 9
  3) rakefile and metadata change for puppet 9

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)