### PR TITLE
Allow empty string value for config entries

### DIFF
--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -10,7 +10,7 @@
 define postgresql::server::config_entry (
   Enum['present', 'absent']                               $ensure  = 'present',
   String[1]                                               $key     = $name,
-  Optional[Variant[String[1], Numeric, Array[String[1]]]] $value   = undef,
+  Optional[Variant[String, Numeric, Array[String[1]]]]    $value   = undef,
   Stdlib::Absolutepath                                    $path    = $postgresql::server::postgresql_conf_path,
   Optional[String[1]]                                     $comment = undef,
   String[1]                                               $instance_name = 'main',

--- a/spec/defines/server/config_entry_spec.rb
+++ b/spec/defines/server/config_entry_spec.rb
@@ -79,4 +79,21 @@ describe 'postgresql::server::config_entry' do
         .that_notifies('Postgresql::Server::Instance::Service[main]')
     end
   end
+
+  # Example use case for empty values: using transaction-bound session
+  # variables, like `SET LOCAL awesome_app.tenant_id = 92834` requires the
+  # variable to be defined in postgresql.conf and initialised with a default
+  # value (at least for PostgreSQL 13 and older, possibly also in newer
+  # versions). The default value can (and sometimes, depending on the
+  # application should) be empty.
+  context 'set a config entry value to the empty string' do
+    let(:params) { { ensure: 'present', name: 'mydb.app_param', value: '' } }
+
+    it 'sets value to the empty string' do
+      expect(subject).to contain_postgresql_conf('mydb.app_param').with(
+        name: 'mydb.app_param',
+        value: '',
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR is created to execute tests for the original PR (https://github.com/puppetlabs/puppetlabs-postgresql/pull/1603).

🤖 Generated with [Claude Code](https://claude.com/claude-code)