### PR TITLE
(MODULES-11935) Fix default_privileges idempotency on PostgreSQL 17

### DIFF
--- a/manifests/server/default_privileges.pp
+++ b/manifests/server/default_privileges.pp
@@ -105,7 +105,16 @@ define postgresql::server::default_privileges (
     }
     'TABLES': {
       case $_privilege {
-        /^ALL$/: { $_check_privilege = 'arwdDxt' }
+        /^ALL$/: {
+          # Some platforms report legacy 9.x versions without the dot, e.g. '96'.
+          $_version = regsubst($version, '^9(\d)$', '9.\1')
+          # PostgreSQL 17 added the MAINTAIN privilege ('m'), which ALL includes.
+          if (versioncmp($_version, '17') == -1) {
+            $_check_privilege = 'arwdDxt'
+          } else {
+            $_check_privilege = 'arwdDxtm'
+          }
+        }
         /^DELETE$/: { $_check_privilege = 'd' }
         /^INSERT$/: { $_check_privilege = 'a' }
         /^REFERENCES$/: { $_check_privilege = 'x' }

--- a/spec/acceptance/server/default_privileges_spec.rb
+++ b/spec/acceptance/server/default_privileges_spec.rb
@@ -8,9 +8,14 @@ describe 'postgresql::server::default_privileges:' do
   let(:group) { 'test_group' }
   let(:password) { 'psql_grant_role_pw' }
 
+  # PostgreSQL 17 added the MAINTAIN privilege ('m'), which ALL ON TABLES includes
+  let(:all_table_privileges) do
+    (Gem::Version.new(postgresql_version) >= Gem::Version.new('17')) ? 'arwdDxtm' : 'arwdDxt'
+  end
+
   # Check that the default privileges were revoked
   let(:check_command) do
-    "SELECT * FROM pg_default_acl a LEFT JOIN pg_namespace b ON a.defaclnamespace = b.oid WHERE '#{user}=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r';"
+    "SELECT * FROM pg_default_acl a LEFT JOIN pg_namespace b ON a.defaclnamespace = b.oid WHERE '#{user}=#{all_table_privileges}' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r';"
   end
 
   let(:pp_one) do
@@ -72,7 +77,8 @@ describe 'postgresql::server::default_privileges:' do
   let(:target_password) { 'target_role_password' }
 
   let(:target_check_command) do
-    "SELECT 1 FROM pg_default_acl a LEFT JOIN pg_namespace AS b ON a.defaclnamespace = b.oid WHERE '#{user}=arwdDxt/#{target_user}' = ANY (defaclacl) AND nspname = 'public' AND defaclobjtype = 'r';"
+    acl = "#{user}=#{all_table_privileges}/#{target_user}"
+    "SELECT 1 FROM pg_default_acl a LEFT JOIN pg_namespace AS b ON a.defaclnamespace = b.oid WHERE '#{acl}' = ANY (defaclacl) AND nspname = 'public' AND defaclobjtype = 'r';"
   end
 
   let(:pp_target_role) do
@@ -229,7 +235,7 @@ describe 'postgresql::server::default_privileges:' do
   end
 
   let(:all_schemas_check_command) do
-    "SELECT * FROM pg_default_acl a WHERE '#{user}=arwdDxt' = ANY (defaclacl) AND defaclnamespace = 0 and defaclobjtype = 'r';"
+    "SELECT * FROM pg_default_acl a WHERE '#{user}=#{all_table_privileges}' = ANY (defaclacl) AND defaclnamespace = 0 and defaclobjtype = 'r';"
   end
 
   let(:pp_unset_schema) do

--- a/spec/defines/server/default_privileges_spec.rb
+++ b/spec/defines/server/default_privileges_spec.rb
@@ -124,6 +124,34 @@ describe 'postgresql::server::default_privileges' do
       end
     end
 
+    context 'supported privilege on a legacy dotless 9.x version' do
+      let :params do
+        {
+          db: 'test',
+          role: 'test',
+          privilege: 'all',
+          object_type: 'tables',
+          connect_settings: { 'PGHOST' => 'postgres-db-server',
+                              'DBVERSION' => '96' }
+        }
+      end
+
+      let :pre_condition do
+        "class {'postgresql::server':}"
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      # SLES reports 9.x without the dot, so '96' must normalise to 9.6 and
+      # not compare as newer than 17
+      it do
+        # rubocop:disable Layout/LineLength
+        expect(subject).to contain_postgresql_psql('default_privileges:test')
+          .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxt' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
     context 'unsupported privilege' do
       let :params do
         {

--- a/spec/defines/server/default_privileges_spec.rb
+++ b/spec/defines/server/default_privileges_spec.rb
@@ -97,6 +97,33 @@ describe 'postgresql::server::default_privileges' do
       end
     end
 
+    context 'supported privilege on PostgreSQL >= 17' do
+      include_examples 'Debian 13'
+
+      let :params do
+        {
+          db: 'test',
+          role: 'test',
+          privilege: 'all',
+          object_type: 'tables'
+        }
+      end
+
+      let :pre_condition do
+        "class {'postgresql::server':}"
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      # PostgreSQL 17 added the MAINTAIN privilege ('m'), which ALL includes
+      it do
+        # rubocop:disable Layout/LineLength
+        expect(subject).to contain_postgresql_psql('default_privileges:test')
+          .with_unless("SELECT 1 WHERE EXISTS (SELECT * FROM pg_default_acl AS da LEFT JOIN pg_namespace AS n ON da.defaclnamespace = n.oid WHERE 'test=arwdDxtm' = ANY (defaclacl) AND nspname = 'public' and defaclobjtype = 'r')")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
     context 'unsupported privilege' do
       let :params do
         {

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -188,6 +188,10 @@ shared_context 'Debian 12' do
   let(:facts) { on_supported_os['debian-12-x86_64'] }
 end
 
+shared_context 'Debian 13' do
+  let(:facts) { on_supported_os['debian-13-x86_64'] }
+end
+
 shared_context 'Ubuntu 18.04' do
   let(:facts) { on_supported_os['ubuntu-18.04-x86_64'] }
 end


### PR DESCRIPTION
Fixes [MODULES-11935](https://perforce.atlassian.net/browse/MODULES-11935).

## Problem

`postgresql::server::default_privileges` with `privilege => 'ALL'` and `object_type => 'TABLES'` is not idempotent on PostgreSQL 17+. The `ALTER DEFAULT PRIVILEGES` command re-runs on every Puppet run.

PostgreSQL 17 added the `MAINTAIN` privilege, abbreviated `m`, to the table privilege set. `ALL ON TABLES` therefore records `role=arwdDxtm/grantor` in `pg_default_acl.defaclacl`, but the `unless` query hard-coded `arwdDxt`, so it never matched.

This is pre-existing on `main` — it is currently failing the Debian-13 acceptance jobs in nightly, e.g. [run 32823034551](https://github.com/puppetlabs/puppetlabs-postgresql/actions/runs/32823034551) (6 of 60 examples, all `TABLES` cases in `spec/acceptance/server/default_privileges_spec.rb`; the `SCHEMAS` cases pass because `ALL ON SCHEMAS` is still `UC`).

## Change

- `manifests/server/default_privileges.pp`: version-gate the check string so PostgreSQL >= 17 expects `arwdDxtm`. Legacy dotless 9.x version strings (`'96'` on SLES, etc.) are normalised to `9.6` first so `versioncmp` does not read them as newer than 17.
- `spec/acceptance/server/default_privileges_spec.rb`: derive the expected ACL from `postgresql_version` instead of hard-coding it, in all three check queries.
- `spec/defines/server/default_privileges_spec.rb` + `spec/spec_helper_local.rb`: add a `Debian 13` shared context (PostgreSQL 17) and a unit example asserting the `arwdDxtm` `unless` clause. Existing Debian 11 (PostgreSQL 13) expectations are unchanged.

## Checklist
- [x] 🟢 Spec tests. `bundle exec rspec spec/defines spec/classes` → 468 examples, 0 failures (puppet ~> 8.0, facter 4.10). New PG-17 example verified to fail before the manifest change and pass after.
- [x] 🟢 Acceptance tests. Debian-13 jobs in this PR's CI are the real verification.
- [ ] Manually verified.

## Not in scope

Three other jobs are red in that run for unrelated pre-existing reasons, left alone here:
- Scientific-7 / CentOS-7 / OracleLinux-7 on `puppetcore8`: `litmusimage` EL7 containers cannot start systemd on the cgroup-v2 GitHub runner (`Failed to get D-Bus connection: Operation not permitted`). RedHat-7 passes because it is provisioned as a real VM.
- SLES-12: ABS provisioning never opened SSH on the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
