### PR TITLE
(MODULES-11940) Exclude EL7 docker platforms from acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,9 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly"
+      flags: >-
+        --nightly
+        --platform-exclude centos-7
+        --platform-exclude oraclelinux-7
+        --platform-exclude scientific-7
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,5 +16,9 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly"
+      flags: >-
+        --nightly
+        --platform-exclude centos-7
+        --platform-exclude oraclelinux-7
+        --platform-exclude scientific-7
     secrets: "inherit"


### PR DESCRIPTION
Fixes [MODULES-11940](https://perforce.atlassian.net/browse/MODULES-11940).

## Problem

Three acceptance jobs fail on every nightly and every PR, and have done so for as long as the acceptance stage has been reaching them:

- `Acceptance tests (CentOS-7, puppetcore8-nightly)`
- `Acceptance tests (OracleLinux-7, puppetcore8-nightly)`
- `Acceptance tests (Scientific-7, puppetcore8-nightly)`

Each fails **42 of 60 examples** with an identical signature. Latest reproduction: [run 34070142202](https://github.com/puppetlabs/puppetlabs-postgresql/actions/runs/34070142202).

All three are provisioned as `litmusimage` Docker containers. EL7 ships systemd 219, which cannot obtain a D-Bus session when the host runs cgroup v2 — and every GitHub-hosted runner image is cgroup-v2 only. So the first service start fails:

```
Error: Could not start Service[postgresqld_instance_main]:
  Execution of '/sbin/service postgresql start' returned 1:
  Redirecting to /bin/systemctl start postgresql.service
  Failed to get D-Bus connection: Operation not permitted
```

Every other failure cascades from this one — 58 occurrences of the D-Bus error per run, and no second distinct cause. `RedHat-7` on the same collection passes, because it is provisioned as a real VM via provision_service rather than Docker, and that provider choice is made by `cat-github-actions`' matrix generator, not by this module.

## Why exclusion

There is no in-module remedy — this needs a cgroup-v1 host, and the last cgroup-v1 runner image (`ubuntu-20.04`) is retired.

Every sibling supported module that manages a service already excludes exactly these three, while still declaring them in `metadata.json`:

| Module | `--platform-exclude` |
|---|---|
| puppetlabs-apache | `centos-7`, `oraclelinux-7`, `scientific-7`, `almalinux-8` |
| puppetlabs-mysql | `centos-7`, `scientific-7`, `oraclelinux-7`, `almalinux-8` |
| puppetlabs-ntp | `centos-7`, `oraclelinux-7`, `scientific-7` |
| puppetlabs-service | `centos-7`, `oraclelinux-7`, `scientific-7`, `almalinux-8` |
| **puppetlabs-postgresql** | **none** |

postgresql is the outlier. This brings it in line and leaves `RedHat-7` as the EL7 acceptance coverage.

## Change

Adds `--platform-exclude centos-7 / oraclelinux-7 / scientific-7` to the acceptance `flags` in `ci.yml` and `nightly.yml`, using the same folded-scalar form as apache. Verified the YAML resolves to a single flag string.

## Merge-order note

`main` currently has plain `flags: "--nightly"`. #1700 also rewrites that same line, so whichever of the two merges second will conflict. Resolve as the **union** of both flag lists — and at that point #1700's `--collection-platform-exclude 9:scientific-7` becomes redundant, since a blanket `--platform-exclude scientific-7` already covers it, so it can be dropped.

## Out of scope

- CentOS 7 and Scientific Linux 7 both reached EOL in June 2024, and Scientific Linux is discontinued upstream. Whether to also drop them from `metadata.json` is a separate maintainer decision, deliberately not touched here.
- Debian-13 reds are [MODULES-11935](https://perforce.atlassian.net/browse/MODULES-11935) / #1701.
- SLES-12 reds are ABS provisioning never opening SSH on the target — infra flake, left alone.

## Checklist
- [ ] 🟢 Spec tests. Workflow-only change; no manifest or spec code touched.
- [ ] 🟢 Acceptance tests. The verification is this PR's own matrix: the three jobs should no longer appear.
- [x] Manually verified — YAML parsed to confirm the folded `flags` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
